### PR TITLE
Do not track TCGA data downloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 # Jupyter Notebooks
 .ipynb_checkpoints
+
+# Large downloaded data files
+data/expression.tsv.bz2
+data/mutation-matrix.tsv.bz2


### PR DESCRIPTION
Eventually we may want to move `expression.tsv.bz2` and `mutation-matrix.tsv.bz2` to a `download` rather than `data` directory, but I thought that would cause problems with all the active forks right now.
