### PR TITLE
LinearSVC: added more evaluation metrics

### DIFF
--- a/algorithms/LinearSVC-htcai.ipynb
+++ b/algorithms/LinearSVC-htcai.ipynb
@@ -1,0 +1,1096 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Create a logistic regression model to predict TP53 mutation from gene expression data in TCGA"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import urllib\n",
+    "import random\n",
+    "import warnings\n",
+    "\n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "import seaborn as sns\n",
+    "from sklearn import preprocessing, grid_search\n",
+    "from sklearn.linear_model import SGDClassifier\n",
+    "from sklearn.svm import LinearSVC\n",
+    "from sklearn.cross_validation import train_test_split\n",
+    "from sklearn.metrics import roc_auc_score, roc_curve\n",
+    "from sklearn.pipeline import make_pipeline\n",
+    "from sklearn.preprocessing import StandardScaler\n",
+    "from sklearn.feature_selection import SelectKBest\n",
+    "from statsmodels.robust.scale import mad\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "plt.style.use('seaborn-notebook')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Specify model configuration"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# We're going to be building a 'TP53' classifier \n",
+    "GENE = 'TP53'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Parameter Sweep for Hyperparameters\n",
+    "n_feature_kept = 500\n",
+    "param_fixed = {\n",
+    "    'loss': 'hinge',\n",
+    "    'penalty': 'l2'\n",
+    "}\n",
+    "param_grid = {\n",
+    "    'C': [10 ** x for x in range(-5, 2)],\n",
+    "    'intercept_scaling': [10 ** x for x in range(-5, 2)],\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "*Here is some [documentation](http://scikit-learn.org/stable/modules/generated/sklearn.linear_model.SGDClassifier.html) regarding the classifier and hyperparameters*\n",
+    "\n",
+    "*Here is some [information](https://ghr.nlm.nih.gov/gene/TP53) about TP53*"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "if not os.path.exists('data'):\n",
+    "    os.makedirs('data')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "url_to_path = {\n",
+    "    # X matrix\n",
+    "    'https://ndownloader.figshare.com/files/5514386':\n",
+    "        os.path.join('data', 'expression.tsv.bz2'),\n",
+    "    # Y Matrix\n",
+    "    'https://ndownloader.figshare.com/files/5514389':\n",
+    "        os.path.join('data', 'mutation-matrix.tsv.bz2'),\n",
+    "}\n",
+    "\n",
+    "for url, path in url_to_path.items():\n",
+    "    if not os.path.exists(path):\n",
+    "        urllib.request.urlretrieve(url, path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 1min 20s, sys: 1.01 s, total: 1min 21s\n",
+      "Wall time: 1min 21s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "path = os.path.join('data', 'expression.tsv.bz2')\n",
+    "X = pd.read_table(path, index_col=0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 1min 15s, sys: 1.22 s, total: 1min 16s\n",
+      "Wall time: 1min 16s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "path = os.path.join('data', 'mutation-matrix.tsv.bz2')\n",
+    "Y = pd.read_table(path, index_col=0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "y = Y[GENE]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "sample_id\n",
+       "TCGA-02-0047-01    0\n",
+       "TCGA-02-0055-01    1\n",
+       "TCGA-02-2483-01    1\n",
+       "TCGA-02-2485-01    1\n",
+       "TCGA-02-2486-01    0\n",
+       "TCGA-04-1348-01    1\n",
+       "Name: TP53, dtype: int64"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# The Series now holds TP53 Mutation Status for each Sample\n",
+    "y.head(6)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0    0.655334\n",
+       "1    0.344666\n",
+       "Name: TP53, dtype: float64"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Here are the percentage of tumors with NF1\n",
+    "y.value_counts(True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Set aside 10% of the data for testing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Size: 20,501 features, 6,935 training samples, 771 testing samples'"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Typically, this can only be done where the number of mutations is large enough\n",
+    "X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=0)\n",
+    "'Size: {:,} features, {:,} training samples, {:,} testing samples'.format(len(X.columns), len(X_train), len(X_test))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Median absolute deviation feature selection"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def fs_mad(x, y):\n",
+    "    \"\"\"    \n",
+    "    Get the median absolute deviation (MAD) for each column of x\n",
+    "    \"\"\"\n",
+    "    scores = mad(x) \n",
+    "    return scores, np.array([np.NaN]*len(scores))\n",
+    "\n",
+    "# select the top features with the highest MAD\n",
+    "feature_select = SelectKBest(fs_mad, k=n_feature_kept)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Define pipeline and Cross validation model fitting"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Include loss='log' in param_grid doesn't work with pipeline somehow\n",
+    "clf = LinearSVC(random_state=0, class_weight='balanced',\n",
+    "                    loss=param_fixed['loss'], penalty=param_fixed['penalty'])\n",
+    "\n",
+    "# joblib is used to cross-validate in parallel by setting `n_jobs=-1` in GridSearchCV\n",
+    "# Supress joblib warning. See https://github.com/scikit-learn/scikit-learn/issues/6370\n",
+    "warnings.filterwarnings('ignore', message='Changing the shape of non-C contiguous array')\n",
+    "clf_grid = grid_search.GridSearchCV(estimator=clf, param_grid=param_grid, n_jobs=-1, scoring='roc_auc')\n",
+    "pipeline = make_pipeline(\n",
+    "    feature_select,  # Feature selection\n",
+    "    StandardScaler(),  # Feature scaling\n",
+    "    clf_grid)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 15.6 s, sys: 3.2 s, total: 18.8 s\n",
+      "Wall time: 2min\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "# Fit the model (the computationally intensive part)\n",
+    "pipeline.fit(X=X_train, y=y_train)\n",
+    "best_clf = clf_grid.best_estimator_\n",
+    "feature_mask = feature_select.get_support()  # Get a boolean array indicating the selected features"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'C': 0.01, 'intercept_scaling': 1}"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "clf_grid.best_params_"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "LinearSVC(C=0.01, class_weight='balanced', dual=True, fit_intercept=True,\n",
+       "     intercept_scaling=1, loss='hinge', max_iter=1000, multi_class='ovr',\n",
+       "     penalty='l2', random_state=0, tol=0.0001, verbose=0)"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "best_clf"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Visualize hyperparameters performance"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def grid_scores_to_df(grid_scores):\n",
+    "    \"\"\"\n",
+    "    Convert a sklearn.grid_search.GridSearchCV.grid_scores_ attribute to \n",
+    "    a tidy pandas DataFrame where each row is a hyperparameter-fold combinatination.\n",
+    "    \"\"\"\n",
+    "    rows = list()\n",
+    "    for grid_score in grid_scores:\n",
+    "        for fold, score in enumerate(grid_score.cv_validation_scores):\n",
+    "            row = grid_score.parameters.copy()\n",
+    "            row['fold'] = fold\n",
+    "            row['score'] = score\n",
+    "            rows.append(row)\n",
+    "    df = pd.DataFrame(rows)\n",
+    "    return df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Process Mutation Matrix"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>C</th>\n",
+       "      <th>fold</th>\n",
+       "      <th>intercept_scaling</th>\n",
+       "      <th>score</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0.00001</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0.00001</td>\n",
+       "      <td>0.742723</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>0.00001</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0.00001</td>\n",
+       "      <td>0.745136</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "         C  fold  intercept_scaling     score\n",
+       "0  0.00001     0            0.00001  0.742723\n",
+       "1  0.00001     1            0.00001  0.745136"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cv_score_df = grid_scores_to_df(clf_grid.grid_scores_)\n",
+    "cv_score_df.head(2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAB9gAAAEYCAYAAAAXhC1uAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAIABJREFUeJzs3Xl8VPW9//HXmSRsCYGwQ9hk+7KvyqaigtZ6a+16b9t7\nbWvrXdpr2/tr7b3XLte22nrbWm3r0nq11q1uuAAKKsomENl3CPmGJIQlkH0l2zAz5/fHmYQkBAjI\nzCTwfj4eeTA5M5P5ZEjeOee7Oq7rIiIiIiIiIiIiIiIiIiIiImfni3UBIiIiIiIiIiIiIiIiIiIi\nHYE62EVERERERERERERERERERNpAHewiIiIiIiIiIiIiIiIiIiJtoA52ERERERERERERERERERGR\nNlAHu4iIiIiIiIiIiIiIiIiISBuog11ERERERERERERERERERKQN4mNdgESHMWYK8E1r7X+c5TED\ngbHW2tXRq6zxtecAx621uRF+nZ8Bcdbae40xq4AF1lo3kq/Z5LXvAB4DbrPWrjrP584CHgZOAtXA\n16y1JcaY1UBnoB5wgfXW2nsvauEirVCmNL5OTDLFGDMS+AveQLkQcKe1NqfFY/oAzwOJQBxwt7V2\nkzGmC/AsMAjoBPzSWrvUGOMAjwLTwo9/ylr7dPhrDQD+BnSy1s6L9Pcn0pTypvF1Lpm8CT9nNLAQ\n2GOt/Vqkvw+Rc1HWNL5Oh8ua8H0zgVeAv+l6SNo75U3j67TbvAk/7ha8zPlva+1fI12XyMWgfGl8\nnXbb/nu28xmR9ki50vg67SpX2pIlZ2uTkYtDM9gvE9baXWcLwbAbgPnRqKcV3wBGRvMFrbXzoxiC\ntwPTgZ0X+CWeAb5nrb0eWAH8qsl9X7LW3hD+ftSYJFGhTDldNDMFryP8MWvtdcAjwJ9becx9wKrw\nY76Hd0JF+HZxuKP8i8Cfwydc/wAMs9ZeDXwC+LExZnD4OS8ByyP1zYicjfLmdB09b4wx3fDObZZF\nuniRtlLWnK6jZI0xZgRwP/BedEoV+XiUN6drb3ljjJkHfB1YE6WaRC4K5cvp2mH775munUTaJeXK\n6dpJrrQlS87UBiwXiWawXyaMMdfhjVC5NjzreQUwFxgN/AzYQLjT1hhTAjwe/hgJdAdettb+3hjz\ndeBWoCfejOqteA2kPYAAcJe1Nt0Y8/fAd8MvXwT8s7W2zBhzEu+Xfz7e6Jo7gDHA3wNXGWO+b61d\nc4bv4UvA3cAJwAG+Ya3NNcbcCXwL8AOrrbU/NcYY4P/wZnwnAz+11n7Q4uuF8H4H/gfoDQwOvx+r\nrbXfM8Z0Bp4DhgFHgSDwftORy8aYG4B78WaPE67Ltda2/IOy2Fr7t/B737SGnsATQJ/we/iwtfbl\nFo8ZBnSx1m4LH1qI9//VwGnt/RKJJGVK7DLFGBMPzAM+HT60BHjBGJNgrT3ZpKRbgOsArLXbjTFx\n4dkat4T/j7DWHjXG7AeuBj4JvBY+XhkejfkJ4K/AbcCMJq8pEjXKm0sub+biNVbfCHwJGNraeyYS\nbcqaDps1I4BjeOcx9+LN3hBp15Q3HSJvtltrv2yMeaa171+kvVK+tM/23xZaPZ+xraykIdIeKFfa\nba60JUvO1CZzXqsry5lpBvvlpemomkRr7aeAfwb+y3pLaDwLvGCt/QPwH0CetXYBMBv4ijFmYvi5\nU4BbrLXvAv8LLLPWXosXCF813ozHn+AtkzEP+BD4cfi5cXhLgd6A17F8n7V2Md4InLvPFIJhP8IL\n2vnAfwGpxpih4a99tfVmXQ4y3pKjA/DC76bw9/LAOd6PqdbazwNXAd8wxvQAbgfirbVzgO/gdTQ1\nY61dbU/NHp/fcLuVx504w/f0S+Bda+2NeIF4nzGmd4vHDALym3yeDwxs8vlvjDErjTHLjDFTz/A6\nIpGgTDnz+xHJTOkLVFprg+HnhIBSoH+Lx7WWHYNaOV5whuMNjz9bholEi/LmzO9Hh8sba23IWlvX\n2hslEmPKmjO/H+0xaxoypc5Gb+aryMWivDnz+xHzvNH1j3Rwypczvx+xav9t6kxtMiLtmXLlzO9H\nrHKlLVmivIkwdbBfvtaE/z0E9Grl/huAz4VHxqzE2+d7VPi+7dbaQPj2rIavZa1dZ639ETAHrwN4\nefj5X8ILpgbvh/9NA8afR83PAM8ZY+4DAtbaNLzg2mqt9Ydr+Ka19gBwHPhPY8xa4A94I4nOZn34\n+XV4I6N6AVObfG8FDY+5yG4Avh1+n5bh7aV+xTme43AqxP8A/Dj8B+sxYHEEahRpizXhf5Upnmhn\nio/mJ3e08nnDY1oed85xXKS9WRP+V3nj6Yh5I9IRrAn/q6zxtMesUabIpWJN+F/ljac95I3IpWJN\n+F/liydW7b9N6XxGOro14X+VK55Y5cqFZIny5iLTEvGXr0CT260tMV6PNwrozaYHw0t5+Jsccjl9\noEY9sMlae9sZXrvh8ef1C22t/aMx5iW85f+eMMY8DRTT+jKAjwEvWmufM8ZMAN4+x5cPtPjcCdcZ\nanIs2PJJ57GUx5nUA/9urd3e4us+AkwCyvGWREltcvcgIA/AWruk4aC19l1jTLIxppe1trSNry9y\nsShTmotkphQCScaYeGttILzMYTLeKMSmjuDlRW7480HhY0fDtzNbHG94PE2Of3jW71IkNpQ3zXW0\nvDl6ju9HpL1Q1jTXXrNGmSKXAuVNc+0hb0QuFcqX5mLV/tuUzmeko1OuNBerXGlLlhxGbTIRpRns\n0lQISAjfXo83QghjjM8Y85Dx9gtvKQ0vmDDGXGu8/am2ADONMf3Dx79ojGm6b29DSFwL7G7ltU8T\nruF/8ZbyegH4Bd4opy14e2wkhR+30BgzHegHpIef/iW8kVItnWnv8objGXh7UmCM6Qdc0/KBbV3K\n4yzWcep97mqMedwY47PWfi/8tT5nrT0KlBpj5oSfczvwVvg9WWeMSQ0//0q890ed69JeKFOaH78o\nmWK95QxXAv/QpJ7VTUaANlgK/GP49a4Gqqy1h8LHvxI+PhJvT6QNeKtofMkY4xhvq4rrgeUtvo8z\nfY8isaa8aX68vedNW74XkfZIWdP8eHvJmrbULNLRKG+aH4923ohcypQvzY9Ho/23qbacz4h0NMqV\n5sejkSttyZJlnLtNRj4GdbBfns40umcd3j4Rv8AbqXPCGPMR8BFQZq0tb+U59wI3GGM+xNtP/CFr\n7XG8/SmWGmPWAN8ENjZ5zjRjzHvAncDPwsc+AP7PGPPZ1gqz3r5YxcBHxpgVwPeB31lrjwA/B1Ya\nY9KA7PBs8IeBF4wx74a/r1JjzIMtvvczvQ8Nx58F+oa/7sPAWk4fkdQmxpj/Md6yJlOAh4wxq8Id\nWL8ARhtj1uEtG7I9/L22dAfwoPGWJpkJ3Bt+3EPAEmPMqnCNX7yQ+kQ+JmXK2d+Hi54peO/HneFM\nuANvPx+MMTcbY34UfswvgNnhfPlf4Gvh438Cuhpj1gMvAN+w1vqtt2/RPrz/n2XAT6y1+caYIeH8\nehiYGM6vuy+wbpGPS3lz9vehQ+SNMeaqcK78N3BjOFf+6QLrE4kEZc3Z34f2kjVfDT/m0+FM+Tpw\nezhTFlxgHSLRprw5+/sQk7wxxvxLOFduxlsmdpXxZrGJdCTKl7O/D1Fr/23jtZNIR6BcOfv7EO1+\npdOyxBgzxRjzx/DTW22TuZA6pHWO60Z2yX1jzES8faEfttb+qcV9NwK/wvvhetda+8vw8YeB2Xij\nT/6ftXZrRIuUqDHGhIA4a2273+vBGDMImGutfd0Y4wDbgW9ZazfFuDQRCVOmiEi0KG9EJBqUNSIS\nLcobEYkU5YuIXGzKFWmPIroHuzGmG/AIsOIMD/kjcBNwHPjQGPM63hIMo6y1c40xY4G/El5OQS4J\nLmfZI8MY83Pgulbu32mt/UFkSztNOfBlY8x/4g32WKYQFGl3lCkiEi3KGxGJBmWNiESL8kZEIkX5\nIiIXm3JF2p2IzmA3xvjw9j+4ByhqOoPdGHMF8Jy1dl748/8GqoG+wCFr7V/Dx9OBmdbaExErVERE\nRERERERERERERERE5Bwiuge7tTZkra0/w90DgKImnxcBA4H+LY4Xhx8rIiIiIiIiIiIiIiIiIiIS\nMxFdIv48Oed5vFEgEHTj4+Mucjkicgk7Z640UL6IyAVQxohIpChfRCSS2pQxyhcRuQA6hxGRSFG+\niEgknTFjYtnBfgxvxnqDVCAPqKf5jPVBeHu0n1FZWc1FL05ELl19+3Zv82OVLyJyvpQxIhIpyhcR\niaS2ZozyRUTOl85hRCRSlC8iEklny5iILhHfQrNefmvtIaC7MWaoMSYeuBV4H/gA+CKAMWY6kGet\nrY5inSIiIiIiIiIiIiIiIiIiIqeJ6Az2cAf5Q8Aw4KQx5gvAW8BBa+0S4NvAK4ALvGytzQKyjDHb\njDFpQBC4K5I1ioiIiIiIiIiIiIiIiIiItEVEO9ittduBG85y/3pgbivHfxzJukRERERERERERERE\nRERERM5XNJeIFxERERERERERERERERER6bDUwS4iIiIiIiIiIiIiIiIiItIG6mAXERERERERERER\nERERERFpA3Wwi4iIiIiIiIiIiIiIiIiItIE62EVERERERERERERERERERNpAHewiIiIiIiIiIiIi\nIiIiIiJtoA52ERERERERERERERERERGRNlAHu4iIiIiIiIiIiIiIiIiISBuog11ERERERERERERE\nRERERKQN1MEuIiIiIiIiIiIiIiIiIiLSBupgFxERERERERHpYAKBk7iuG+syRERERERELjvqYBcR\nERERERER6UCCwSA/+P5dPProw7EuRURERERE5LKjDnYRERERERERkQ7E7/dTVl7Gli0bY12KiIiI\niIjIZUcd7CIiIiIiIiIiHYqWhhcREREREYkVdbCLiIiIiIiIiHQg2ntdREREREQkdtTBLiIiIiIi\nIiLSgah/XUREREREJHbiI/0CxpiHgdlACPh/1tqtTe77DPAToA541Vr7uDHmOuA1YC/gALuttf8R\n6TpFRERERERERDoG9bCLiIiIiIjESkQ72I0x84BR1tq5xpixwF+BueH7HOBRYCpQBrxjjFkUfuoa\na+0/RLI2EREREREREZGOSEvEi4iIiIiIxE6kl4hfACwGsNZmAD2NMUnh+/oAZdbaUmutC6wCbgzf\n50S4LhERERERERGRDkn96yIiIiIiIrET6Q72AUBRk8+Lw8ew1hYB3Y0xI40xCcANQP/w48YbYxYb\nY9YaY25EREREREREREQAcN1QrEsQERERERG5bEV8D/YWWs5M/zrwDFAO5ITvzwR+bq19zRgzAlht\njBlprQ2c6YumpHQjPj4uUjWLyGVM+SIikaSMEZFIUb6IXNoSEoKNt/v27R7V11a+iEgkKWNEJFKU\nLyJyMUW6g/0Y4RnrYYOA4w2fWGvXAfMAjDEPALnW2uPAa+H7c4wx+UAqcOhML1JWVnPxKxeRS9b5\nNEApX0TkfCljRCRSlC8i0qC8vLLxdlFR1UX5mm3NGOWLiJwvncOISKQoX0Qkks6WMZFeIv594IsA\nxpjpQJ61trrhTmPMO8aYvsaYROBWYIUx5h+NMXeH7x8A9APyIlyniIiIiIiIiEiH4GoTdhERERER\nkZiJaAe7tXYDsM0Ykwb8AbjLGPN1Y8xnwg95Cq8Tfi3wgLW2FHgLuM4YsxZYBHzrbMvDi4iIiIiI\niIhcTtTBLiIiIiIiEjsR34PdWvvjFof2NLlvEV4netPHnwBui3RdIiIiIiIiIiIdkTrYRURERERE\nYifSS8SLiIiIiIiIiMhFpA52ERERERGR2FEHu4iIiIiIiIhIB6IOdhERERERkdhRB7uIiIiIiIiI\nSAeiDnYREREREZHYUQe7iIiIiIiIiEgH4rqhWJcgIiIiIiJy2VIHu4iIiIiIiIhIBxIKaQa7iIiI\niIhIrKiDXURERERERESkA9ES8SIiIiIiIrGjDnYRERERERERkQ4kFNIS8SIiIiIiIrGiDnYRERER\nERERkQ5Ee7CLiIiIiIjEjjrYRUREREREREQ6EO3BLiIiIiIiEjvqYBcRERERERER6UC0B7uIiIiI\niEjsqINdRERERERERKQD0RLxIiIiIiIisaMOdhFp90KhENbup6amOtaliMglqKiokKNHj8S6DBG5\nQKFQkCeeeJRnn31KMzpF5LIRCqmDXUREREREJFbUwS4i7d7Ondv55S/v5c9/fiTWpYjIJehHP/oB\nP/rRD6itrY11KSJyAQoLC0lLW8vKle9z4sSJWJcjIhIV6mAXERERERGJHXWwi0i7V1paAngd7SIi\nF1t9fT0AtbU1Ma5ERC5EVVVl4+0TJ6piWImISPRoxQ4REREREZHYUQe7iDR6992lPP30E9TVaRan\niFxcrutSWlrSrmdbBYPBWJcgIhegoqKi8XZlZcVZHikiculo2sGuznYREREREZHoio/0CxhjHgZm\nAyHg/1lrtza57zPAT4A64FVr7ePneo6IREYwGOSll54DYOrUGcyYcVWMKxKRS8k777zFK6/8jQUL\nPsEdd/xLrMtp1LRBOhAIxLASkY4hGAwSFxcX6zKaaVjpBqCkpDiGlYjIpWjPnl1s3bqJT33qM/Tr\n1z/W5TRqOmjRdUM4TvvKZhERERERkUtZRGewG2PmAaOstXOBfwYeaXKfAzwKfBK4DrjVGDPobM8R\nuRRs2LCeO++8naeffiLWpTRTVlbaeLu9NU635xmvIu1JbW0Nd9/9Hb7z3X9t9jvdHuTkZAOwc+e2\nGFfSXDAYaHJbM9hFzubFF5/ljju+zLJlS2JdSjPFxYVNbhfFsBIRuVBVVZU8+eTjvPnma7Eu5TRP\nPvk4q1Z9wNq1q2NdSjNNr5F0vSRydu+++zaPPfYwBQXHY12KiIiItDOhUJATJ6o08UbOW6SXiF8A\nLAaw1mYAPY0xSeH7+gBl1tpSa60LrAJuOsdzRNrs2LE8cnNz2l2HybZtm/H761mzZmW7WsqvoCC/\n8XZ+/rEYVnK6kydPxroEkWZOnKgiO/tAu1uKOCcnm8LCAirKy8jISI91Oc00dHr5/f4YV9LcyZOn\nTp4DAWWNxF4oFOLQoYMcPXok1qWcZtOmDQDs2NG+Bsrk5x9v9baInK6wsICMjHRqaqpjXUozmzdv\nZN26NSxatLDZqhTtQXl5GdD+BvCog13am4qKCtLS1pKevjfWpTTj9/t56aXn2bRpAx9+2L4GyohI\n21RXV/PUU3/iscceJjv7QKzLEZFLSDAY5Kc//S++/e1vcvcPv6utc+W8RHqJ+AFA0+Xdi8PHsqy1\nRcaY7saYkcBh4AZg9dmeE+Fa5RKye/dOHnzwVwDceutn+dKX/inGFXlc1yUr69SJ4LFjeaSmDo5h\nRaccOXK41dvtgTq9pD0JBAL8/Oc/pqAgn54pvfjdg4/QuXPnWJcFQHZ2VpPbB5gz55oYVnNKKBTi\n2LE8AKqqqqiqqqJ79+4xrsrTdHSq36+skdhbtmwJCxe+BMB3vvMDZs2aE+OKPBUVFY0rYxw8mEMg\ncJL4+IQYV+U5diyPhE5dCQT8jVkjIqcrLi7innu+z8mTJzFmHD/5yS9wHCfWZQGQk9P0HCaLXr16\nx7CaU+rq6hpvNx2Q3B64btMl4mNYiEjYk08+zu7dOwC4//7fMHz4iBhX5MnNPdh4Wx1zIh3TokUL\nG1eSycs7yn33/YaEhPZxLbJ162befvtNRo8ey+233xHrckTkPC1Z8mZjX0hpSTEvv/wCd9zxL+3i\nOqmiooKnnnqcQCDA1752J4MGpca6pEb19fUcOnSQQYNSSUpqH228sRDpGewttfyp/DrwDPAGkBOu\np+WlYex/kqVDqa4+wXPPP934+bvvLW1cmjjWjh8/1mz59T17dsWwmuYOHmx4jxxycw8SCrWfmf+a\nwS7tyaJFrzU2sJaXlfLKKy/EuKJTGhq0vNs7Y1hJcwUF+c1GgObm5sSwmuZOnvS3elskFvLyjrJ4\nyRuNn7/44rNUVJTHrJ6m9uw5lSl+fz3eQlOxV19fT2FhAT17DyW5xwDy8o5qJqdIK0KhIM8882Tj\nebW1+1m9ekWMq/K4rsuevbsbP9+7t/1cIzVdTeTo0SPtKl80g13ak61bNze7FnnuuafbzUD5Xbu2\nN962mRnU1tbEsBoROV8ffriK5cvfgaQuMLw/R48e4cknH283Szm/9dab5ORks3z5sna35aaInJnr\nuixbtoRFixZCUhd8/3Q99OrOqlUf8MorL7SL8+sPP1zFrl072LdvD++9tzTW5TTzzDNPcv/9/8Nv\nf/urWJcSU5GewX4Mb/Z5g0FA47qN1tp1wDwAY8wDwEGg89me05qUlG7Ex8ddpJKlI6usrOT+X/6a\nwoJ8nKlX4AzsRfDdbTz00AP86le/YvTo0TGtb/lyb3GGuJnXEtyynm3bNvLVr345pjU1yMqydO6S\nxKCh0ziYuY4TJ0oYOXJkrMsCIL5JUvXtG90RUcoXaeC6Lq+//jpvvfUmdO+K77ZZhN7ZyooVy+nT\nJ4Wvf/3rMR3dWFJSQmZmBk7/QThdu3E8N4uqqiJGjIj9zJEdOw4BMCB1Ivl5ezl2LJf589vH7PqT\nJ6sabycmJihjJGYOHz7Mgw/+En99Pc6CKVBVS9nmTB588Jc88MAD9O4d29mc27dvAiD+6vkE0lax\nc+dmrr9+bkxrAsjMPI7ruvRMGUJ9/QkOZ+fhurX07Tvg3E++xClfpEEgEOChhx7yBt8N6YPv6vG4\nizbw3HN/oW/fnsyfPz+m9e3bt4+y0hJ8I8fi5h1i67bN/OAH/0F8fKSbK85tw4ajjbfr6mrx+ysZ\nMmRIDCs6JSnp1ApKvXp1IykpejvrKV+kqfT0dJ74v0chPg7fZ2fj7sghKyuT559/ih/+8IfExcXu\nZyUUCrFp80cQn0Dc+CkEd29l//6d3HzzzTGrSc5NGSPgLdv8wgsv8Morr+B0TsD55AxI7kZo2RY2\nbkyjvr6Ge+65hx49esSsxgMHDjSZsAQbN37IHXfcEbN6WsrPz6eqqooRI0bENIvbE+WLgLftxKOP\nPsqaNWtwErvg/N2VOIld8H1yBqF3tvDOO29TWHicH/7wh/Ts2TMmNdbW1rJi5XsQFw8+H2lpa7nz\nzjvo06dPTOppKhQKsW/fHsCbRNW5s0tycnKMq4qNSF+xvg/8HHjKGDMdyLPWNm72Zox5B28Wew1w\nK/A74MjZntOasjKNPhU4fjyP3z0U7lwfk4pz1Rgcx8GZN5HKtXu5+4c/5K5//w+mT78qJvWFQkHe\ne2+5d2E3djKhvMNkZGSwc2c6qamxbaQpLCygsLCQwcOvpP+g8RzMXEda2maSk/vFtK4GlZWnIqCo\nqOosj2yb8+lAU74IeA3Tf/vbs6xcuRwSu+BrOPG6ZQahpVt45ZVXOHLkGHfe+a2YLVP21ltLcV2X\n+FFjoWsiodwsFi9+m69+9ZsxqaepzZu9/ZrHT7uN/Lx9bN26nZtv/kyMq/Lk55c13i4qqlDGSEzs\n3bubRx59iNqaGpzZY/GNHIjrulBdx6F9h/jud7/HD35wD8OGDY9JfaWlJWzduhWnT398ZhLOzs2s\nWfMhX/jCP9KlS9eY1NRg1650AHr2Hoq//gSHszeyY8derrwyMaZ1RYryRc5XdfUJHnnkIW9P5P49\n8S2YitMpHm6ZQeidrfz2t78lJ+cwt932+ZgNFFy8+G0A4saMJ9SlK5X7drB8+Spmzoz9Fhnbtnmr\nd4yZeDOZe5ezceM2unSJTSNbS+Xlp66RCgsrqa39+OvEtzVjlC/SYN++PTz8+9/g9/vx3TQVp1d3\nmDcB90Qtq1ev5sSJWv79378Xs21ldu3aQUF+Pr4xE4gbN4Xgnm0sWrSEadPmtIulXy8nOoeR81FR\nUc6f/vRH7/yle1ecT87ASfEGkvn+7kpCK3exY8cOvvWtb/Od73yfMWPGRr1G13X585+fBCD+ptsI\nrl/BokWLmTPn+nax1U1paQnf//6/EwqF+NrXvslNN90S65IiRvki5yMnJ5vHHnuYoqJC6N8T58ap\nOIldcP0ncZK6eBOqVu9m69at/Ou/fYt///b3mDBhUtTrfP75pykrLSVu2iycpGT86z7goYd+z/e/\n/98xP4exdj/l5V57quu6LF++iuuvXxDTmiLpbBkT0SXirbUbgG3GmDTgD8BdxpivG2MaWtWfwuuE\nXws8YK0tbe05kaxRLg3W7udnP/9xeOb6CJzrJuJusgTT0vGNHYzvpmn4gwH+8IcHWb58WUxq3L17\nF8XFRfhGGJxOnYgb6wXzypUfxKSepvaGl2Tsnzqe/oPGh4+1n6UZ6+vrY12CXMbq6mp56KFfe53r\nvbrj+8ws3P1HCKal4yR5M9np14O0tLX8+tf3UV19Iuo1hkJBVq1eAfEJ+EaOxTf0Cpyuiaxfv7bZ\n3qGx4Loue/fupkvXZPoNNPTqM5wDB2yzJeNjqemy8H6/loiX6Pvww1U8+OCvqK2rw7l+EtTUefni\nODhzx+FcNZrS0hLuu/+nzZZejaY1a1biui5xYyfh+Hz4zETq6mr56KP1MamnqcOHvRUyUnoPpWev\noeFjh2NZkki7UVxcxC9+8ROvcXpYP3x/dyXu9iwvY/r19M5hkrry+uuv8Je//JlgMPpbRFVWVrBh\nQxpOck+cQUPxha+R3n//3ajX0lIoFGL//n107daTUWOvB/Dey3bCbbLxentYwlIuPzt3bud3v3sA\n/8mT+G6cijO8v9c4nRCP75YrYWAKW7Zs5Pe/fzBm59nvvPMWAHHjp+J0T8Y3dCS5uTlkZKTHpJ6W\nCgryWbjwJVasWN7sd1rkcnbo0EF++tP/OnX+8vm5OClJhDZmeOcwCfH4bp6Oc9VoysrL+NWvfs6a\nNSujXue6dWtIT9+Db/BwfENHEDdjLvX1dTz33F/axe/zpk0bGs8P1q//MMbViLQPaWnruO/+n1JU\nVIgzdQS+T8+E+pMEn11B6NmVBF9dCzX1+D45A2eWobKqgt/85n7eey+6/UmbN2/ggw/ew+nZi7gp\nM/GNmYC7MoWIAAAgAElEQVQzaAg7dmzjnXfejmotrVm1yuvPmjnvn3Ech5Ur328XuRcLEd+D3Vr7\nY2vt1dbaedbaPdba56y1S8L3LbLWTrPWzrDWvnKm50S6RunYrN3Pb377S2rranGun4Rv5hgoO4G7\n5xDsO+wFY49uXmB27cTf/vZsTIJo5cr3AYgbPxkA37ARON0SWbd+Tcw7wBr2gh84eBLdknqRnJJK\nRkZ6u9n7vGkH2OUa1hIbfn89Dz74gDfgZGhfryHaH2ieL3V+fLfOxBkxgMzMDP731/dFfV+/3bt3\nUlJchG+kwenUGccXh2/sRGpqqtm06aOo1tLSkSOHKS8vo3/qRBzHx4DBEwkGg+zf3z4atZoO4PH7\nNZhHomv16hX85S9/xu0Uj+/Wq3D6JDfPl7IT+KaNxHfjVPyBkzz88G+i3skeDIYH8HTqhG+kNzMk\nzkyCdnIRdfToYcChR0oqPXt7KwIdOXIopjWJtAdlZaX86lc/4/jxYziTh+P7xDSoqm2eMYDvs7Oh\nbzJr167myScfj3pH7apVKwgEThI3YSqO4+BL6Y2TOgxr95ObezCqtbR05MhhKisr6D9oAskpqXTt\n1pO9e3e3m87sUOhU/rpu+6hJLh8HDlj++McHCeDi++R06NGteeP0iVqvk31IH3bv3sETTzwa9XOG\ngwezSU/f6w3e6eOtzhc3eQYAS5cuiWotZ/LSS8/x9tuLeO65v5CZmRHrckRiLj//OA/87y8oLy/D\nmTkG3yem4XROwC2tav066VNXEuoUx9NPPxHVTuSSkmJe+NszOAmdiL96gXcOYybiDBzC9u1bSUtb\nG7VaWuP3+3nvvaXExSXQp/9ocnKyG5dzFomVnJws0tLWkZa2jszMjKifF2zdupn/+79HCcY5+G6Z\ngW/mGByfj9AHO8Af8B5UUUPog53e7/SUK/DdNgu3aydefPHZxk7lSDty5DD/9+TjOPEJxC/4FE58\nPI7jkHD9LTjdEnn11b/F9Pf5+PFjbNyYRo9eQxhh5jF4+JXk5uawa1dsJoTEWsQ72OXSVVxcxJIl\nb7Bw4Uu8/vor5ORkRb2GqqpK/vjI7zgZOInvE9PwjUkF8IKxIaQbgrFvD5zbZuEkduGVV15g//59\nUauzrKyUXbu24/TpTyjbEti01usAMxOpq61ly5aNUaulpVAoSHr6XhKT+pCU3B/w9kn2+/1kZWXG\nrK6m6utPdbC3l05/iaxA4CTr13/IwoUvsXDhS6xduzomsx5eeul5b1/zEQO8C7tO8a3nS3wczoIp\nOGYwh3IP8swzT0a1zobR2nHjJhPYtJbAprXEmYnN7ouVpgN4AAYOmRw+vjNmNTXV9OdKHeyXj9zc\nHN544xUWLnyJxYtfp7CwIOo15ORk8+yzT0GXTjifnokzIKXVfAG8DLrlSoK4PPrY7ykpKY5anbt2\n7aCivAzfqHEEt2/wzmESk/ANHcnhw7kcOhTbDrCjRw+T0Kkre7Ytomu3FDp16kZe3pGY1iSXt+rq\napYvX8arr77Iq6++yPbtW6PeIRsKhXj88T9QXFyEM2MUvtljcRyn9XOYbp3x3ToT+vfko4/W8cEH\n0Zs5HgwGWbXqfUjoRKiinMAmrzE6buI0AG/1oBhqOIcZMGQSjuMwYPBEqqoqG1fOiLWmP1ftpdNf\nIst1Xfbv38fixa+zePHrrFixPOoDe8HbE/Sxx35PIBj0loUf3Kf1xun4OHw3TWucyb5iRXR/pxtm\nm8VPvrLxGsnXfxBO/0Hs3r2DY8fyolpPS1lZmWzfvrXx89dff0W/yxIzoVCIjIx0nn32KZ588nGe\neupPfPTRuqi3w7zwwjPUVFfjzJuIb+qIxmWQQx/soFNCAqmpqXSqDZy6ThrU25tQ1Sme5577CzU1\nZ91l9qJwXZdnn32Kutpa4mbNI5i+07tGchwS5t2Ek5DA8y/8lYqK8ojXciZLly6mtLSE0RNuYsbc\nrwLeexsIqE1Vosd1XY4fz2P58ne4776f8rOf/YgnnniEJ554hPvv/x/uvfce3nnnbY4ePRLxzvZA\nIMCzzz6FG+fD96mrcIb09WqsqYeKGjp16uTlS6dOUFHtHYdTq351SeDFl56jujqyGVNXV8sjj/wO\nf309cdfdjC+lT+M5jNMtkfgFt+I6Do899nvKykojWsuZvPbay4RCISZN/xyO4zBh+mcBh9dee4lQ\nKPorosVapPdgl0tIIBDg0KGD7N+/j127dmDt/mbht2TJGwwZMpSpU2cwfvxERo0aHfF9OZcuXUJV\nZSXOLIMz1BuR3DQY+/btS1FREf5wMDrJ3eCmqYQWb+Tll1/gvvt+HdH6Gmzc+JG3N/KYCQR2bwXX\nJX7WPOJGjye4YxMbNqzn2muvj0otLR05cpiammquGDODnZu8hSQGpI4nc+9y9u/fx7hxE2JSV1P1\n9adm+Pv99d4fO7nklJQUk5GRzt69u9mxY+tpJy0vvvgs06bNYOLEKYwdO57evftEdM+Z48ePeaMT\nU5JwrveWRT5rvnTrDNeOxy2rYsOGNG655dNcccXIiNXXoLq6mp07t+P06oOvT39OrljamDFO6lCy\nsjIpLCygX7/+Ea+lNenp3qjK4oIsykuPMPmqvyc+vlO7WWK1ab40Hcwjl5b6+nqysjJJT9/Lzp3b\nOXw4t9n9b765kDFjxjJ58jTGj5/A8OFXRHyv0FdffZFQKIRvwRSclKRz5oszqBfO1eOoW+s1rN95\n57ciWl+DjRu9ZeDjRo/n5MpljfniGzOe0KEsPvpoPcOHj4hKLS1VVVVRVVVFXFwCR3I2M232V0hO\nGURB4UECgQDx8brUkchzXZdjx46yf386e/fuYvfunacNCO3VqxfTpl3FhAmTMGYsyck9IlrTjh3b\nsHY/DO+HM907FzlXxvhumkbotfW88cZCrrtufsSv4wD27dtNWVkpvrGTCR3OOZUvqcNwkrqzYUMa\nt9/+DTp37hzxWlrTsGXWgFRv0OKAwZM4mLmevXt3MXz4FTGpqSl1sF8eamqqOXAgk/T0PezYsY3j\nx481u//ll59nypRpTJw4hXHjxjNgwKCI78u5fPkySktLcKaPxBnS99z5smAqodfW8/obr3DttddF\nJV+qq0+wefNGnB4pOKlDCa5fcaodZsJUAgXH+PDDlXzlK1+LeC1nqu9Pf3oEgAWf/ikZu98hI2M7\ny5Yt4dOf/lxMapLLSyBwkiNHDpOdncWBA5b09D2UlzfvEF67djWdO3dm7NjxGDOOkSNHM3z4FXTr\nlhihmgLe394+yfjGDm487tbU06k2wF133cXNN9/M8uXLefzxxwk0XCelJOFMHEbd9mwyMzOYOnVG\nROprsHv3Tq8NZtAQfGYi/lf/eqoNpnsP4q68htoNq3n99Veids3W1JEjh3jrrTfpmpjCxOmfJaFT\nV0aNm0/W/lW89dYiPv/5f4h6TXJ58Pv95OYeJCsrk6wsS2ambTbQpFeqS+/BEApCRQHkHsohNzeH\nl19+nu7dkxk92jB69BhGjRrDFVeMvKjXAHl5R6moKMcZOxinT/KpO4JBOnXqdHq+NNk6y0nuhjN+\nKP7t2WRnH2Dy5KkXra6WFi58mfz848RNnE7cFaO9Eg8eOHWd1H8Q8bPmcWLDGv761ye5++57IlZL\na7KyMtmyZSO9+41k8BVXAt52fcNHX03ugfWkpa2LWR9XrKjVSc4oEAg0NkZnZKSTnX2g2cjF5H4u\ncfEQlwD9r4CCbMjLO8yRI4d5++1F+Hw+hg27AmPGMm7cRMaNm0DXrhf3QmrLlo3QOQFn4rBTB88R\njE6/njC0LwcPZlNcXESfPn0vak2t2bEjPCq5Zy+oPgFuCP9rzxK/4Fac3v3Yl76X2trai/7+tMWB\nA94s9X4DDXu3LcJ1Q4yf+unwfTbq9bSm6RLO9fX1JCV1j2E1crEUFhawd+9uMjLSyczMaDYjs1NX\nGDLBpa4aQiFITIaCnJrGpYTAa6weM2YcY8eOZ+LESfTvP/Ci1rdt22Zc18WZOgInPs47eK588fnw\nTRtJaPl2tmzZFJUO9t27dxIMBom7Ygyh0uJmGeMbYQjmHWbHjq3cfPOnIl5LS6FQkMxMS/ceAzh+\nxGuknjb7K/TpP4a8vL1UVVXSvXvyOb5KZDX9u9a0s106trq6WjIy0klP3xdeZjinsfPB8UHvwS44\n3u0+g+F4lou1+70OKSChUydGjRyNMWMZP34So0ePuagd7tXVJ7zBJwNScFJ7ewfbcmE3ZjDutmy2\nbNnEN7/5bxFvQA8Gg+zcuQMnKRnXF9csX+JuuAUSEti+fSv/+I+xaZwuKMgHwPHFNR5LSh5AcUEW\nJSVFF/3vwoXyBgfGpoNQLj7XdTl8+BD79u3BWu8c5sSJE433d+sB3Tq7JHSFVAOFB6HoUCkrVy5v\nnJE9cOAgjPHOYSZMmETPnikXtcaG1bF800edyolzncN064wzfgi1O3LYt28vM2ZcdVFras3mzeE6\n+w0kZPc2u0byjRxL/a4t7NmziyuvnBnxWloKBE6SmZlBj15DyNj9DgBjJ/8d4O3Dfuutn416TS01\nXRZeHeyXjsrKinAbzH4yMzM4evRw48QGXxz0G+4SCoILJPeB/Gw/W7ZsYsuWTQAkde/OmNFjMWYc\n48dPYOjQ4fh8F3fxyrVr10BCPM6U8ECTtuTLhKHUbM9mx47tzJlz9UWtpzXbt2/1tp8YPR63rOT0\nc5hOndm0aQNf/vJXI34+1VIgEOCRRx6iqKiACdNuo99AQ3LPAbz35kFee+1lUlMHM3165DNYLh+h\nUIi8vKNkZWWSk5PFwYM5HD16mGCT64xOXaD3EJfy4xAMOHROdEkZCJWF9ezataPZ0r/9+w9g+PAR\njBgxilGjRjN8+IiLMhHGcRxo7fcxGKRv377cfPPNANx8880sXLiQ48HTZ0pe7LxrzaJFrwEQP/v6\n0/IlfsGt+MZNxtm/i7VrV/OZz3whKu3ODUKhIH/5y58JBoNcde03SejktTNPmfUljh3eyZIlbzJz\n5hwGDx4StZrk0hUKBTlwIJPdu3eyf/8+cnKymudKV++8JWUg9B4CJ+thx7sQ8Dt0TXaZ+gmXuhNQ\ndhzK8yvZvn0L27dvAbzf5eHDRzBu3AQmT56KMeOIi4s7Uynn1NhZfzJw2n2t5kvLB4VX6YnkpL+8\nvKOsWPEeTo8U4q7yzpVatvPGL7gV3/ipOLnZ7Ny5jT17djFp0pSI1dTSwoUvAV7bbsNEzWmzv8Lk\nq77IkZxNvPHGq8yZc3XEJ6y0J+pgl2ZCoSB79+7ho4/Wsn37VmpraxvvS+zp0ucK6NkfUgaCvw62\nvgWu61Bd5jLxBhg3z6WiAMryoaIgSO6hbA4ezOa995YRFxfHhAmTmDv3WmbMmEmXLl0+dr0lpSXQ\nOwknrvkJ1LmC0emVhHu4iJKS4oif6Pj9fjIPWJze/QimrYRwQ4hbUUZg5VJ8w0cTLCkkMzODKVOm\nRbSW1hw8mA1AQqeu1FSX4bpBPljyC7om9iI396DXwRjlC86WWnawS8dVWFjA+vVr2bQprdmSfAld\noM8Qlx4DIGUAJPWC6vJTGVOT7DLpRheH8IlXAVQUlrJxYxobN6YBXmP1rFlzuPrq6xgw4ON3qjR0\n+Du9kpodP+eJV/jxpaXRWcJ5/35vJrhv8DACK5c2y5hgltdZmJ6+LyYd7MeOHaOurpaBQ2dQeCyj\nsSG4T/9R5OftJScnOya511RdXdMZ7MqXjszvr2fbti189NE69u7dTSDgXQA5Pujey6VHf+g5wPuo\nO3H6OUynri5lx72R1OUF9ezfvy+8DOsbdOnShWnTZjB37jwmTZrysS7sAEpLvaW8nJTzyxfH50BK\nEtVHi/H7/RGf1Xno0EFqa2vwjZ1EcNWy5vmy+l18AwZTcOQgpaUl9OrVO6K1tKakpAgAny+uMV+S\nunvndcXFxe2igz0tbR1PPvkY3/3uD7jyylmxLkcukOu65ObmsH79h2zZspGysrLG+7okQf8RbuM1\nUjB4er6MmeNSWQTl+d45TGHRMY4fP9a4jcvIkaOZPftq5sy5hh49Pv7s9sZBi72aD0o9Z8b0TsZt\n+vwI27t3N07nLgR2bT7tGil+3icI7trC3r27Y9LBnpt7kJMnT9JvgOFIzmZcN8S02V+he48BHDiQ\n6a1AEoVG/LNp2qke7T0s5eIqLy9jw4b1bNq0gZycrGYd6sn9vHzpOQB69IPaqibXSBUuE653iYtr\neo1U1ayBOjk5menTr2Lu3GsxZtzH/rmtrq6mqKgAhvTBSTjVpHjOfBncB3d7Nrm52VHpYG/Ym9Q3\ndMTp10ir38WXOoySg5kUFORflGvH8/Hii8+Snr6X1GHTmXTlFwDo0rUH827+ASvfup8//emP/Pzn\n/xvzDrCXX36edWvXcM+PfsbQocPO/QRpV0KhELt372TDhvXs3r2j2WBAXxwkprh07+0N1Enu6w0Q\n3LQI4nydGZDqrURRWVjPrM+71NdARSFUFUNlCZSU5FNQkM+mTR8BkJCQwNix45k5cw6zZ8+94FUq\n4uLiMGPGsn//PtzyEzg9T10rFRUVsXz58sZBPEVFRUB4lZ6Qi5t9nPj4eEaOHHPhb1ob5OYeJDv7\nAL6hI/D16oP/tWdPO4fp9Pd3EDf5SgJr32fNmpV88YtfjmhNTa1b9yE5OdkMGzWH1KFT2bHxZcDr\nALvymjtYu/xhXnjhGX70o3ujVpNceurr61m+fBkrVrzXeF3kOJDUy6VHPy9Tkvt610lNuxR2vAc+\nOpMazpjMDfXM+jwMHA3gTbKqLPI+KgqDHMzNIicni2XLlpCcnMz8+Tfxd393G127djvvmvv3H0Df\nvv0oOlSEW+vH6Xqqo/xs+QLgBoK42fl069aNESNGXeC7dm7vvvu2twLyVdfgxHnnWC3PYRoyJn7W\nPE4ufpFly5ZErYM9M9Oyf/8+Bg6ZTN8Bhg2rnmi8RkpM6s2ocfOxe5eTlraO666bH5Wa2gN1sAsA\npaUlrFr1AWvXrmoMxi5JkDrWJWWQ16me0KINd/u7kJDQuXEJsH2rvVDsPdj7AAgGvMaksuNQcjTA\n7t072b17J126dGH27Ku58cabGTbswpfX65XSi+LyctxA8NQM07i41oMx7tRJlltc5T0/Co3BR44c\nIhgI4PTug5uZ3uw+t6IMwjNWcnKyYtLRdOxYHo4vjl2bF+K63iizqop84uM7Uxuop7Ky8qI09H0c\nTWeVNu0Mk44hEAiwZctGVq9ewf79+wDvgq73EJfeqV5jUbcepw9U3ru6ecakr/EyJqkXDJngNSTW\nVnr5UnoMCo8dY/HiN1i8+A2MGcf11y9g9uy5FzxqriEf3OJKnN7hWdZtyBdKvHxJSYlOZ1NOTjbE\nxUPXRC9TmqqqgK7dyMnJikotLR05chiALl17Ng7gWfrqfzJq/ILw/Ydi3sHefIl45UtHdOTIIVas\nWM6GDesbBwYmprgMGux1dvXo5/2KNNUyXxrOYfpf4X0AnKx3qSj08qXkSB0bNqSxYUMaPXv25Jpr\nrmfBgk9c8CC9lJQUHMfBLak8NZCtLecvoRCUVpGYmBSV7VJycrxBeE7PXoQy9jS7z60owxk+Co4c\n5ODBnJh0sDcMVDjpr8FfX83SV/+ToSPnAMRsP7KWli9fRigUYs2alepg74Bqa2tZu3Y1H364svFv\nWkJnr0O9V/gcpkuLVVI3vtl6vvTs732A1xB8otQblFxyFHJyDpCdfYCXX36eadNmMH/+J5g0acoF\nD3JNSQnPiC+tgj5tP4dxSyrDz+91Qa97PsrLyygpKcZJHQp5h5vd51aUQbckiIsjJ+dAxGtpzcGD\nOQB07ZbS7Byme48BHDucT0HBcQYOTI1JbQ20RHzH5roue/bsZOXK99m5czuhUAjHgR79TuVL997e\ndVNTZ7pG6tYDUsdCQwN1eX74OuloJWvWrGTNmpX07duP669fwA033HjBq0g1xlKLMR3napwmyoNA\ncnMPQkIn6NzltGskt6IMZ+RYOAi5uTlR7WDfunUzK1Ysp0fKYObM/zY7N71KMHiSK6/+Gr36DGfW\n9f9G2opHeeyx33P//b8hISF2M8DeeedtwGurUgd7x1JcXMQf/vBbDh3KBaBzN+g/Mtzx1QcSU6Dl\nWJv6GgjWdT5tJYr6mno6d4N+w70P8PKr7kS4E6wIyvP97Nmziz17drFw4Yt8+9v/ccEdPjfddAv7\n9+8jtPkAcZ8ItxXExeH3+3n88cdZuHChtw2F348vPOjZzTwKFTVcfd18EhMjs3x9g4YJHr4xE3Br\nqnErylpsj1GGW1ONb8QY+Gg1GzemRa2DPRAIsGjx68TFJTB1lveaTQcJpg6bxoDBk0hP30NGRjpj\nx46PSl1yafH7/dz/y//hUO5B4hNg4GiXPkO985azNb+eK2PAu67qkngqa4InXcoLoPgIFOVWsnjx\nG2zc9BH3/eLX593J7jgOn/zkrbzwwl9xt2XhXBP++T9HvgC4u3Ohtp4bb/tcxNph/H4/Gzd+hJOU\njG9YwxZfZ8mYPv1wBqSyb9+eqE14aFiNbdyUWykvPdLsGumam76HmXwLmfs+YMWK5epgl8vL1q2b\nefzx33t7VSbAoDEuA0Z5I43O1KbTllAEr0E7ZaD3MWI61FS65GdDflZd40XeZz/7Bb7whQs72bjm\nmnksXvwG7oYMuGY8juPgdOuMv2t882DsmkBcN2+EQCjrOBwtZsyYsfTt2++CXvd8NMzS9XXvSRCa\nh6Lfj697D4JNHhdtRUWFdOnak6qK/GbHAwFvJmdxcWHsO9jr1AHWUdXUVHP//fdy9KjXcNqzv8uA\n0dB32Mc/8XKc8DKs4cak4EmXosNwPIvGpZ7feutN7r33lxe0rcCsWXN5441XCW45gDu4D05il3Pm\ni1vnJ7TR4jgOc+dec96veb5c1+XY8Tycnr1wwiMaW2YMPVIoz8+jtrbmgkZ5fhz5+d4ekblZac0G\n8GTufT98/2mLLkVd00E7GsDT8SxZ8gavv+4tS9W5Gwyb7DJgpJcLZ9LWc5iEztBniPfhznSpKob8\nbCjIKWfp0sW8885bfPvb32P27POfhZWU1J2pU6ezY8c23P1HcMYPPWe+ALhbDkBNPVd/Yn5UVpc5\nduwoAE537w1tmS8Nx48dOxqV5aRbqqysAE7N3KyqyCcnYw1As73eYqlhZn2sVwOS85eXd5QHHvgZ\nlZWVOD7oO8y7RuqVenqjdIO25ovjg+59vI+hE8Ff51KYA8cPBNm2bQvbtm1h8uRp3H33PRc023Tu\n3Hls2JBGKC0d36euwomPO/c5TEkV7p5DJCYlMWnS5At5y85Lw7WPk5yCm3f49HzBxenRi7y8vJis\nqNWQf1kZq5qdw/jrqwHIy8tTB7tcMNd1+eMfH2TbNm+WeVJvl4GjoN8V3jLNZ9LWjOmSCANGeh9u\nyGuczs+CokOFvPbayyxduph77vkZI0ac/3ZW3bolMnjwEI4eO4pbdsJbjedcnV+ui5vuXQ8aM+68\nX/NCFBcX4iT3wAl5v7+nZUxiUvhxRVGpB7xrjeeff5q4uASuvvE7VFcVYfcsx3WD5B/dwzU3fY+h\nI2ZSEN4r+d13l3LbbbHfj722tibWJch5euutNzl0KBdfvMuk+V6b7Ln+jIaCra9EEQoePe2xjgNd\nu3sf/Ud4x2oqXTLWe6toPPfcX/jd7x69oNqvvHImY8aMJTMzg1BmHr4xqTjdOkOPbvgrasjLC7ed\n9kjE6dYZt6Iad6Olc+cuUdlbfM+eXRAXh2/wcKitbnV7DIIBnPhEfKlDKTiUTVFRYVTan7dt20JJ\ncRGjx99It8RerXaATZz+WfKP7mH58mUx7WDfv38fjz/+B2bPnsvtt38jZnXI+Tt8+BCHcg/ii3OZ\ncEPb8gXOL2MaxCV4kzh7pXoDnPeshPzjx8nMtBc0WWf+/Bv5YMV75Kcfxr2iP05q77PmC3gDkN0d\n2SQn9+BTn/rMeb9mW2VnH6C+vo640eObbPEVOGPGAN6qyPl57N27m3nzbohYbeANANi2bTNJyf3o\nN3Asyxb+V7NrpPUfPMqtX/otAwdPIjd3FwUF+fTvPyCiNbUXsV3TTNqFXbu2Ny6j2qO/S5fuEPB7\ny6eebZBxy1Ds2/fMs7hcF/y1UF/tXTCmDDj1hbdu3XzBtd966+cYMmQo7v4juGnp3swuwHfTNPxO\niLy8PPxdE/DdNBWAUGYe7prddOnShW9+818v+HXPR0lJCQBOeLbZXXfdxdNPP81dd93ljXrqmgiO\nE7WlGJsKhUJUVlbQpeuZR6+3hwbqOs0w7bAKCvIbO9c7dXXp3sc78aqtbDwfOKPzyZhgwFsu0XEg\nuTd0TvQy5vjxYxw7duyCau/Xrz9///f/CDX1hN7ejFvhNaieKV/cE7WE3t4MlTV8+tOfY8iQyI/y\nr6qq5KTfj5Pk/Q63ljFON29wQXFx9DOmtNTLv9rq5rNGqquKmt0fS5rB3rE1NEwD9Bzo0qmL1/hc\nX3Nxz2Hqq739wrokeQOFwPsbunPn9guu/fbbv0FiUhLu+nRC+w4BZ8kX1yW0yeLuOki//gP4/Oe/\ndMGvez4at8o4wzmMk9i92eOirbUMqa3x8qa6ujra5cgl5sABS2WlN6M7KcUlsafXMFRbCWfryzyf\nfAHvuqu2Cnzx0KP/qeN79+664L9LU6ZMY86ca6CgnNB723DrTwJnyZjCckLLtkAgyDe/8a8XvLTr\n+Wj4/XUSE1u/RgKcpO74/fVUV58425eKiIZOt5oTzXOmvq6q2f2xpCXiO65gMMju3TsbP0/u7V3H\n1FR45xtncz4ZEwpBTaX3NTsnQWIv7+ektraWzMyMC67/C1/4MoRcQsu3456oO9U47fd7+eL3n+r8\ncl3cHTm42fmMGDGKqVOnX/DrtlUwGPS2fursjVZo9Rymk9dwHs3zhffff5eyslLGTr6FHimprP/g\nkfiEYC4AACAASURBVNMap8HbK7lzl+4sXbqIEyeqolbfmbSHGuT8TJo0BZ/PRyjgsOsDh61vQ8ZH\nkJfhbSXRWs744k6tRAE0rkTRchUN8Npfqkq8gTtZW7w9lbe+5VBR6HUKfZxV6hzH4V//9S66du2G\nu3Yf7pHwllA3TYPO4XmCPRLx3TQVt7qO0LvbwB/gjjv+OeIzOEOhIEfzjuD06osT79Vytkx2+nmr\nYxw+fCiidTVYvfoDAMZMvAmg1Yzp0380Kb2HsX37VsrLy874tSJt377/z955h8dRXn37ntmm3nvv\n625J7gV3I+MCNmAcIAESyEcvCT0JkAIpJiGQYAIvkDeN5IWEGkpsbGPAHfe+li1Z3eq9bJv5/hjt\nSrLlgm3tyM5zX5cu787s7pyVtWef55Tf2UtzcxMrV36smw2CcyMtLY1hw0aguCV2r5LY+KbEvs+g\nbL/mX1zO/p/3dX1Mcw2UH4D9n8Omf0rs/ETC5ZDIzMw652I9o9HE7f/vHmTZgLJ6F2qjtsfoz79A\nd5x35U5wK3z3u3cSEDBwChkVFd3NDVF9i3FO52Pk7sf6omlTKwCwk5iSR1dn80mNmq3NVXR2NJGY\nqq3zPKN6/hsQHewCli69HoPBwPbtW6kvb6K+V+GQwQj+IVpAKSAMgsIhOAIsgdDa2VcCrK2zFkuA\ntlBra9B+2pugvRk6miRcjr7X9fPzY+TI0SxZsvScbbdYLDzyyI9Yvvxpyg6Uoja1I8/ORYoIxnDz\nHFSHE8lsQlUUlE2HUPcewz8ggIcefJzERN/Ms+roaPMY22+lVq0sIZktugSO7HY7qqpiMvdsPPt0\nvgIdHfpWKyuK4rUFRIfpxUZaWga33XYna9as4tixIsr29w3++QVBQKjmYwLDNR8TGK51ovbnY0x+\nPf6lrbHbvzRLdJ2w55ckibS0NGbOnEt29rnP4Jo/fxFdXR28997bKO9tRp45Cikluo9/AVAr61FW\n74YuBwUF87nmGt8kv7wBoe7gUb+zDy0WVDQ1AV/TOxhzon8xGEy0trb43KYT6T13XfiXi4/bb7+H\nd999iz17dlF9tJPqoz3njOYe/+Jdw0Se2r9YArTEfGs9tDf2rGE6m6WTCoJCQkIZM2bceXVJxMTE\n8tijT7L82adp3XAQpb4Vacqwk/2L3Yny2R4orSU2No7HHntywKUPPXh9jLn/NUyNDsHp3pyuo6qr\nq9OHlpwaT/W5SH5dfEydOo3GxgY2bVpPVVUlrb3yrJIM/sEqAaEQ2O1fgiK1Tq5T+Re3S1u7ePZI\nHU3Q3izhOOHP2GAwkJMz5JznC4L2d/fd796F0+lg27atKO9uQr4876Q9EoBiK0ddfwBJUfn2d25n\n/PhJ5/or+1p4RnpgMve/RwLo9jFdXV3npEZ0PrS0NCPLRhSl/4pQj4KGnvT2K6KD/eLCaDTy8MM/\n5MMP3+Pgwf1UHu4bjTb5da9hQrv3SBHaz6nWMGZ/LTnf2tCzhulogs42yTO200tcXDwTJ05h1qy5\n52z/2LHjWbz4Gk1N8P3NMC8feW4eyqe7oLm9J/mlKKibDqHuLyUiMor77nsQub9I+gXmxO/c/nxM\ndc+jB9we0NYlH3/8AWZLIENGL6Czo4nW5uN99kie4LR/QBjDchexc/Pf+c9/PvLp/GYPvfdIzc36\n+zvB12PcuIksX/48GzZ8yf79eygqOkpbg4ve+nGWAK3oJjhCU9QJjQGDn72PEoXRz47RrI2baKmD\ntnptLdPRIvX56EiSREJCEsOGDWfChMnk5Aw5L/tjY+N44IGHefbZZ3Ct2qnFedNi+sZ5Wzu8DQ5X\nXXUNU6dOP69rng12uwPF7UbuVYjY/3gMDan7cb6IxdTV1bJ//16i43IICUs4pY/p6mwmc8gMtm34\nMxs2fDGgHbmno3eBtsvlwmgUKaqLBaPRxKOPPsHevbvZvHkD+/btobakkdpedSQBoVqDVUi3bwnq\njvP252PM/tr+qLlG8zOt9dDe1NfHhISEkD9pFOPHTyI/f8x5rSWysrK59dbbefXVl1A+3Io8fxxS\n5Ml7JLW1A+WjbdDWydKlN5CbO+acr3k2eNfyJ6iXnc7HeKoT3GfqYLsAHDtWDEBUbDZut7ZuPTHO\n63Y7iYzN6n580YDbNFgQ3ktASEgot9zyXW6++Tbq6mopKSmmrKyUysoKqqoqqKysoK2h74bPEgjB\nkXZe/aPmFJvbawmKsrP1fWhv7KsLIssyMTGxJCQkkZCQSFJSCqmpaSQkJFyQzVVYWDhPPPEzXn75\nRXbs+EoLIF0xBik8SFt0OZzaRq+invj4BL73vUd8KufndmvVgkjyqZ2iLOsSFHE6tcS1LBn7lRxx\nOBxedQO9cDgcfTbIIgF2cSFJEtOnz2L69Fl0dnZQUnKMsrISKirKqaysoKKinIaKZhp6FdsZjBAS\noxKebOe1/+32Ma21yH521v+9v0RXCGlDNP+SmJhMcrLmYy5EZaEkSVxzzTeIjY3n9ddfxvWf7UgT\nrMij03sC0wfLUNcfQJZkvnXzbcyZU3De1z1behZgmt/t18eEatWNXl/kQzzB834ljSTLoPg8d4kR\nFBc1iYlJ3HPP91EUN1VVlZSUHKO8vIzKynIqKyuprqmipbbv92tgmEpQpJ1XPf6lrRb/MDub/iXR\ndUKtm8lkIiE+gYSERBISkrz+JTo65oLIFaelpfOTH/+C559/ltJDx1Ab25AL8pH8tO5NtaUD5T/b\noamdESNGcffdD/g0yaQoCkgSkiT171+6fwd6+BcAp7P/jR3QpzhPIDgXjEYTS5YsZcmSpTQ3N1NS\nUkRZWRkVFWVUVVVQUVFBXWkHdb3Gh5ssEBRh59XXe/ZIYQl2dnwMLXUnJ7oiIiJJzOy9hkklJSX1\ngsz2M5lM3Hvv97vloN9HeX8L8uzRSCnR2h5JVVE3H0LdW4J/QAD33P09Ro3KPe/rngunDRzpRFdX\nF0aTHw57W78+ZjAU8fTtYBcJ9ouNoUOHM3TocFwuF+XlZZSWHqOiokzbI1WWU1dTS3N17wwWBEeo\nBEf3WsO01mIKsrPh/6STOlIDAgLIzEjqs4ZJS0snJOTCjH+7+uplWCz+vPnm31A/2II8azSGZZf1\nJL8cLpT/7IDyOpKSknnooR8QGRl1Qa59JoxGIyaTCZdD+6X052PUTO2cr0ZoffHFOtrb2xg55mrM\n5gDa7P1LS3uC1lnDZnFg179Zvfo/XHnlEsxmyxmucGHp3dmqZ5er4NyJjY3n6quv4+qrr8PlclFR\nUU5ZWUn3TyllZSU0lDfR0KvJKiBURZXtVFRUYPZXMfrD+r9LfZR7/P39yclOISkpheTkVJKTU0hJ\nScPf/8Kq3wwbNoIHH3yc3/72Vzg+3amtYTLiNP/S3I764VfQ3sXixdf4TN3Lz88Pi8VPm4GsqmAw\n9jsew2zQ0i1qs/bZCQsLH3DbPOqwadna+DK323lKH5OSOYHtm/7G1q2bdUuw9x4XWFtbQ3x8gi52\nCM4NWZYZPTqP0aPzUFWV2toajh4tpLj4KEVFRykpKab6aJe3AcJohohEleRhUHZA8zGWQBX/ENjw\npoSzVyjObDaTk51OWloG6emZZGZmExcXf0HHRU2bNhOHw8Gf//yalmS/YgxSTFhPcr2xTVP36rCz\nePG1LFq0+IJd+1R4PgPK8UoMGVbt4Bl8jHJcC6YnJCQNuH21tTUABHVLrvUb5wWCQ+P6PP6/AZFg\nF3iRJIno6Biio2MYO3aC97iiKNTV1XZv+kooLj6CzXaQutJ2wEFbs/ZhbmuSMJnNDB2aTWZmFqmp\n6SQlpRAXF4fxdMOWLwD+/gHcf/9DvP/+27zzzluo/94Ki8ZDkJ9WbVTbTF7eGO688z6fzyD2Siw6\nnf06RZOqojodF3wxejb0/nLqr6rbO3tERzwJLwkJFbVPJbXg4sLfP4AhQ4adNOepvb2NiopybY5P\nSTGFhTYqKspprARw0NrU/XfYIpGQkEhWVg7p6ZkkJ6eQmJjkk2TT1KnTSUhI4vnnl9O4xaZVLedn\noew7hrrxEEFBwTzwwMM+mynowc+ve0hjr4TSSbMPu+VDfCH3eiKewG9//qW+oU23pFxvPAl2CUn4\nl4sYWTaQmJh8kjqNy+XsHlVRRknJMYqKjlBYaKO6yQE4aOv2L23NEgGBgeTmDiEjI5OUlDSSkpKJ\njo4e8E6r6OgYnnzyaV577Q9s3rwB5d9bka+cAHYnygdboMPO/PmLWLbsRp90ffXG398fVBXV5cTZ\nj38xdvsXPdYwAG63csoCwcHgX3ojZrBf3ISGhjJqVB6jRvVInqqqSnNzE+XlZZSVlVBcXMThw4eo\nr6oDHLS19OyRJEkiPT2DzMwcUlPTSE5OISEhccC/m2XZwLJl3yQtLYNXXnkR56odmgRiSjTql/tR\nD5WTkJDI97//mM9n5HmVOOz2/gNHAN37AF+pdvTG5XIhSfKg9jGig/3SwGg0kpaWTlpaep/jDoed\nqqpKyspKKS09xtGjhRw9eoTWeje91zC0SERGRpGTP4T09AxSUtJITEwiNDRsQL97JEli4cKriIuL\n46U//A7nqp1IM0chZ8VrTQ7dcZjRo/O4++4HfB6HiYiIorqpEVU29LuGMXQr9Q20pLSHrVs3IUkS\nWcNmeY/1t0fyYDRayLBO5+DuDzlwYN+Ad86dSO8xPINhrJfg/DAajaSmppGamtbneEtLMyUlmn85\ncGAfNttB7/eJo1PC0QnJyamMGDGSrKwc0tIyLlih8dkwYsQoHn30SZ599mm61u5G9jNBRDDKx9ug\nvYtly77JwoW+SxBLksTo0Xls3boJtaIUOSkVKTQcR3OjN34qhYYjBQSiOhwohQfw8/M/747+s8Ez\n9iM+eZT32Kl8jMUvmMjoDIqLj+B0OjGZBjZmfyKqqlJRUea9X15eKhLsFzGSJBETE0tMTKw2ogpt\nXXr8eBVHjhzm8OFD7Nu/h5riOmqKe55nb5ewt2sFKCPGjsJqHUpmZjaJiYk+iXvMmVOAn5+f1sn+\n0TbkheOQokN7Cng67dxww01cccWiAbcFtMLL8IgIGm37UIbnInf7klP6mK5OlL3bMJstjB07fsDt\n8yhxmC3avuxU/sVoNCMbTLorIvsSkWAXnBFPB3pMTCz5+WMBbe6MzXaIXbt24Ha7kSTIysohL2+M\nzytre9u5ZMlSwsMjeP31l1FX7oCIYKhtZurU6Xz3u3f6PDANWuAcQG3XpJI9c8m8OBzgchEZefr5\njAOBR4JHUV001PXfOaK3TI8n4RVqDqHJ0SwSYJcggYFB5OQM6bPpqK+vY9OmDd5q+dDQUCZNmkpU\nlO8/Jx4yMjJ58smneeaZp6jbdgTF7kLde4zQsDB++IOf6LIhCAsLx2AwoLQ0aa3/nOxj1G6Z9jPN\ngB0IPBvv/rpGJNlvUCScPEU8oeaQQdFRL7iwGI0mb+J9woTJgPYZ2b17B4cPH0JVwWCQGTUqj6FD\nh+myTgBt5M2dd95HUFAQq1evRFm7G9q7oMPO9dffxPz5vtnUnYjH56rdEvAn+Zfu8TaetY7vUQdt\ngeCJCIn4Sw9JkggLC9eCQiO0YKaqqpSXl7J16yY6O7XvlLi4eCZMmExwsG8lznszYcJkwsLCWb78\naRxrdiMNS0E9VE5aWgaPPfYEgYFBPrcpJkZL6Ktt2riYk/ZIBiNqUz1BwcE+T8yBtrdU1VP7GEmS\nz/AKA4+YwX5pYzZbSE1NJzU1HdCkjzs7O9i6dbN3TqfFYmH8+IkkJaXotq4eO3YCP3j8xyxf/jSd\n6/aghvij7DgKtc1cdtkMbr31DgwG36+vkpNTqK6uQlKUfoPTaveYh+TkFJ/Y09jYgMUvGD//HgWB\nM6l3hIZryosNDQ0+sbE3vTvPamtrUVV1UOzdBBeWkJBQRo4czciRo1m8+Fqam5vZuXMbTqcTSZKw\nWof67DNyKnJyrDz44OP88pc/xb16N0QGQ2snixdf49PkuodFi5bw1VebcW1Yg2nxDRhnL8T50Vtg\ntyOFhmOcvRAA1+Z1qJ0dXLHkOiyWgY+Te5Jffn4h3mOn8zF+/iGoqkpXV6fPE+zHj1fR2dlJiCmY\nFmcrRUVHGTduok9tEAwssix3K+gkMm3aTFRVpbj4KJ9++h9qarTZ3RERUcydO4/sbKtu3y9Tp07H\nZDKxYsXzKKt2Ii+eiLJqJ3Tauemm7zB37hU+s8VoNHLjDTfz4ou/xbX635gWLUMyW/r1MarbjXPt\nR6idHSxZ9k2Cg0POfIHzxLOWUxU3kmw4pX9RVQVVcWM06hNb0wORYBecE7Js8EqaDTZmzJhNSUkx\nq1evhJYOUlLSuPXWO3QLmqelZQCgNtZrG7nmHnmt3vfT0zN9bpvFYkGSJFyO/jtHQJ+u1954El7B\n5uDuBLtIgP03EBkZpctm6UxERUXzwAMP88QTj6LuPQbAvfd8X7dqW4PBQGpqGkXHisFkOsnHEBqO\nWl9LZGSUTxZcJ+KRuO1XvcMkY7GE+dymE7Hb7RgkmQBjAC32tjM/QXDRYzabGTdu4qDbxMuyzLe+\n9W1KS0u8HQhTplymW3IdICMji7VrP0Vt6n8NQ2N99+N8v4YB7Xd2qo2dLOuf/AKR9PpvQ5KkbrnU\nVL1NOQmrdSg333wbr776EuqeYvz8/Pje9x7RJbkOkJKSitFowl1b3b9/UdyorS1k5ebrYp/FYkFx\n15/Sx1gs5y/jf770loUXHez/Hfj7BzB9+qwzP9DHZGVlc999D/KrX/0M5b3NAAwfPpLbbtMvDmO1\nDmXbti0olaVacPrdN0DVku2GWQtwf/oB/v4BPksepqSksW3bFipLd5GQkovBYOp3j2QwdI8hUxSK\nD3/Z/Vzff6fU1GhT6v0MfnR1ddLa2nLBxgsIBi+hoaHMmDFbbzNOYsiQYSxatJj33nsbKurJyMhk\nyZLrdLElLS2dK6+8mvfffxvnZx9junwxlm/dheqwI3U3nLkP7EI5vJ/U1HSfSEuDJi+9f/9eaqoO\nEZ886rQ+xu12UldzhKCgYF3WgYWFNgDmpszinaMfeO8LLl0kSSIjI4vbb79Hb1NOYsKEyVRVVfH2\n2/+H8sY6AGbPLvBpcr23LYcPH2LVqk9wrnwP07yrkSOi+vgYVVFwffYxamUZ+fnjfBYvCg+PAKCt\ntZawiORT+peO9kZUVSEsLMIndg0GBkfkSSC4wFxzzTImT76MMWPGceutt+vahZ2SkkpoaBhqaRGG\nmfOhu3LRU3WkHDsCoMvMQ1k2EBAQiKM7qeTpHOk9t1TPbhvQpPEAQsyaHaKDXaA3qanp3HjjLeTm\njmHp0ht8Lgt/IqNG5YGioJQWadXSvX3MqLFg79JtpmpvSdcT/YvT2UVAgO8lX0/EbrdjNpixGMyi\ngEegO7Js4JZbvsvYsROYMGEy3/jGt3S1x+M7lOLCk/yLYdYClGOFmM0WrNZhp3uZAcNo7JlJduut\nt3qlmz3nBhMizy4YDEydOp3ZswsYOXI0t9zy/3wmjdwfZrOZ4cNHoDbWYRh/2Ul7JHdRIQCjR+uT\nYA8ICMTlcpzSxwyGNUzvAh5RzCPQmxEjRnmlYQ0GAzfffKtuyXWAvDxNUt1dZEOOiMIwIg95WC7m\npbcguV2obS3k5ub7zMbFi6/BaDSycc0KaioP4h8QRnBoXJ89UnBoPP4BYSiKiy2fv0p15QFyc/PJ\nzMz2iY29OX68EoBRkSO67x/3uQ0CQW/mz7+SKVOmMWbMOG6++TZdi2mvvnopubn5qOUluDavA/Am\n15XyElyb1hEcEsIDDzzss+7wadNmArBj0xu4nF2n9TF7t79DV0cz06bN1OX3eODAPgByo0aTEpzM\n0aOFItYr0JWFC68kqluVLzAwiOuuu143W2688WYmTJiMWl2Jc/W/UbvHUklmC6qq4lq/GqW4EKt1\nKHfddb/PPsOextDa44dP619qqw51Pz7DJ3YNBgZX5EkguEAEBQVz55336W0GoHVQTZo0hf/85yNo\naexbddTZgVJylPj4xJNmIfmK8PBwjlfXnvJ8WFi4D605Gc8iK8ikVVV6Eu4CgZ4UFMynoGC+3mYA\nMGnSVN5771+4bfswz7+2j49xfvYxAJMnX6aLbaGhp+9QDwvTv4Pd4bBjls2YDRacTqeQPxToTnJy\nCvff/5DeZgBalfLw4SPZv38vSPTxL0pFCWpLM+OmTPOJ7GF/9FbJOFEW3mLx08Okk/D4E+FWBIMB\nWZa55Zbb9DbDy5Qp09m9eydqVVnfPZKqoqz5EKPR5B3v4Wt6K//052P0UAY6kd5d66KDXTAYuO22\nOykomE9wcAgxMbG62hIbG0d2tpXCQhtqSxPGCdO859yHtOTO1KnTTvX0C05qajp33XU/L774PJ99\nvJxxl32bqXPvY/2nv6e1uYrg0Himzr0Xe1cbG1b/nurKA2RkZHHHHffpsjepqqrEbDAzLMLK1ppt\nVFVVkJNj9bkdAoEHf/8A7rjjXr3NALSi6LvueoCf/uxHlB/YjTs6DkP2MNS2FlyffYzRYOR7Dzzi\n0xGH6emZXH75Faxa9Qkb17zE1Mvv69fHFB9ez8FdHxIdHcvixdf4zD4Pqqqyb98eQszBJAUmMCx8\nCCWtpdhsB7TmEYFAB4xGEz9+6uccP15JdHSMroW0smzgjjvuxW63s2vXdlwb1mC8bC6SJOHetQXl\n8H7S0zN58MHHfBqHGTZsBGazmZLCjYzIX8LUuffxn7efQFXdXv8CcOzIRqCn0FEPVFXllVdepLm5\niXvv/f6A/3+KDnaBwAfMmjUXAPe+nVryxiMbdHA3KG7mzCnQLaETFRWDy9lFUEjf+akGgwlJkoiM\n1K+zBcDp1LpEgkyaMxQJdoGgLwkJiQwbNgK1sgylXiuWkcwW1LZWlOJCEhOTdeuyj4rS/ErvWYMA\nAUGRfc7ricPhwGwwY+6WY+yt4CEQCGDOHG32sHvvDqCnO8PVfX/u3Hn6GAanlTQMCPD9zGaBQPD1\nGDduPKFh4Si2/aj2rp7ur9Ii1OZGJk2aopuaVnj46YuMPTKJeqIoaq/bIsEu0B+z2UxmZrbuyXUP\ns2dfDmhyzR7Uzg6Uo4eIiYllxIjRPrVn3LiJPPLID/Hzt7Dl81c5dmQjC677Fdfc8goLly3HYDSz\n6r0fU115gPz8cTz++JN9FMF8haIoHK+qIj4glviAeAAqK8t9bodAMJjx9/fngfsfxs/fH/emz1A7\n2nCuX41q7+Kmm75DdrbvC1Kuv/4mRowYRUXpTrase43Q8EQWLlvu9TFtLTVs+fxVAgIDefDBR/H3\n9/1+qby8lObmJoZHDEWSJEZEakpoe/fu9rktAkFvQkNDsVqH6qrw5cFoNHLPPd8jLS0D5fB+lCIb\nyvEK3Ns3ERkZxYMPPu7zz6+/vz+TJ19GW2sNZcVbCYtIxjqygOzhc1m4bDlhEck01pVQVbaHnJwh\nJCYm+9S+3jQ1NbJhwxfs27eHw4cHfgSFSLALBD4gPj6R/PyxqDVVqNVa94PqcqIc2E1AYCDTps3Q\nzbaEBG129Ij8xUiSJo8WHBqPbDASExOL0egbOaNTYbefmGB36mmOQDAoueIKbeaOe8827zH3vh2g\nKMyfv0i3Ap6EhETt35TcPv4lPXtqn/N64u1gl0WCXSDoj/z8scTGxqMcOYjaro2UUeprUcuPYbUO\n1UW21ENkZNRJx/wCNGWMoCB9R9wIBIIzYzSamFewANXpwH1AC6yqqop791eAJgerF94iwYC+ajsm\nc0D3ed91pZ2K3jPYhUS8QHAyEyZMIjw8ArdtH2r3KCj3gd3gdlFQsEAXaeThw0fykx//gri4eA7u\n+pCdm97AbA6grbWWNR88Q1tLNYsWLeH++x/Cz8/f5/YB1NXV4nA6iA+IIyHQk2Cv1MUWgWAwExsb\nx7LrbkR1OHCufB+1vIQRI0bpNsfeaDRy//0PkZmZzbEjG9i99S0AzOYA6qoL2bhmBWaziYcf+oFu\nya99+/YAMCJCS6xnh2Zhkk3e4wKBQMNisXDvvd/HZDbj3vIlro2fAXDXXQ8QGhp6hmcPDAsXLkaW\nDez56p+4XQ7yJl7P2Ck3AdpeZOeWfwCwePG1utjnoa6uR6m5vr5uwK834KtJq9X6nNVq3Wi1Wtdb\nrdaxJ5y7u/vcF1ar9bnuY9OtVmuN1Wpda7VaP7NarS8MtI0CgS9YsOAqANx7tgOgHD6A2tXJnNkF\num2cAJKTUwFwOjq9lUczFzyK09HpPacnLpeWUA8wasEsT0e7QCDoYfToPJKSklGKbKhtragOO27b\nXsLCwpk8eapudnlGX3S0N/SpbOzqbO5zXk+cThcm2YipO8EufIxA0BdZNrBgwZWgKN4OMPdebS2z\ncOFVeprWM4aiu4goODSetKzJfc8NEsToCYGgf2bPnou/fwDKgV2obhdqdSVqTRX5+WNJStKv8yEu\nTksqJaeP7VMkGBQSgyRJxMbq36G7Z09PV67oYBcITsZoNHH55VeA04n78H5Utwvl0B4CAgK984r1\nIC4uniee+BmJicnY9q2k+PB6Nnz6ezo7Grn++pu47robdJ0vXVWlJdPjA+IINgcRbAryHhMIBH2Z\nMWM2oWHhqPU1gJZY0nPd7+fnz0MPPa4V8ez+iPJj23HY21m/+veoqpv77nuQrKwc3ew7eHA/AEPD\nhwBgNpjICcuivLyM1tYW3ewSCAYjMTGxzJ41F7WjDbWhlrFjx+s6riU2No7LL59HW0sNh/Z80udc\nefE2qiv2M2pUHiNH+lYh6ESOH6/qdXvg1y8DumKzWq3TgCybzTYZuA34Xa9zwcBDwBSbzTYNGG61\nWsd3n15ns9lm2Wy2mTab7f6BtFEg8BXZ2VYyMjI1ycO2FtwHd2MwGHSVVgXIyMgCoK7mqLfyqL7m\naPe5TD1NA8Dp1BLs/kb/PvcFAkEPkiQxb95CUFXctr0oRw6C08ncufN0VaEICgomLi6e+pojbsob\nAgAAIABJREFUjB6/zFvZWFtdiMViISkpRTfbPDidDkyyCaNsBMDlculskUAw+JgyZRqBQUEoh/ai\ndrShFB0mLj6B0aPzdbXLM8bGZPInIDCChcuWoyruPucEAsHgxt8/gJkzZ2uyzcVHvJ3s8+Yt1NUu\nT3K/q7PFWyS44Lpf0d5aS0xMLGaz72YenoqKih7JZtHBLhD0z4wZszEaTSiH9qKUHEXt7GD69Jn4\n+fnpaldISCjf//6jmM0WNq97hYa6YqZOnc78+Yt0tQt6gtFxgVohUWxALLW11WKfJBD0g9Fo5PK5\n85AkiYzMbHJyhuhtEkFBwdx//8MYjSa2b/gLu7a8SWd7I0uWXKfrnHNVVSksPEyUXySrytbwV5vW\n7ZoTqsWlCwsP62abQDBYmTv3CpKTU0lISGTBgsV6m8OSJUsJCQll/64PaG+rB8DlcrBj8xsYDAa+\n+c1b9DUQKCsr6XW7dMCvN9AlkbOB9wBsNtshIMxqtXqGJToAOxBitVqNgD/Q0H1OtHgILjkkSWLm\nTG0Wu2vretTGevLzxxIWdvr5fgNNXFw8gYFB1B3vWcjUdt/WY2bQiXgS6haDGRDJL4HgVEyYMBmL\nxQ+l8CDuwoPIsqxrZ4aHIUOG4XR00lh3DIDOjmZaGivIyRmCwWDQ1TZFcaOqKkbZiNHbwS6KeASC\nEzGbzVw2dTqqvQvXl6tBcTNj+mzdu7KjozUJ54DACFIyJwLQ1lrb55xAIBj8ePZI7oO7UUqOEhef\nwJAhw3S1KTIyisDAIBpqi71FyO2ttTjs7aSlpetqW3/0losXCAQ9BAUFM2bMWNTmRlxfrQfgssv0\n3yOB1pnmSagHBARy7bXf0NkijerqagBi/WO6/41GURTq62tP9zSB4L+WK6+8mr/85S1+8uOf674/\n8pCUlMzll8+jo72Bo4c+IyoqmoUL9Ru9A9DY2EBbWyux/jGsKlvDmvJ1PLbpSQJNWqqotLTkDK8g\nEPz3ERMTy89//mt+9avnycrSbzyfh4CAQJYtuxG3y8Hebe8AcHjfKjra6pk3byHx8Qk6WwhFRUeR\nkAg1h1BcXDTgSl8DnWCPA3qvwOq6j2Gz2ezAT4EioBjYYrPZjnQ/bpjVan2vWzp+zgDbKBD4jLFj\nxyPLMkqRDdASYnojyzJDhgylva3OG5SuqTyAyWTydrfridutdaK5FTdG2SgS7ALBKfDz8yM/fwxq\nWwtq7XGGDBmmewEPaHMGAY5X7AOguvvfYcNG6maTB48/MUgGb2Ba+BiBoH/Gj58EgFJWDGhzTfUm\nOjoGWZYxmQPIm3g9AK3NxwkICBx0M9gVRXSXCgSnIi4untTUdNTqSnC7mDB+ku4BakmSyMzMpr21\nls4ObbRNXY0WrsjM1D+4pdHjV0QDu0BwasaMmaDdaG0hNjaO5GT9VbQ8XHPNMl577W+sWPEakZFR\nepsD4E2kf1m1kf8r/BdR/poqUG2tSLALBBcTs2Zd7m1qmD27QFd1Q+iRbT7WWorSHX853lHNytJP\nu8+LURQCwcXA1KnTSExM4ljhelqaqji052MCAgJZtGiJ3qbhcrkoLj5KYlACwyKG0tHRTlVVxYBe\n0zigr34y3l1yt0T8D4AsoA1Ya7VaRwKFwI9tNts/rVZrBvCZ1WrNtNlsp4x4h4cHYDTq2wUnEJwN\n0dHBZGVlcfiw1iE+bdokQkL0DwCPHz+W7du/orriAKa0fJoaysjNzSUxUX951Y7ugNb/HPhfAByO\nLqKjffc7E/5FcDExceJ4Nm3aAGifa19+Vk7FtGmTeOmlFzhevpfheVdSVb7Pe1xv+9rbtTrDg402\n3KpWzNPWVk90tO+S/8LHCC4WIiLysPj5Ye/qIj4+nqFDM/Q2CYD4+Hhq6ypRVRVFcdPaUo01J5uY\nmBC9TQPwfr4NBnzu84R/EVxMjB2bT0mJVsAzefJ43dcIAHl5o9izZyd1xw+TnDGO2iqtSHr8+PxB\nYV/vIoTgYIvYIwkEp2DKlHG89JJ2Ozd39KD4/PZlcNnT0tKEWTazq24PiqqyOF0b2eFydfjsdyd8\njEBw/kRHB/OXv/yF9vZ2kpKSkOWB7rM8PYrSBUC7qx2z2Ux0dDS1tbXUdtUB0NHR6hMfI/yLQHD+\nLFt2Hc899xxfrnoee1crS5cuJS0tTm+zOHDgAA6Hg5zoLJKDkth0fAsVFcXk5g6cOtpAJ9gr6e5Y\n7yYB8EyZHwoctdlsjQBWq/VLYIzNZvsT8E8Am81WZLVajwOJwCl1QhobOy685YOIhoZ63n//bdxu\nNzNnzhlEFfOCcyE5OZ3Dhw8THByM3S5RW9uqt0kkJ2ud6jWVBzGbAwDIzBwyKGz79NPVfe5XVVWd\nt11fZ8F2qfsXVVX55JMPqagoIzExmSuuWKh7x5Dg3ImOTvTejo1NHhSfYZBJTU2ntLQQp7OL6op9\nhISEEhQUpbt9bW3a9T3JdYBXX32N4cPHnNfrCh/Tw9GjhXz22WoMBgNXXXUNERH6F24Jzp2U5FQK\nC22kpWXq/vn1EB+fSEVFBZ0dTTjsbaiKm7i4xEFjn8Oh1Qh3dHRdEJuEf+nB4XDw9ttv0tbWyqhR\neYNCVUFw7iQm9siuh4fHDYrPcHJyJgA1xw+RnDGOmqpDmM0WQkNjB4V9veeuNzW1+9THXOr+BWDb\ntq3s3r2DwMAgrr56KWazRW+TBOeMmdjYeKqrq0hPtw6Kz+9gpqGhkQCjP432JhRV4d2ifwNQUVF9\nXr87sYYRCPTAjL+/mfr6dr0NoaamEdDGj919990UFBSwcuVKVqxYgcvhpLW17Zx9jPAvAoFvGTo0\nF6PRREuTpjyRlzdxUKyvNm/eBoA1PJvkoGQAtm7dzvjx087rdU/nYwY6wb4K+DHwqtVqzQcqbDab\nx6MfA4ZarVZLt1z8WOAjq9V6AxBvs9l+Y7Va44AYYGD7+AcxbW2t/Pa3yzl2rAiAnTu388Mf/oSE\nhMQzPFMwWFm0aDFhYWEMHTpcb1O8JCYmERQUTM3xQ5j9AgEYOlTfuYcATU2NtLW19qlsdDgcNDU1\nDgrp60uBjz76gDff/Jv3vqIoLFx4lY4WCc6HpKQUvvOd23E47AwbNnh8zPDhIzl2rIgi2+d0djQx\neuIU3aunARobezZ4Hh9TX18nfMwFoqqqguee+xUtLZoSSVHRUR599EeDTrpbcPbcfvvd7N+/j7y8\n8ytCuZAkJaWwbdtWmhrKcNjbvMcGCy6XEwCn06GzJZcWbrebP/7xZTZs+BKADes/x2KxkJubr7Nl\ngnNlzJixPPLIjwgJCcHfP0BvcwDIyMjCaDRRU3WIrs4WWpoqGTFiFEajr4UAz4wYQ3Fh2bdvDytW\n/NY7OqihoZ7bb7/HK7UruPh4+unltLW1EhUVrbcpg5729jbcTrdXwrnJ0dR9XP8E3aWCw+Fgz56d\nOJ0uhg8fQUhIqN4mCQQ+Izo6moKCAgAKCgp46623qKqoOsOzBALBYMLPz5/s7BwOHtxPaGgYSUnJ\nepsEwMGD+wGwhuUQag4h1ByCzXYQVVUHrKFwQKPbNpttE7DdarVuAJ4H7rZarTdbrdarbDZbDfAs\nsM5qtX4B7LDZbBuAD4Dp3cfeBe44nTz8pcyRI4U8+eRjHDtWxNAkicuGSrS0NPPjHz/Oli2b9DZP\ncI5ERkaxePG1WK1D9TbFiyzL5ORY6Wirp7x4GwaDgfT0TL3Nwul0eisbX3/9de6++27MZjNOp1Nv\n0y56Ojs7+Z//WcGbb/6NID+JK8fKBPlJvPnm33jllRfp7OzU20TBOSBJEjNnzqGgYAGyPHgCgEOG\naAU7B3d9BDBo/J/T6RA+ZoDYsmUTTz31OC0tzVw2VGJoksSxY0U8+eRjHDlSqLd5gnMkNjaeWbPm\nEh4eobcpXlJSUgFoqi+lqb60z7HBgMefOJ3/lduZAaG+vo5f/vKnbNjwJbGhsCBfRpIUnnvul7z/\n/tsoivvMLyIYdMiygZEjR5Oamn7mB/sIk8lEZmYWTfVlVJbuAsBq1b8I2UPvueuqGMJ+QVAUhY8+\n+oBfP/sMquJiXq5MbChs2rSeX/ziJ9TX1+ltouAc8fPzE8n1s0BVVex2Oy715HVLc3OzDhZdejQ1\nNfLLX/6UF174NS+99Dw/+tHD3qYqgeBSxmLRlGBqa2tZuXIlACtXrqS2thYFRSjFCAQXGTfeeAsL\nFy7mzjvvGxRquIriprDwMHEBsYRZQpEkiZywbJqaGqmpOT5g1x3w0mubzfaDEw7t7XXuVeDVEx7f\nBlw50HYNZhTFzQcfvMu77/4TVVGYMkRi+jAZSZIID1T4ZGcnL774HLt2Tefmm2/Fz89fb5MFlwDp\n6Vns2LGNjvYG0tMzMJvNepsE9F/ZKDg/jh4tZMWK31JbW0tcGFw7USY0UCIlSuVfm92sX/85NtsB\n7rrre2RliZEUgvPHM9qks0PrGM/KytHTnD4IH3Nh6erq5M9/fp316z/HaIArx8qMTJVRVZWIIIWN\nh2r42c9+xJIlS7nyyiWDqhBEcHHiTbD36mBPTh48HeyeBLunk11wfmzZspHXX3+Zzs5OrAkSi8bK\nWEwSUSES72xR+Ne//o/du3dy1133i0SK4IKQkzMEm+0gh/etAiA7e/CsYfoiEuznS2NjA3/4w+84\neHA/QX4SS8YbSImWGJEi8e9tCjbbQR5//PvceuudYiSF4JLF7e5JrJ+oJCjUeM4Pp9PJ6tUree+9\nf9LR0UFqtERYIOw+1shTTz3O7NkFLF58jehmF1yyeJTsHA4HK1as4K233vL6l97nBQLBxUFqahqp\nqWl6m+GlvLycrq5OsuPz+L/CfwGQE5bFVzXbKSw8TGxs/IBcV399VkEfXC4nv//9c7z99psEWVRu\nuExmxnADa/cqrNzpYmSqzK2zDcSHw/r1n/Oznz0hqkgFF4SUlJ5gdHLy4On86q+yUXDubN26iaef\nfpK62lomWyVumWlg21HNv4QGavcnWyXqamt55pkn2bpVqGUIzp/g4GDv7G1ZlklMTNLZoh6Ej7lw\nNDc387OfPcH69Z8THw63zTZQ06yycqcLSZKYMdzAjdNkgiwqb7/9Jr/73W9E0lFw3kRHx2I2W2hu\nLKepoYzw8IhBFZxxeTvYxd/6+fLOO//kxRd/i8vZyfx8mWsmyqw/qK1hkiIlvjtHZmiSRGGhjSef\neFR0gwkuCBkZmqpXY31Jn/uDg56kuqIoOtpx8VNWVsqTTzzKwYP7yYmXuG2OTGGV5l8sJolrJsrM\nz5dxObVmh3fe+afeJgsEA4JHDKM/lS+hlHFuqKrKpk3refjhe/n73/+M29lBQa7MjZfJLBxj4Pqp\nMqH+Cp9++gkPfv9u3n//bW/CUSC4lAgLC/PedjgcVFRU9PlbDw8XY/ouFHV1tZSUHKO2tkZvUwQC\nn1FUdASAjJB0vqrZwVc1O0gPSes+d3TArjv4hof9F6OqKq+99jLbtm0lLVri6oky/maJmmaVrUdU\nFBWKalxcM9HAzTMMrNylsLO4hN/85uf88Ic/9UqtCATnQlxcQq/bA1PRcy6cqrJR8PU5cGAfL614\nHoOssHSqTEas3K9/mTnCQGq0wtubXby04nmCgoIZNmyE3uYLLnLi4xNoaKgnNDQMk8mktzlehI+5\nMNjtdn7zm59TWlpCXrpEQa5MfSsn+ZfUaJnb5qi8s1lh+/aveO21l7n99nsGhZyU4OJEK9pJpLhY\nS6Zmpo/S2aK+OEWC/YKwatUnvPvuW4QFwrLJBqJC+t8jLRkvkxKlsmpXK8t/9TQ//skviImJ1dt8\nwUVMSkqa93Z0dMygmQ9/IiLxde40NNSzfPnPaGpuYvZImQnZErUtJ69h8tJlkiMl3tzo5t133yI4\nOIi5c6/Q23yB4IJiMGh9WP2pfAnlqa9PZ2cHL7/8Ijt2fIVBhgnZEpOtMgEWiTV73LjcKgV5Rm6/\nXGJHkcr6Qw7+9a//Y9Om9dx//8PExyec+SICwUVCRETUac+Hh0f6yJJLl9bWFt5++y3WrFnpPTZj\nxmyuvfYbhIaGneaZAsHFT2npMQBSQ3qaSFOCkpCQKCkpHrDrig72QYKiKPzjH39lw4YvSIiA66Zo\nyXWAtze7Ubr3yw1t8M5mNwZZ4oo8mVGpEsXFRfz+97+hq6tLx3cguNiJiorqdXtwSWr2V9ko+Hoc\nOVLICy88i4rCdZMNZMRq7r8//wKQEStz3WQDKgovvPAsR44c1st0wSVCWJhWjRwQMHgC056krvAx\n50dXVxe///1vKC4uYlSqtj4xyNIp/Yu/WeK6KTIJEbBhwxf84x9/FZ13gvOid5FgfHyijpacjNMl\nEuzny4YNX/C3v/0vgX4S37xMS65D/2sYSZIYmylTkCvT2tbKs88+Q12dUCYRnDu990iDzb/0RnyP\nnhtNTY08++wzNDVpyfWJOdpovlOtYaJCND8UaJH461//lw0bvtTReoHgwiPLBiRJ6lfly2gUCfav\nQ0NDPU8//RQ7dnxFarTE7XMNzBllIMDSUyS4rQj+sNJFfSuMy5K5q0AmP0OioqKcn/70hxQW2vR+\nGwLBBSMoKOi040gHWyz6YkFVVY4cKeS11/7AA/ffwZo1KwkLhDEZEuGBsG7dGh544E5eeeVFDh8+\nJIoyBZcs5eVlSEgkBmrxIUVVMBvMxAbEUFFRNmB/+6KDfRDQ0tLMK6+sYM+enUQGSyydJGMyaIGj\nti6Vhra+j69v044H+WlB7LYuhd27d/KTn/yAe+75HomJyTq8C8HFjtlsITMzm/Ly0kEmfSg4H1RV\nZfXqlZoUmdvFlWNlUqPPzr+kRkssGiPzwbYOnnnmKW644SbmzJknOk0F58T06bOora3m8ssX6G2K\nF1kWdYbnS0VFGS+++FvKy8vIiNXWJZIkndG/mAwSSycZ+NsXCp988m8qKsq5/fa7xcxBwTkRGxvb\n7229URQ3breWlBFzS78+TqeTN9/8GytXfozFBNdNMhAaeHZrmDGZMi2dKhttVTz5xKPcfse9jB6d\np8O7EFzs9O7YjI4evIFfESv9+uzfv5eXX/4dTU1NjMuUmJB9dv4lNFDiuskyf1/v5uWXf0dx8VGW\nLbtxUCk0CQTng9lsxm63n6TyJVQzzw5FUbQi4r//hda2VvLSJeblyshyTxylvyKeOwqMWEwSV+QZ\niAtT+GRnG8888xSLFi1mwYLF+Pn56fSOBIILgyRJREREcvx4Vb/nexc1Cs6Mw+Hgyy/XsXr1fygv\nLwMgLBBmDJPJS5dwKTB3NOwqVtlyxMX69Z+zfv3nJCQkMmdOAdOmzRJ+XXBJUVlRTqRfBLWdtTTa\nG1FUhcc2PUm4JYzjjdW0tDQPiJKDSLDrTF1dLU8//QT19fVkxEpcNU6TCvLg0mJymM1moqOjvQtb\nz3GjQdvcfbpbYXtRGU899TgPP/xDrNahOrwbwcXOk08+jaqqGAyiMvlSQFVV/vSnV1m79lP8zRLX\nTpDJjOtJKJ7JvwCMSJHxN8MH29z85S9/pLy8jG9/+//5+J0ILgWGDh3OE088rbcZfRDFIueHzXaQ\nZ599BrvdzpgMibmjtc51ODv/EuQncdN0mfe/UtizZydPPvkoP/rRz0TluuBrExkZ3e9tvXE6Xd7b\nLpcLVVWF3zlLHA4Hy5c/jc12kKhguHqigeiQs98jAcwYLhPsr7J6Tyu//vXPufnm25gzp8DH70Rw\nKZCVlcORI4eJjR08Y7RORmTYvw5ffrmOV199CQnVKwvv8c9n418SIiRunmHg7c1uVq78iJKSYh5+\n+Ien7cwTCC4WLBY/7Ha7V+Wr93HB6amoKOd//mcFRUVHMBrg8tEyYzOlPus/TxFPbx9T3+bwFvEA\n5KXLhAXCv7e5ee+9t/ni88/49nduJzc3X6+3JhBcEGJiYk9KsPsZLHS57URGigT72bJt2xb++tc/\n0tDQgCzDkESJ3DSJjFhtzM0LH7npckJEEFwz0UB+hoFjtSq7ilVslRX85S9/5IMP3uHGG29hwoTJ\nYo8quOjp7OyguaWZERHDeHHvKyiqpu51vKOaVkerdvt41YAk2EXrls58/PEH1NfXMylH4htT+ibX\nPZjNZu6++25ef/117r777pM2bQZZYl6egcXjZex2O2+++YavzBdcYsiyLJLrlxDl5WWsXfspkUFw\n25y+yXUPZ/IvAJlxMrfNlokMgrVrP6WsrNQX5gsEA46YI3h+vPnmG9jtdhaPl5mXZ/Am1z2cjX8J\nsGjrn0k5EvX19Xz00fu+Ml9wCREREeG9HR4erqMlfXG5emThVVX1drMLzsyWLRux2Q6SGSfxnVl9\nk+sezuRjPHLxt8w0YDHB3//+5z7/JwLB2XL//Q/xwAOPMHv2XL1N6UPvrnUh93n2qKrKX//6Rwyy\nyk3TDV5Z+N6czRomOkTzTxmxEocOHWDr1k2+egsCwYDi7+/f73E/v/6PCzQcDjs///lTFBUdYViS\nxB2XGxiXdbJ/cbn79zGuE5aJ6TEyt881MNkq0dTcwHPP/XJAZ8gKBL4gIkKbsy53p6TiAmKJ8ovC\nYDAINbuz4PjxKn73u9/wwgu/prmpgYk5EvfMM3DNRAOZcT1jbrq6tzy9x2ilx8gsmWDg3is0v9LW\n2sSKFc/z/PPLqago1/eNCQTnSXV1NQBhllCOd1T3Odfu6uh+zPEBubZIsOtMVFQMAPvKVL46otLl\n6LsxNho0KbqCAq3boqCggOjoaHqPPnK5VfaVKmy0Kd2vOXg6dwQCgX6EhIRgNptpaIfP9ytUN319\n/wJQ3aSybr9CQ7u2EQwODvbVWxAIBhRRUHR+eNYbG20K+0oVXO4eH3O2/qXLoa1/9pVpz42OHjzy\n3oKLh97BmMEUmDlx7rqYw372ePxLaZ3K+kMKzR1ffw2jqirFNQrr9inYnVohhiisEpwLYWHhjBkz\nDrN58MpoigT72SNJElFR0bjcsG6/wtHjSp/f39muYZo7VDYcUiir154r4jCCSwV//4B+jwcEiAT7\n6XA6nXR0aEF8kxEa21Tcysm++Wx9jKqqNLVrtw2ydr+1tXVA34NAMNCEh2sJ9iBzIOGWcH456ae0\nu9oJD48QI/xOgaIo7Nq1nd/85pc88sj9fPXVZpIi4bbZBmaPNBDs379CRmJiImaz2TvmxkOgn8TM\nEQa+O8dAShTs2LGNxx77HsuXP8327V+hKKIoXHDxUVtbA0CY5dQd6p7HXGiERLzOzJs3n66uLj76\n8F0+3ePks/2QEy8xKlUiPVYiyE/C0VHLypUrKSgoYOXKlTg7agm0QGWDyp4ShQPlKp0ObaM4bdoM\nvvnNb+v9tgQCwSAgNDSMRx99ktdf/wN7SirYU+ImNgxGpciMSDm1fwnyk+iwq+wvU9ldolDdpL1e\nQkIit956J2Fhg6c7UCA4H8QG7vz49rf/HyaTiS+/XMf7Xyms2g3DkiRGpcrEh3NK/6KoKsXVKntK\nVA5XqVoXh8nEkiVLmDdvvt5vS3AR0lvmKzg4REdL+nJiQl3rnhbB6bNh6NDh3Hnnfbzxxp/YaGth\nk81NWozEyFSJIQmnX8M0tqnsKVXYV9oTmB46dDi33Xan8PuCSxaRYP96PPjg47z++svs3bubY7Uq\nIQEwMkVbw0QEndq/OF0qtkptDXOsRkVFK+y67cabGTJkmN5vSyC4IJyqg/1UiXeBRmBgEPff/zB/\n/cvr7D5Ww+5jKhYTZMRIZMZpP0F+p1/DOFwqxTUqR49rPy2d2msHBASw9LprGT58pL5vUiA4TzzK\nY4qqYJJlFFWh2dFCZni2zpYNTmpqqnnhhWcpLS0BICECJmbLDEmU+pV1762Q4fEvK1aswNWPklpE\nkMQ3pxk4XKmyuVBh797d7N27m8SEJO5/4CHi4xMH/P0JBBeKurpaAMItWs7ixFFPvR9zoREJdp2R\nZQNXX72UOXMu54sv1vHFF2s5UF7JgXKV0AAYlymzMFfhjT+t4K233sLRUcuIBCevr1W9Sa/Q0FBm\nzpnOrFlzBvlcOIFA4Gtycqz84he/YdeunXz++Rp279rBp3sU1u7TEmEzhvT4F2dHLdOHuPjgK5UD\n5SpuRUtA5uXlMWPGHHJz80Tnl+CSQiRazg9/f3+++927uPLKJaxdu5oNGz5ne1Ez24u0Yp4RiQp/\n6+VfFuS62HIYvjqq0Kw1dxAfn8C0aTOZNm3moOo8FlxchIdHcM8938dsNuPnN3jmg54oRy462L8e\nkydfxtix49m8eSPr1q2hsNBGcY3KShPkpUlcPrLvGmZ8hot/rFcpqtYSjRaLhcsum8TMmXPIzrbq\n/G4EgoGgJ6kuEuxfj8jIKB555EcUFR1l7dpVbNmykQ2HuthwyE16jMS4dHcf/zJ3pIs1e1R2HVO9\nsqvZ2VZmzJjNxImTB7W6gUDwdQkKCur3+GAqYhys5ObmM2rUaA4ePMBXX21h9+7tHKyo42CFigQk\nR8HIFJmFeX3jvPkpTv61CY5Wq16p+MDAQCZOzGXs2PHk5o7BYhF+RnDx0zvBDtBsb0ZRlT4jvwQ9\nrFr1iTe5XpArk5cunTSarzf9KWS89dZbGA39S2NLkoQ1USI7XmJ3icrHOxQqKsv55JMP+c53br/w\nb0ggGCCamhoACDWH9Ftk4nA4aGpqHJBriwT7ICEkJJSFC69iwYIrOXq0kM8/X8umTetZvddOSIBE\nfroL1EoOtat8tl9LCowdO5bp02cxcmSukLkVCASnRJYN5OePJT9/LM3NzWzc+AWffbaavaWV7CtT\nGZ3qJDyokkYT/GuziqpqSa+ZM+cwefI0QkNF0ksgEJya2Nh4rr/+W1x33Q3s3bubzz9fw44d2/is\nSSEuzEF2aCWESby9RaWlQ8VsNjNjxmVMnz6LzMzsfiuvBYKvy4QJk/Q24SQcDpFgP1/MZou3COf4\n8Sq+/PIzPl+3ls2FzewoVhmT4cTPXEmZGz7criUYs7OtzJw5h3HjJoh5sYJLlrKyUm/m9KhcAAAg\nAElEQVQ3BkB9fb2O1ly8ZGRkkpFxJ9/61nfYtm0L69at4dChAxTXQEask5SwSuyB8M+NKg4XhIaE\ncvkVs7jsspnExYnmBsGlSVhY/4muuLg4H1tycSLLBoYPH8nw4SNR1VuprCxn166d7NjxFYWFNkrr\nFIL8ICvOCVRQ4YaVu7XnJiQkMmbMeHJz88nMzBaxXsElR0RElPavJYIRkcOot2tJscjIKD3NGrRM\nnnwZW7ZsoKmpiZW7FNbuhfhwSAiXiI+QSAiXCA3AG1M5nUKGB1VVaemAykaVqkaVykbtttOlnQ8O\nDmbq1Ol6vF2B4Jxpa2sDINAY0G+RSU1VDW1tAzNmRSTYBxmSJJGVlUNWVg7f+MY3+fDD9/j443+z\nbr/ifcykSVNYuvQGoqNjdLRUIBBcjISGhnLFFYsoKFjAzp3beeONP7HrWM8MkujoGG688Rby8saI\n7l6BQPC1MBgM5Obmk5ubT21tDf/859/ZtGkDx5tUQEWWZRYuvJIFC64iKChYb3MFggHnxA72E+8L\nvh5xcfEsXXoDixcv5fPP12o+5nCH93xWVg433ngLWVlCYlJw6fO73/26T9f62rWruPrqpTpadHFj\nsViYMmUaU6ZMo7j4KG+88WdstoMUVWvn/f39uemGG5gxYzYmk0lfYwWCASYwMBAAGRkFBYvBgt1t\nJyCg/852wamRJInExGQSE5NZsOBK6upqWbNmFStXfsSuYz3rwkmTpjJ//iJSU9NF8bHgkiYqKhqA\nUEsI38i+lo3HtwAQHR2rp1mDloyMTJ577iX27NnF3r27sNkOUlZRTmmdFmMBCLBAUoREarQ2imLx\nmL4qPFeNcdPQBkePq5TUqpTXq7Tbe64hSRIJCUlYrUMZMWI0o0fnCmUewUWH3d4FgNlgpra2b5FJ\nbW0tFoMZu91+hlc5N0SCfRATGBjEsmXfZOrU6VRUlANaJWlOjpA4FAgE54csy4wZM45hw0Zw4MA+\n3G6Xt9L6VDPXBAKB4GyJjo7hrrseYM6cK7xSTYmJSSQmJutsmUDgO1wuV5/7TqfrFI8UfB1MJhNz\n5hQwdux4CgttAFgsfgwfPlJ0egn+K2hqauT48ao+x5qbm2hqaiQsLFwnqy4d0tMz+cEPnmL//n10\ndWnBuuzsHPG7FfzXEBioJdIDTQEYZRMx/tHYmg4TECBmsJ8vUVHRLFt2I/PnX+ndIwUEBIruXcF/\nDX5+foSFhVPdoTX61HT/GxMjEuynwmQyMeb/s3fn8VXVd/7HXzcbayCAgYSAyPrFBRcQxQ0QVGo3\n29rRtmprtdPO1FqdaWepM07Vtk43ndqOHWc6bf1VrVatA7ZVcVdEVJaiQPGLbC6sQfYlhCy/P7IY\nAgkJuTf3Jryej0cfvffce+753Fvy7jnnc77fM24848aNB2DPnj2sXr2SlStXsHLlcpYvX8ayde+z\nbF01T70BA3rDgN5VVFWvISs/wR/mVbN+6wef16dPX447cSTDho1k6NBhDBs2nG7dzHd1dB9cnFZe\nXs6dd9ZcZFJ3D/bcnNyUXcBmg70DqLvaUZKSrVu3bvU7aZKUbF4UqCNZ4wZ74+dqm4KCPowfPyHd\nZUjtrqnbTXgbiuTJyspmzJiT0l2GlBZ1I9irqSYrkcXuit1069bNi9iSKD8/n/x8Z/TSkam4eCBv\nLv0L5ZXlrNu9oX6ZWqZbt24ce+zxHHvs8fXLNm0qZcmSRcyf/xqvv/5nNmyrmwm5mkQiwYknnsyp\np57G8cePobCwvzNlqNOpGyxYUVVzzqW8vJw1a9bUv15WWcaArl1Tsm0b7JIkSZKUZHUN9QQ1E/hV\nVtpglyRJma1uBHtV7W0odu3bRY98p4eXlBzFxQNZunQJ63avZ+2udeTldXEWhzY66qhCJk2awqRJ\nU9i1aye7d39wG62uXbt5QY86vT59+gKwr2ofRd0HsL724h2A/t0K2binlL59+6Vk295gV5IkSZKS\n7IMR64lGzyVJkjJTz541jZjq6poRkDv37bQ5IylpBg2qmaX33Z1rWLd7PSUlJWRl2aJKlh49elJY\n2L/+P+a3jgQlJYMAeHfne3xtzFfIStRkSlH3AVx49AUADBxYkpJtN5teIYQDXg8h5KakEkmSJEnq\nJOpGrNdNwGeDXZIkZbpevXoB0LdrX8YWnkR51b76prsktVXdbXAXlr5BRVWFt8WV1GbDh48EYNnW\n5QzqWcIFg6cyddBkvn/GLWzZu7X2PaNSsu0mp4gPIRwDPBFCOD3GuK122WnA/4YQpsYYS1uygRDC\n7cAEoAq4PsY4r8Fr1wCXARXAvBjj3x9qHUlHjtzcg1/P09RySWoNM0ZSKtU31BMJqK52inhJkpTx\n8vNrGuxHdevHBYOn8tS7z9KrV+80VyWps6gbaTqvdMF+zyXpcB11VCEDBhSzdNOb7Kvax2dGfrr+\ntUWbl5Cdlc3o0cemZNvNjWD/D+DmuuY6QIzxNeB7wG0t+fAQwkRgRIzxTOBLwE8bvJYPfBM4K8Y4\nETg+hHBac+tIOrIUFPQ54D48PXr0pKCgT5oqktSZFBT0OaCZXlw80IyRlBSVlZUAJGrHsNc9lyRJ\nylTdu3cnJyeH7eU72Fa+HYDevW2wS0qOXr160717j/rnRUUD01iNpM5i7NhxlFXuZcnmN+uXvV+2\nmVXbVzP62OP2y51kaq7BXhRjvL/xwhjj74BjWvj5U4Hpteu9CRSEEHrWvlYO7AV6hRBygG7A5kOs\nI+kIc9llV+73/LTTJqSnEEmdUnHxB/fgycrK4tprv5HGaiR1JjbYJUlSR5NIJCgo6MO2vdvYtrdm\nzJUXIEtKlkQiwYABRfXPi4qK01iNpM7i1FNrekZzN86vXzZv44La105P2Xaba7A3OX080L2Fn18E\nNJxKflPtMmKMe4FbgJXAKuDVGOPy5taRdOQZNKhmqqC6k9N9+vRNZzmSOpnu3Wt2aRIk6N2rN4MH\nH53miiR1FlVVVfs9t8EuSZI6goKCPmwr38bmvVtqn3seRlLyFBb2r3981FGFaaxEUmcxYsRI+vbt\nx4LSP7Ovah8Ar26YRyKRYPz41A3YbK6JvjWEcFrttPD1QgiTqGl6H45Eg8/JB24ARgA7gWdCCCc2\nt05T+vTpTk5O9mGWJCmTVVTsPxVZr17dKSzMb7ftmy9S59atW5f6x7l5ue2aL2DGSJ1Zt277H2r1\n6JHnPoykNqus3HXQ5X379mi3jDFfpM6tqKg/y5cv450d7wIwdGiJ+zCSkqak5IOxlIMHt2+D3XyR\nOq/JkyfxyCOPsGTzmwzuWcLK7as4+eSTGTFiUMq22VyD/V+A34cQ7gHmAtnA2cCngUkt/Py17D/6\nfCCwrvbxscCKGOMWgBDCS8BYYE0z6xzUli27W1iOpI5m69Y9+z0vK6ugtHRHmz6zNQeG5ovUue0/\noDTR5nwBM0ZSjXfeWQtARXUFACtXvus+jKQ227z54A32zZt3kZ3dPhljvkidW48evQBYuX01AFlZ\n3dyHkZQ0eXkfTI7sORhJyXL88afwyCOPsLD0dd4vex+AE08cl9J9mCaniK8duT4eqASuAC6l5h7p\nJ8UYV7Rw209S05AnhDAWWBNjrDsaXA0cG0KoGzp2KvAW8FQz60g6wuTk1FwHVE01ANnZzV0XJEmt\nk51dsytUTTXZ2V7FLCl5Xnjh2f2eP/vszDRVIkmS1HJ1t+Zbs6vmYkHvwS4pmYqKBgIwZsxJaa5E\nUmcyYsRIevTowaLNf2Hx+38B4OSTx6Z0m812qmKM60MI36dmtHkV8JcYY1lLPzzGOCeEMD+EMJua\nRv01IYQvAFtjjDNCCD8Cng8h7ANejjHOBmi8zuF9NUmdQVbW/tcB1TXDJCkZGl60k5Vlg11Scmzd\nuoUdO7bvt2zbtm1s3brFk9SSJCmjNbznes+e+eTl5aWxGkmdzbhx4/nhD39Cv37ef11S8mRlZTN6\n9HHMnz+X98vep7CwP4WF/VO6zSYb7CGELOBmahrca6i5F3phCOH2GOMPWrqBGOMNjRYtavDaL4Bf\ntGAdSUeoxiNKbYBJSqaGF+14AY+kZNm3b1+rlkuSJGWKPn0+uBiwoKAgjZVI6owSiQTFxSXpLkNS\nJzRixCjmz59b+3hkyrfX3JnkfwMCMDLGOCbGeAI1I9nHhBD+OeWVSRIHNtSdwllSMjXMGPNFkiRJ\n0pGud++Cgz6WJEnKZIMHDzno41RprsF+EXBFjPH9ugUxxs3AVcBfpbowSYIDR5Q2njJektqiYaY4\nQ4YkSZKkI13v3r0bPLbBLkmSOoYBA4oO+jhVmutU7Y4x7m28MMZYDrT4PuyS1BYH3oPdBpik5GmY\nMU4RL0mSJOlI1717j/rH+fn5aaxEkiSp5QoL+3PCCSdx9NHHMGrU6JRvr8l7sAM9Qgi5Mcb9bhQY\nQugC9GhiHUlKqsYjSh3BLimZGl60k0iYL5IkSZKObA3Pu/TsaYNdkiR1DNnZ2fzTP/1ru22vuTPJ\nM4C7Qwj18wKFEPoB9wG/TnVhkgQHNtRtsEtKpv1HsDtDhiRJ6hjy8vIoKSkhLy8v3aVI6sS6deue\n7hIkSZIyUnOdqluAd4BVIYTXQwiLgAgsijHe0S7VSVIj3iNZUjI1bKrbYJeUbDbAJKVCXl4e11xz\nDb/85S+55pprzBhJKdOtW7d0lyBJkpSRmmywxxgrY4zfAoYAfw18BiiJMd7cXsVJUmPeI1lSMjW8\naMcZMiQlkw0wSalSWFjItGnTAJg2bRqFhYVprkhSZzN48BAAevcuSHMlkiRJmanZM8khhGnAl4Gc\nGOOSGOPeEEIihPAP7VOeJEF2dk79Y0ewS0qmhhftOIJdUjLZAJOUKqWlpcycOROAmTNnUlpamuaK\nJHU23/jGP3P99f/ICSecmO5SJEmSMlJOUy+EEG4CzgNeA34VQrgZWEjN/dffbZfqJAno2qULu3ZX\nADbAJCXX/iPYzRdJyVPXAJs2bZoNMElJVV5ezp133smDDz5IaWkp5eXl6S5JUifTr99R9Ot3VLrL\nkCRJylhNNtiBacDZMcbKEMKt1DTX9wDfjDHOaJfqJAnI8h7JklLEe7BLShUbYJJSqby8nDVr1qS7\nDEmSJEk6IjU3RXxZjLESIMa4CVgDjLW5Lqm95dgAk5QiNtglpVJdA8zmuiRJkiRJUufRXIO9utHz\nXTHGHaksRpIOZv8R7M1NvCFJrdMwU2ywS5IkSZIkSZIOpblOVd8QwpQGz/s0fB5jfDZ1ZUnSBxo2\nvXJybIBJSh5HsEuSJEmSJEmSWqO5BvtW4MYmnlcDNtgltYucHEeYSkqNhhftOEOGJEmSJEmSJOlQ\nmjyTHGOc3I51SFKT9p/C2QaYpORpmCkNL+aRJEmSJEmSJOlgmjyTHEL4t0aLqoFtwPQY4zst3UAI\n4XZgAlAFXB9jnFe7fCBwX+3nJoBhwD8B64CHgMW1y9+IMV7X0u1J6nwaNr1sgElKJmfIkCRJkiRJ\nkiS1RnOdqtyDLDsBuC6EcGWMcdahPjyEMBEYEWM8M4QwGvgVcCZAjHEtcG7t+7KB54BHgfHA8zHG\nS1r1TSR1WjbYJaWK+SJJkiRJkiRJao3mpoi/8WDLQwhDqGmUT23B508Fptd+3pshhIIQQs8Y485G\n77sS+H2McXcIAWpGrreriop9PPXUE7z//vt0796DadMupEePnu1dhqSD2H+EacdsgC1duoT58+eS\nSMD48RMYNWp0ukuSROeYIn7Hjh089dTj7N69m8LCQs4770OOxpeUFNXV1bzyymxWrFhOTk4OkydP\npaioON1lSeok1q9fxwsvPENFRQXDh49kwoSz0l2SpE6isrKSF154li1bNtO1azcmT55Kjx490l2W\npE5g48YN3Hvvr4lvLgVg1KjRXH7FFxkwoCjNlUlqb60+kxxjfLu2Cd4SRcC8Bs831S5b3uh9XwLO\nb/D8uBDCdKAvcEuM8enW1tlS1dXVxLiU++//DStXrqhfPvul5/nMZ69g3LjTyMrKStXmJbVARx5h\num3bVv74x+nMnPkY1dXVADz55ONceOHH+PCHP0avXr3TXKF0ZOvI+VJVVcncua/ywP33sOn9TfXL\nX3nlZT772Su8kEdSm6xbt4aHHnqAuXNfqV/27LNPcvHFlzJ58nl06dIljdVJ6sj27t3L888/w+9/\n/wB79uypXz5v3mt8+tOf8UIeSYeturqaZcve5He/u4+33or1y595ZiaXXno548efRlaWFyNLap2y\nsj288cZC5sx5iQUL5lFVVUWfrt1JAAtfX8AbixZyyinjOOOMczjxxJPp1q1bukuW1A5afSY5hJAL\nHG5CHDAyPYQwAVjaYFT7W8BNMcaHQgjDgOdCCMNjjBVNfWifPt3JyWndztH777/PrFmzePLJJ1m5\nciUAE0qGcM7gYbyxcR1PrYr89Ke3UTRgAOdfcAGTJ0+mpKSkVduQlBzdu3etf1xUVEDXrl2beXdy\nHU6+7Nu3jwULFvDss88ye/ZsKioqKOzek0+MGkNudhYPLl3In/40gyeffIyzzz6bqVOncvLJJ3e4\n5p7UGfTrl1//uHfvHhQW5jfz7uQ7nIx59913ef7553nqySfZWFpKdiKLD484luOOKuKFd1Ywd/ky\nvvOdGxkxYgTnn38+EydOpE+fPin6BpIOprJy10GX9+3bfjlzOPmye/du5syZw9NPP82f//xnAEb2\nLeTDw49l055dPBLf4N5772b69IeZMmUKU6ZMIYRAItHuE5BJR6yOmi81Ta9lPPPMMzz77LPs3LmT\nbrm5XHbCOPp17cGfVvyFV199mddem8PYsWM577zzmDBhgieopSPQ4WTMxo0bmTVrFk8//TSrVq0C\n4NTiwZxZMpQ3N2/g6VXL+M//vJ3CwkKmTp3KxIkTGTp0qPsw0hGmpflSXV3NqlWrmD9/PvPnz2fx\n4sVUVNS0p4b07sNHRhzPhJIh7N5XzqLSdfzxrZqZS+fPn0tOTg4nnHAC48aNY9y4cWaN1Ik12c0J\nIUw5yOK+1E7n3sLPX0vNiPU6A4F1jd7zUaB+hHrtvdkfqn28MoSwHigB3m5qI1u27G5RMWVlZbz2\n2hxmz36RpUuXUF1dTVYiwanFgzm1eDDT4yJeWfM2RT3yuX78RBZsWMPL763mnnvu4Z577mHoMcM4\n48xzOPvsieTn92rRNiW1XWXlB4+3bi0jO3tfmz6vNSeeWpov1dXVLF++jFmznmfua6+wc1fNNUMD\ne/ZiXPFgXlv7Dr9YOIeiHvlce+o5vLV5E0+vijz33HM899xz5PfM57TTz+CccyYzbNgId7ykdrJr\n1wd5sndvFaWlO9r8manImG3btjF79ou8/PIs3n675oRRl+wcphwzklMGDOK+xfN4bPlSinrk8+VT\nzmDeundZuGIF/7V8OXfddRfHHXcCZ589ifHjJzjqVGoHmzcfvAG2efMusrMPP2dSkS+VlZW8/vqf\neemlF1i4cD779tXk4qi+hYwvPppnVi/jjrkvUtQjn78/bTKLStfx/NvLefTRR3n00UcpLOzPGWec\nxcSJ5zJggKNOpVTbsaO8yeVtyRdoeca0NF8ANmxYz4svPscrc2azsXQDAL26dOXjo05gTGExv1z4\nCut37aCoRz6fPX4sc9e+U38yOy8vj1NOOZVzzpnMmDEnOupU6sBSc4y0lZdffolXX32ZFSveAiC7\n9jzv2KJBPLpsMT9dV7MPc/1pk1hYe573gQce4IEHHqCoqJjTTjuDs8+eSHGxg6qkjiqZ+bJy5XJe\neukF5s9/jc2bN9cvH9K7D6cMGMSpA4/m6F4FvLdjG3/7+EPs2ldOUY98vn7aJKqrq5m79h3+vOE9\nFi5cyMKFC/nlL39Jnz59GTduPGefPYnhw0ce9veUlB7NZUyibsrixkIIzx1k8XbgYeCFGOM7h9pw\nCOEMakajTwshjAV+EmOc2Og9M4G/jzEuqX3+OaA4xnhbCKEImAOMbG4Ee2npjoN/iVpVVVU88cSf\nmDHjYXbvrgnRkX0LmVAyhNNLjqF3l678w9Mz2LxvL4WFhZSWltIvrys/nPpx9uzbx/x17zJnzWoW\nl66jqrqa3Jxczjt/Gp/+9GfJy8s71M8gqY1+/vOfMGfObADuueehNn9eYWF+i7vXh8oXgFWrVnD3\n3f/LypU1d7/o3aUbp5cczRklQxnepx//+MyjB82X6upqlm/ZxJz3VvPq2rfZvrcMgJEjA1/4wpcY\nMuSYw/yGklpq6dIl3HrrTQBcddVXOPfc89r8mcnMmL179/Lgg/fx7LNPUVFRQXYiwZj+A5lQcgzj\nigfRNSe3yX2YrWV7eHXN28xZs5oVW2qmkO/Zoyef+ORfccEFF3ohj5RCW7du4dprv3zA8p/97H8o\nKDj8GSWSvQ8zb95r/Pa3/4/S0o0AFPfsxYSSYzhj0DEU9+zVZL5UVFWxeONa5qxZzYL171FWO5pj\n/PjT+fznr27Td5R0aP/wD19n/foPxi706tWLO+/8ZZs/t6UZ05J82bZtK7/5za+YO/cVqqur6ZKd\nw9jiQZxZcgwn9B9ITlZWkxmzdsc25ry3mjlrVrNhV81FA0UDirn8ii9y0kmntPFbSkqHZO7D7Ny5\ngwceuJeXZr1AZVUliUSC4/oN4LSSoxlffDT5zZzn3VtRwcINa3h17du8vmEN5bUjOk488WQuv/yL\nFBcPbOM3ldTekpEve/bs5uc/v4OFCxcA0DOvC2P6F3Ni/4GcUFhMQdf9Z9RpKmPqbCvbw+LSdbyx\ncS1vbFzHzvK9AJx00ilcc831dOvWvfVfVFJaNJcxTY5gjzGe2/B5CKEbcDHwReAH1IxGb1aMcU4I\nYX4IYTZQCVwTQvgCsDXGOKP2bUXAxgarPQr8NoRwEZAL/E1zzfWWeOqpx7n//t/QM68LnwhjmHj0\ncAq796x/fWvZHjbv28s111zDtGnTmDlzJnfeeSdby/ZQ0LUbZx89jLOPHsb2vWW8/N4qZq58k8cf\n/yNlZWVcddVX2lKapBbIzs7cqdO3bdvGrbfeRFlZGacWD2bKMaM4vnAAWYks4ND5MrJvISP7FnLZ\nCeNYUrqep1dH/vxW5NZbv83tt99Jjx49D1GBpLbIzc096ONMcffdv+Cll16gf498ph0bOGPQUPLz\nPhiBfqiMmTZ8NNOGj2bDrh28+M4Knlm1jHvv/TU5OTlMnXpBGr+Z1LkVFPShoKCArVu31i/r06dv\nRjWeY1zKHXf8iJysLKYcM5Jzh4xgSO++9RffHCpfTi4axMlFg9hbUcG8de/y5Mo3mTv3VTZsWM/3\nvvfjNH87qXP7+te/yQ03fKP++cSJ5zbz7vS4/fbvs3LlCoYW9GXasNGMKz6arg1uidVcxgzM783F\nx57Ep0afyMqt7/Ps6reY/d4qbrvt37nllu9zzDHD0vjNJKXbT37yI2JcysCevTlv6ChOLxlCry4f\n3ErwUPswp5cM4fSSIZRVVPDn9e/y7Oq3eOONhXz3uzdy223/Sdeu3ppCOtI89dQTLFy4gFF9C/n4\nqBM4obCY7Kysg773UBkD0LtrN84aPIyzBg+jsqqKJaXrmbFsEa+//mdmznycT3zi4vb8epJS5JBd\nq9p7pH8RuBTIAr5My6eIJ8Z4Q6NFixq9flKj5zuBj5NEdVd2Tz1mJJ8KJx4wYmtfVSWFhYVMmzYN\ngGnTpvHggw+yr6pyv/f16tKVDw0/lt5duvLz+bP3u2JcUupkYtOrzvbtWykrK2Ngz15cddLp5HfZ\n//7wLc2X7KwsThwwkCG9+3DLjpls3LWT7du322CXUiynwYneTLyYp25f4zPHncL4gUcf8HpLM2ZA\nj3w+PfokKqqqeGz5X9iwwX0YKdU+9KGP8sAD99Y///jHP5nGag60cWPNVM0nFBZz+Qmnkpu9/9TL\nLc2XLjk5nDV4KIN7FXDzrJls2LCeqqoqspo4ISWp7QYPPpq8vDzKy2umiy8o6Jvmig60ft06crOy\nuOqkCRxzkPpakjGJRILhfY5icK8C3t+ziyWl69m4cYMNdukIt3btGrISCa4++XRG9et/wOst3Yfp\nmpPDGYOGMrJvf26Z9QRbtm9n586dNtilI1Dfvv0A2FG+lz5duzfZXIeWZ0yd7Kws+nTrVj+KvV+/\nfkmuXlK6NJkUIYR/DCH8BfgdNSPMTwVWxBgfiDG27QbI7ezCCz9GQUEBM5Yt5q4FsymvPHBAfGlp\nKTNnzgRg5syZlJaWHvCequpqHl66kJ/Pn01eXh4XX3xpymuXtH8DLNMMGnQ0Eyeey9qd27nxhcdY\ntfX9A97TknwBWL65lBtfeIyNu3YyZcr5Tk0mtYOGTfVMzJq/+qvPkpuby8/mvsj0+AYHu7VPSzKm\nrKKC/5w3i8eW/4V+ffsxbdpHUl67dKTr339As8/T7fTTz2D48JEs3LCG781+is17DrwfYUv3Yea8\nt5qbZ82kvLKCz3728zbXpXbxwcCBTLzty2c/93n2VVXxnZdmMvvdVQd9T0syZtPundwyayZLStcz\nevRxjB17akrrlpT5LrvsC1QDt85+msdXLD3sYySAhevf41+f/xNbyvZw4YUf46ijClNZuqQMddZZ\nE/nIRy5i3c7t/NuLj/PQ0oWUVRy8BZablX3QjMnNyj7gvWUV+3h46UJufOFx1u7czoc//DHOPntS\nSr+LpPbT3Jnk7wFLgGtijM8BhBAOeZ+tTNS//wBuvvn7/Oynt/HyirfYuGsnf3/65PqRprlZ2ZSX\nl3PnnXfy4IMPUlpaSnl5+X6hWF5Zyf8seJlX175N/8L+fP26f/D+yFI7ycSmV51EIsHVV/8NhYUD\neOSR3/Hdl57kmlPPYWzRIKBl+QIwd+07/Nf82VRUV3HppZfzkY8kdSIPSU1omC+ZmDXHHXcCN974\nHX56x4/5/ZtvsG7ndv76lDPIqc2QlmTMtrI93PbKc6zatpkQjuVrX/u7jJqmWsxzOvcAACAASURB\nVOqssmr/DhMkqKa6/nmmyMvrwre+9W1+/ev/ZvbsWdz04hP8wxnnMrhXTT60JF+qq6t5dNliHn7z\ndbp27cp1X7ueU089PV1fSTpiZWKDffLkqfTq1Yu77voZdy2YzcbdO/jEqDH1tbYkY1ZvfZ8fv/Ic\n2/aWMXnyVK644ipycjJ3djNJ7eOssyZSUNCH//r5Hfx28Xze3baFL550ev1sPC3dh3lsxVJ+t2QB\nObm5XHXVV5g8eWq6vpKkNEskEnzmM5czevRx/PpX/82jyxbz3Oq3OG9oYMoxIyjo+sE90wu6dqNv\nbpf9MqZfXtf97tO+tWwPz739Fk+tWsaOvWX06dOXq676MiefPC4dX09SijQ3tGAwcD9wVwhheQjh\nX4G89ikr+fr27ccN/3IzZ511Dsu3bOLbLz7B8s2bgJpQLOqRT3l5OWvWrKG8vJzinr3qQ3Hjrh3c\nOvspXl37NiEcy823fN/mutSOMnHa5oaysrL4xCcu5vrr/xGysvnJay8wIy6isqrqkPlSUVXFI2++\nzs/mvkhWbg7f/Oa3+OhHL8rIk2RSZ5TpDXaAoUOHc/Mt32fE8JG8/N5q/n3202zavRM49D7Msvc3\n8u0Xn2DVts1MnHgu//zPN9pcl9pJdnbNoVY11bXPM6vBDtClSxe+8pVrufTSy9lStptbZj3JnPdW\nU11dfch82b2vnLsWzObhN1+nX7+juOmmW22uS2mSqccOY8eO56ab/p2jjirkkTff4L/mz2bXvtpp\n7ZvJmOrqal56dyXfnf0U28v3csUVV3H11X9DXl6HPSUlKcmOP34M3/nuDxk2bDiz3l3Jd196krU7\ntgGHPkbasbeMO+e/xANLFlBQ0Id/+7fvcu6552VslkpqPyefPJYf/PAnfPKTl1CZk83/xTe47sn/\n4/ZXn2PeunepqKoC4OunTaJfXlfWrFlDv7yuXDt+IhVVVcxb9y7/8erzXPfkIzzy5htUZmXxyU/+\nFT/84U9srkudUOJg0+g0FkKYCFwFXAw8D/xXjPGx1JbWcqWlO1o8sr6qqor/+7+HmD79YRKJBOcO\nGcHFo09i294yfjb3Rdbt3E5xz15cO34i/bv35E/L/8Kfli+hvLKSs846h6uu8qBOam+///3vmD79\nYQDuueehNn9eYWF+i4+aWpMvACtWvMUdd/yYLVs2c3SvPlw+Zhw987oekC+DexWweOM67ls8n/d2\nbKVfv6O4/vp/5Jhjhrb+C0k6bFu3buHaa78MwA033MSxxx7f5s9MVcbs3buXX/ziTl59dQ5dcnL4\n2IjjuXDEsWzYtfOAjOmV14WH33ydF95eDokEn/rUpVx00ac8aSS1ozfe+DM/+tGt9c//9V9vIYRj\n2/SZqdyHeeWV2fziFz+nvLycE/sP5LITxlFZXX1AvpTk9+ald1fy4F8Wsm3vHoYPH8l1132TPn0y\n7x7QUmf2pS9dzt69NffyvPLKv2bq1Ava/JktzZjW5svWrVu4444fs3z5Mnp36colx53C2YOHsWbH\ntgMyJgHct3g+i0vX0bVLV77yN9dy6qmnHdb3kZQ5UnmMVDcbT3ZWFucPHcXHR41ha9meA/JlQI98\nnlkVmbFsMbv2lTNyZOBrX/u7+nsvS+qYUpUvZWV7eOmlF3nhhWdYvbrmdje9u3Rj6tCRXDBsND1y\n89hde+Hgkyvf5OlVb7Ft7x4AhgwZyuTJUznrrIl069atyW1IynzNZUyLGux1Qgj5wOeAL8YYJySh\ntqRo7cEdwNKlS7j71//D2nVr6ZaTy8WjT+L8YaMoq6ige24er619m/sWz2fznt307l3AZZd9gQkT\nzvLEtJQGM2b8nocffgDI/AY7wM6dO7j//nt48cXnADi1eDBXjDmVrjm5dM/NY9PuXdyzaC4L1r9H\nIpFg0qQpfOYzV9CjR4/WbkpSG+3YsZ2vfvVqAG688buMGhXa/JmpzJjq6mpmz36R3/72N+zYsZ1+\n3XpwxZhTGVc8mN37yumSncPMlW/yf3ERZRX7KCkZxFVXfYVRo0a3/otIapPFi9/gBz/4Tv3zb3/7\ne4wYMapNn5nqfZj169dx969/wZK/LCIrkeD8oYFPH3sSVdXVdM/NY+WWTdz9+mus2raZvNw8Pn7R\np/jIRy7K2BlApM6sYYP9i1/8MlOmnN/mz0xVgx2goqKCxx57lBnTf0/5vnKO6d2XL550GsP6HMXu\nfeUkgIeWvs7Tq5dRXV3NmDEnceWVf03//gNa/T0kZZ5U78PMm/cq9933/9i0qZTuuXl8IozhgqGB\nvZU153nnrX2H+5bMZ9PuXXTv3p1PfvISzj//Qxk5w5Ck1kl1vgC8887bvPDCM7w06wV279lNfpeu\nfGxkzQCNP7y1hB17y+jerTtnnT2JSZOmOPux1IkkrcGeqQ43GCsqKnj22ad45Pe/Y9fuXZxQWMy1\n48/hgSULeO7t5eTm5HLhhz/KRz/6Sa80ktLoT3+awQMP3At0jAZ7nZUrl3PfvXez7K1Ij9w8rjtt\nIhVV1fznvFns3lfO6NHHcdllVzpqXUqjPXt28+UvfwGAm2/+PsOGDW/zZ7ZHxuzevYtHH/0/nnji\nj1RWVnL+0MDFo0/kjrkvsnTTBnr27MnFF3+Gc889z5NGUposXbqEW2+9qf55MjKmPfKlurqaBQvm\ncf/9v2HDhvUU9cjnm2dM4Y0Na7l38Tyqqqs588xzuOSSz9Gv31GHswlJSdCwwX711X+TlHsHp7LB\nXuf99zfx4IO/5eWXZ5GVSHDFmFM5obCYH73yHBt37aCoqJjLLvsCJ5001gEOUifSHvsw+/bt4+mn\nZzJj+sPs2r2L0K8/Xxl7JtPjIl58ZwXZ2dlccMGFfPzjn6Jnz/zD2YSkDNRe53mhZlT7k08+wfTp\nD7Fv3z4AcnNyuegTF3PBBR+2hyR1QjbYD2Hbtm387//+nIULF9QvGzJkKNdccz3FxQPbXJ+ktnni\niT9x3313Ax2rwQ41J6mfffYp7rnnV1RWVgKQm5PD57/wJSZNmuJJIynNysv3cvXVlwPwve/9mKOP\nHtLmz2zPjFmz5j3uvPM/ePfdd+qXjRs3nquv/lvy8z1pJKXTsmVv8p3v3Fj//Lvf/SFDhrTtorr2\nzJfy8nIefvgBHn/8D/XLevfqzd9+9TqOP35MWz5aUhI0bLB/6Ut/y6RJU9r8me3RYK+zZMki/uvn\nd7Bt+7b6ZR/5yEVcfPGl5ObmtvXjJWWY9tyH2bFjO7/61f8wb96r9cuOOWYoX/3qdRQXl7TloyVl\noPbMlzpr1rzHokWvAzBmzImUlAxOxsdKykDNZYxz+QG9e/fm+uv/kQceuIeVK5dTWNifz3/+arp3\nd7pmKRNkZ2elu4TDlkgkmDr1AgoLC/njH2cAcNFFF3tiWsoQWVkfjO7uiFlTUjKIG264id/85le8\n/34pI0eO5pJLPrvf95KUHo3/Djva32VeXh6f+9zn6d9/AHPmzKJ795589rNXMHCgJ6alzPDBeZ6O\neNHu8ceP4YZ/uZn77/8Nu3fv4qyzJiVlmntJys/vxbXX/j0zZvyelStX0K9fPy655HOe55WUNCUl\ngygpGZTuMiSlmQ32WtnZ2Vx22ZXpLkPSQSQSHa/p1diJJ57CiSeeku4yJDXScPr07OyOuVvUs2c+\nX/3qdekuQ1IjjS/a6ai3azjvvGmcd960dJchqRlZWR3zeGngwBK+8Y1vpbsMSZ1QVlYWn/zkX6W7\nDEmS1Il1zKMwSZKkJGg44qujnpyWlJkaj1jvqA12SZmvI45glyRJkqSOzDPJkiRJQE5OxxzBLikz\n5eTYYJeUOg176jbYJUmSJKl92WCXJEnCEeySkqvxbSe8iEdSMvXvX1T/2H0YSZIkSWpfHoVJkiTh\n6FJJydU4U8wYSckUwrH1jxMJT+1IkiRJUnvyKEySJAlHf0lKrsYj1m2wS0qmhvst7sNIkiRJUvvy\nKEySJAnIyrL5JSl5GjfUnSJeUjJlZX1w33XvwS5JkiRJ7csGuyRJEo7+kpRcB45gt8EuKXkaTgvv\nPowkSZIkta+Un+UJIdwOTACqgOtjjPNqlw8E7gOqgQQwDPinGOMDTa0j6cg0cuQosrKy+OhHP5Hu\nUiR1QiNHBjZu3EBurs0vScnTsMGeSCScIl5SUjUcwW6DXZIkSZLaV0rPJIcQJgIjYoxnhhBGA78C\nzgSIMa4Fzq19XzbwHPBoc+tIOjINGTKUu+66m65du6a7FEmd0L/8y81UVlY6RbykpGrYYM9x9Lqk\nJPMe7JIkSZKUPqk+CpsKTAeIMb4JFIQQeh7kfVcCv48x7m7FOpKOIN26dfPegpJSIjs7m7y8vHSX\nIamTycrKrt93yXGGDElJZoNdkiRJktIn1UdhRUBpg+ebapc19iXgl61cR5IkSZIyVt0odu+/LinZ\nEonsBo+9EFmSJEmS2lN7n+k54KgvhDABWBpj3NnSdRrr06c7OTlO6yop+cwXSalkxkidW25uLvv2\n7SMvL5fCwvx23bb5InVu+fkf3D6rX7/8ds0Y80VSKpkxklLFfJGUTKlusK9l/9HnA4F1jd7zUeDp\nVq6zny1bdrehRElHmtacfDJfJLWWGSOpTnZWzcmbrKxsSkt3tPnzzBdJdfbsqah/vH17WbtmjPki\nqbXch5GUKuaLpFRqLmNSPUX8k8CnAUIIY4E1McZdjd4zHni9letIkiRJUkarmyK+7r8lKVm8B7sk\nSZIkpU9Kj8JijHOA+SGE2cBPgGtCCF8IIVzU4G1FwMbm1klljZIkSZKUCtneg11SijRsqnsPdkmS\nJElqXyk/0xNjvKHRokWNXj+pBetIkiRJUodSN3I9N9cGu6Tkathgz872XqKSJEmS1J6cR0ySJEmS\nUsAp4iWlyv4j2D21I0mSJEntyaMwSZIkSUqBHKeIl5Qi3oNdkiRJktLHozBJkiRJSoG6+yI7gl1S\nstlglyRJkqT08ShMkiRJklKguroa8P7IkpLPBrskSZIkpY9HYZIkSZKUAnUj2Ov+W5KSpWFT3Yt4\nJEmSJKl92WCXJEmSJEnqQBzBLkmSJEnp41GYJEmSJKWQI9glJZsNdkmSJElKH4/CJEmSJCkF6u7B\nXlVVneZKJHU2DaeFt8EuSZIkSe3LozBJkiRJSoEP7sGe5kIkdToNm+qJhKd2JEmSJKk9eRQmSZIk\nSZLUgTRsqjuCXZIkSZLal0dhkiRJkiRJHYj3YJckSZKk9PEoTJIkSZIkqQNp2FTPzvbUjiRJkiS1\nJ4/CJEmSJEmSOhDvwS5JkiRJ6eNRmCRJkiSlUCKRSHcJkjoZp4iXJEmSpPTxKEySJEmSUqi6ujrd\nJUjqZGywS5IkSVL65KR6AyGE24EJQBVwfYxxXoPXBgH3A7nAghjjV0MIk4CHgMVAAngjxnhdquuU\nJEmSJEnqCGywS5IkSVL6pLTBHkKYCIyIMZ4ZQhgN/Ao4s8FbbgN+FGN8NITws9qGO8DzMcZLUlmb\nJEmSJElSR7T/Pdi9DYUkSZIktadUX+Y8FZgOEGN8EygIIfQECCEkgLOBP9S+fm2M8b3a9Tw6lCRJ\nkiRJOgib6pIkSZKUPqlusBcBpQ2eb6pdBlAI7AR+EkKYFUK4tcH7jgshTA8hvBhCOC/FNUqSJEmS\nJHUYTgsvSZIkSenT3kdkiUaPS4D/ACYBp4QQLgSWATfFGD8BXAn8MoSQ8nvFS5IkSZIkdQQ22CVJ\nkiQpfVLduF7LByPWAQYC62ofbwJWxxhXA4QQngGOjzE+DjwEEGNcGUJYT00j/u2mNtKnT3dycrKT\nX72kI575IimVzBipc+vSJQ+Arl3zKCzMb9dtmy9S57ZtW8/6x+aLpM7EjJGUKuaLpGRKdYP9SeAm\n4BchhLHAmhjjLoAYY2UIYWUIYXiMcQUwDvhtCOFzQHGM8bYQQhHQH1jT3Ea2bNmd0i8hqXNpzQko\n80VSa5kxkupceOFFvPP2O5x77jRKS3e0+fPMF0l1tm0rq3+cjHyBlmeM+SKptdyHkZQq5oukVGou\nY1LaYI8xzgkhzA8hzAYqgWtCCF8AtsYYZwB/B9wdQkgAi2KMfwgh9KSm0X4RkAv8TYyxIpV1SpIk\nSVKyjR17Knf9990kEolDv1mSWsFckSRJkqT0Sfm9zWOMNzRatKjBayuAcxq9fyfw8VTXJUmSJEmp\nZhNMUipkZZktkiRJkpQuWekuQJIkSZIkSS2XleXpHEmSJElKF4/IJEmSJEmSOpBEwtM5kiRJkpQu\nHpFJkiRJkiR1IN5+QpIkSZLSxwa7JEmSJElSB2KDXZIkSZLSxwa7JEmSJElSB+I92CVJkiQpfTwi\nkyRJkiRJ6kAcwS5JkiRJ6WODXZIkSZIkqQOxwS5JkiRJ6WODXZIkSZIkqQNxinhJkiRJSh+PyCRJ\nkiRJkiRJkiRJagEb7JIkSZIkSR2IU8RLkiRJUvrYYJckSZIkSepAbLBLkiRJUvrYYJckSZIkSepA\nbLBLkiRJUvrYYJckSZIkSepAbLBLkiRJUvrYYJckSZIkSepAbLBLkiRJUvrYYJckSZIkSepQbLBL\nkiRJUrrYYJckSZIkSepAHMAuSZIkSemTk+oNhBBuByYAVcD1McZ5DV4bBNwP5AILYoxfPdQ6kiRJ\nkiRJRzKniJckSZKk9EnpCPYQwkRgRIzxTOBLwE8bveU24EcxxglAZQhhUAvWkSRJkiRJOmLl5uYC\nUFIyOM2VSJIkSdKRJ9VTxE8FpgPEGN8ECkIIPQFCCAngbOAPta9fG2N8r7l1JEmSJEmSjnQ5Obn8\n8Ic/4Vvf+na6S5EkSZKkI06qG+xFQGmD55tqlwEUAjuBn4QQZoUQvteCdSRJkiRJko54xcUl9O7d\nO91lSJIkSdIRJ+X3YG8k0ehxCfAfwDvAH0MIHz7EOgfVp093cnKyk1OhJDVgvkhKJTNGUqqYL5JS\nxXyRlEpmjKRUMV8kJVOqG+xr2X/0+UBgXe3jTcDqGONqgBDCs8BxwJpm1jmoLVt2J6lcSUeCwsL8\nFr/XfJHUWmaMpFQxXySlUkszxnyR1Fruw0hKFfNFUio1lzGpniL+SeDTACGEscCaGOMugBhjJbAy\nhDC89r3jgAg81dQ6kiRJkiRJkiRJkiSlS0pHsMcY54QQ5ocQZgOVwDUhhC8AW2OMM4C/A+4OISSA\nRTHGPwA0XieVNUqSJEmSJEmSJEmS1BIpvwd7jPGGRosWNXhtBXBOC9aRJEmSJEmSJEmSJCmtUj1F\nvCRJkiRJkiRJkiRJnYINdkmSJEmSJEmSJEmSWsAGuyRJkiRJkiRJkiRJLWCDXZIkSZIkSZIkSZKk\nFrDBLkmSJEmSJEmSJElSC9hglyRJkiRJkiRJkiSpBWywS5IkSZIkSZIkSZLUAjbYJUmSJEmSJEmS\nJElqARvskiRJkiRJkiRJkiS1gA12SZIkSZIkSZIkSZJawAa7JEmSJEmSJEmSJEktYINdkiRJkiRJ\nkiRJkqQWsMEuSZIkSZIkSZIkSVIL2GCXJEmSJEmSJEmSJKkFbLBLkiRJkiRJkiRJktQCNtglSZIk\nSZIkSZIkSWqBnFRvIIRwOzABqAKujzHOa/DaKuCd2teqgcuAUcBDwGIgAbwRY7wu1XVKkiRJkiRJ\nkiRJktSclDbYQwgTgRExxjNDCKOBXwFnNnhLNfChGOOeBuuMAp6PMV6SytokSZIkSZIkSZIkSWqN\nVE8RPxWYDhBjfBMoCCH0bPB6ovY/jR1smSRJkiRJkiRJkiRJaZPqBnsRUNrg+abaZQ3dFUKYFUK4\ntcGy40II00MIL4YQzktxjZIkSZIkSZIkSZIkHVLK78HeSOOR6TcCTwCbgRkhhE8Bc4CbYowPhRCG\nAc+FEIbHGCua+tDCwnxHvEtKCfNFUiqZMZJSxXyRlCrmi6RUMmMkpYr5IimZUt1gX8v+I9YHAuvq\nnsQY7617HEJ4DBgTY3wEeKj29ZUhhPVACfB2imuVJEmSJEmSJEmSJKlJqZ4i/kng0wAhhLHAmhjj\nrtrnvUIIT4QQcmvfOwlYHEL4XAjhG7XvKQL6A2tSXKckSZIkSZIkSZIkSc1KVFdXp3QDtfdWnwRU\nAtcAY4GtMcYZIYRrgSuB3cCfY4xfDyH0BH4LFAC51EwXPzOlRUqSJEmSJEmSJEmSdAgpb7BLkiRJ\nkiRJkiRJktQZpHqKeEmSJEmSJEmSJEmSOgUb7JIkSZIkSZIkSZIktYANdkmSJEmSJEmSJEmSWiAn\n3QW0hxDCCcB04PYY489buM4g4B5qLkJYB1wRY9wXQtgHzAISQDUwNcbYqhvZhxBuByYAVcD1McZ5\nDV47D/geUAE8HmP8blPrNFNjAXA/sCPGeElrakt2jbXLvw78GCiIMe4+nHqSWGOr/y2kuM4uwH8D\nx8cYx7dHPQ223eRv0dTv1571NPXvu9E6Tf627cV8ab2OkC9tqLNdMyZT86V2+xmTMR01X2rryJiM\n6Qj5ksw6a5cfsfsw5svh19NRMiaT8qX2szM+Y8yX5DFjDq8W88V8OVSNtcs9RjJfDqseM8aMOVSN\ntcvdh8nAjDFfksN8ab2OkC9tqNN9mA+2b8YcRKcfwR5C6A78FHi6laveAvwsxjgJWAFcVbt8S4xx\nSozx3Nr/bm0oTgRGxBjPBL5UW1tDdwCfBM4GLgghjG5mnaZqvIua8D4syawxhHAF0B9Yc7j1JLHG\nw/23kMo6fwT8mZr/k203LfgtDvj90lBPU/++69Y51G+bcuZL63WEfGlDne2aMZmaL7W1ZUzGdNR8\nqa0jYzKmI+RLsus8kvdhzJc215PxGZNJ+VJbT8ZnjPnSrnWaMU3XYr6YLx4jta1G86X5eswYM8Z9\nmLbV6XnepusxX8wX92HaVqP7MM3Xk5aM6fQNdqAMuJCaqxYACCEcG0J4JoTwVAjhkRBCr4OsNxn4\nQ+3jPwDn1T5OtLGeqdRcWUGM8U2gIITQs7auocD7Mca1tYH7p9rtHmyd/GZqvBqYnQE19gQeiTH+\naxtqSUaNj9W+/4B/C+2gyTprfavu9XbW5G/RzO/X3vVM5uD/vusc6rdtD+ZL+mpMZb60ts50ZUym\n5gtkVsZ01HyBzMqYjpAvyazzSN+HMV/aVs9kMj9jMilfoGNkjPnSDnXWMmOarmUy5ktrmS/J0xEy\nxnxpWz2TMWNay4xJjo6QL83WWcvzvE3XMxnzpbXMl+TpCBmTqfkCZkyTOn2DPcZYFWPc22jxz4Av\nxxjPB54CvnaQVbvHD6YQ2AgU1z7uGkK4N4QwK4Twd4dRUhFQ2uD5ptplB3uttHa7Aw6yvKipGmOM\nuw6jrmTXuAkoSkItyahxI1DcxL+FVGuuzmT8b3VYDvFbHPT3S0M9PZr4G6zT7G/bHsyXw9IR8qW1\ndaYrYzIyX2q3nTEZ01HzBTIuYzpCviSrTvdhzJe21pPxGZNh+QIdI2PMl+QxYw6/FvOl9cyX5OkI\nGWO+tK0eM6b1zJjk6Aj5crBaMiJjzJfkMF8OS0fIl9bW6T5MI2ZM03La+gEd1GnAL0IICSAPmHuI\n9ze82ugbwL21j18MIbwQY1zQhlqau5KpqdcOtrytV0Q1J1k1ptLh1JgOmVRLS2VCzS2pIRPqBPOl\ntTpCvhxqm5nyby9T6mitdNfdkfIFMidjOkK+HOrzMyVjzJfUyYS6O1LGZEq+NP7slr7mPkzrtpcp\n/+4gs2ppjXTXbb4cHvMleTpCxmRKHa2VCXWbMYfHjEmOjpAvkFm1tFQm1Gy+HB7zJXk6QsZkSh2t\nlQl1t1vGHKkN9l0xxikNF4QQJgD/Ts09DC4HdoYQutReCVECrAWIMf5Pg3WeAcYArQnGtex/ZcRA\nPpjKYC37X1lRQs09J/YeZJ21TdWYBMmqseEUDcm+N0Rra0zWb9NazdWZqTLl99txiH/fmfrbmi/t\nU2Mq86WulkzPmEz9GziUTPj9Omq+QPoypiPkSzLrPNL3YTL5b6A5mfL7ddSMcR+mfWo80vOlrpZM\n/Bs4lEz4Dc0X88VjpOZl6t/AoWTK72fGmDHuwzQvU/8GmpMpv5/5Yr64D9O8TP0bOJRM+f3SkjGd\nfor4JrweQvgQQAjh0hDCuTHGV2KM58YYp8QY1wJPAxfXvv9i4IkQwqgQwn216+UAZwFLWrntJ4FP\n137GWGBN3fQOMca3gfwQwtG1n//R2vc/1WidtbXrHFBjg+0kOPyrMJJRY/06DepJpsOpsaH2upKm\nyTob1ZLOK3v223YLf7/20Ny/b2jZb5sO5kvqa0x1vhxunQ21x990R8iXuhrqZUjGdNR8gfRlTEfI\nl2TV6T6M+dJWHTVj3IdJfY3myyHqbFSLGXMg88V88RjpMGtsVIf5cnBmjBnjPsxh1tmoFs/zHsh8\nMV/chznMGhvV4T7MwaUlYxLV1am4ICRz1P5YtwFDgH3UXCXzL8APgEpgD/C5GOPWRusVAb8BugBv\nA1+MMVaGEP4dmFq77owY4/cPo6ZbgUm1n3ENMBbYGmOcEUI4G/ghNVfqPBxj/I+DrRNjXHSwGmvX\newboTc2VGkuAW2KMz7dzjV+NMS4OIdwAnA+cTs0UKnNijP/cyp8sKTU28W/hU43/t0+2Q9T5IDAY\nOA6YD/xPjPGBVNZTW9PBfotHgVXN/W/czvVcBvw/DvwbvB+4Msa492B/F6mss4V1my+przHl+XI4\ndaYjYzIxX2rrypiM6aj50kztacuYjpAvSarTfZhD12i+NF9PxmdMpuVL7WdnfMaYL8ljxhx2LeaL\n+eIxUttqNF+ar8eMMWPch2lbnZ7nbboe88V8cR+mbTW6D9N8PWnJmE7fYJckSZIkSZIkSZIkKRmO\n1CniJUmSJEmSJEmSJElqFRvskiRJkiRJkiRJkiS1gA12SZIkSZIkSZIkSZJawAa7JEmSJEmSJEmS\nJEktYINdkiRJkiRJkiRJkqQWsMEuSZIkSZIkSZIkSVIL5KS7ACnZQghFFUA/mgAAAeRJREFUwI+A\nE4CdQDVwc4zxmbQWJqlTMGMkpYr5IilVzBdJqWTGSEoV80VSKpkxagtHsKszmg7MjjGeEmM8B/gq\ncE8IYWia65LUOZgxklLFfJGUKuaLpFQyYySlivkiKZXMGB22RHV19f9v5w5xKgmiKAwfgiIhYQP4\nK8CTDJI9jcKxANbCFrAEhapFIAaFIW8U5qlK+t10Uvk+Weqq35x0730DnExVPSR5GmP8OXq/GmP8\n2+ksYBEaA3TRF6CLvgCdNAbooi9AJ41hK1+ws5qbJG/Hj4IInIjGAF30BeiiL0AnjQG66AvQSWPY\nxMDOan6SnO99BLAsjQG66AvQRV+AThoDdNEXoJPGsImBndV8JLk/fqyq26q62OEeYC0aA3TRF6CL\nvgCdNAbooi9AJ41hEwM7SxljvCb5qqq/v29VdZPkJcn1bocBS9AYoIu+AF30BeikMUAXfQE6aQxb\nnR0Oh71vgJOqqsskz0nuknwm+U7yOMZ43/UwYAkaA3TRF6CLvgCdNAbooi9AJ41hCwM7AAAAAAAA\nAEzwi3gAAAAAAAAAmGBgBwAAAAAAAIAJBnYAAAAAAAAAmGBgBwAAAAAAAIAJBnYAAAAAAAAAmGBg\nBwAAAAAAAIAJBnYAAAAAAAAAmPAfmgP2xxQ5OAEAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x7f6f5c634240>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Cross-validated performance distribution\n",
+    "facet_grid = sns.factorplot(x='C', y='score', col='intercept_scaling',\n",
+    "    data=cv_score_df, kind='violin', size=4, aspect=1)\n",
+    "facet_grid.set_ylabels('AUROC');"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAdMAAAFhCAYAAAAr/EDTAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAIABJREFUeJzs3Xd4FNUax/HvplCTkARCV5T20rsVRRBUEARFVBAVBUXa\nVURQVERBVJSuFBWQIs2uSLEgTSlKVaQceq9JSCgJKWTvH7MJCaRsApNkk/dzn30kM3tmzu8u5Ow5\nc+aMw+l0opRSSqms88rpCiillFKeThtTpZRS6ippY6qUUkpdJW1MlVJKqaukjalSSil1lbQxVUop\npa6ST05XID2xZ8L0vh2llEdzJlzM6SpcMwUDSzrsOnadCndl+ff9vwdW2FYvd2nPVCmllLpKubpn\nqpRSKn9wOHK8c3lVtDFVSimV4xwOzx4o9ezaK6WUUrmA9kyVUkrlOC90mFcppZS6Kp5+zVSHeZVS\nSqmrpD1TpZRSOc7LwycgaWOqlFIqx+kwr1JKKZXP2dYzFRGHMcaZ7OcGQG1gqzFmvV3nVUop5Xkc\nHj6b186e6e+JfxCRl4DPgBrAWBEZaON5lVJKeRgvh1eWX7mBnbVI/jWjPdDEGPMq0BRoZ+N5lVJK\nqWxlZ2Oa/AkABxL/YIyJB7xtPK9SSikP43A4svzKDeyczXuniJzE6qEWAlYCn4nIbJINASullFJe\nuaRRzCrbGlNjjG8au4YYY3badV6llFIqu9k2zCsiviLyvIh8LSJ/ul5fAXeIiC3DvN/PX0DXHn3o\n1rMPXXv04damLZL2rVqzljo3N0613K7de7j/oUeY9/W3Sdtmz/uKJ7s9z+iPJyRtW/jzr8ycM8+O\nql9Bs2gWu2mW3JplId16vkC3Xi/SrecL3NbsvqR9q9b+Rd1bm6RabvTHE3ny2Z483rU7S1esBGDW\nvK956rmejBk/Kel9C3/5jS/mfmlviCxw4JXlV25g5zDvF8AeYBSQONxbDngYmAY8da1P+FDbNjzU\ntg0A6zdu4tfflwEQGxvL1BmzCAkpcUWZ6AsXGD5qDLfefFOK7b/+vowvpn5K9z4vcuFCDF5eDn74\naSGTxo261tVOlWbRLHbTLLk1S2seatsagPWbNvNbsiyfz5hNSIkrs6zbsIm9+/bzxZRJREae4dGn\nunL3XU347fdlzJw8ief/1y8py48LFjFxzIhsyZIZueXaZ1bZ2aSXMca8YYxZa4zZa4zZY4xZaYx5\nEahg43kB+GTKNJ7v9jQAk6fNpNOjD+Prc+XIc8ECBZg0bjQhJYqn2O7rY33PCA4K4ty5c8ya9xUd\nH2mPj0/2LxqlWS7RLPbQLJfkpiyfTp1O965PAzB5+hd0fKQ9vr5X1qNRg3qMfO8dAPz9/bhw4QJO\npxPfAlbu4OBAzp0/x6wvv6Zjh4dyJEteZ2djmiAi7UUk6W+xiBQUkceBGBvPy9Zt2ylTuhTFg4PZ\nf+AgO3fv5p67m5FygrHFy8uLAgUKXFl5p5P4+HhCQ8PA4WDzv1soXLgwg995j9nzvrKz+ilolpQ0\ny7WnWVLKNVm276BMqVIUDw5i/8GD7Nq9h3vuborzyig4HA4KFSoIwHc/LuDOxrfhcDhwJlhZToWG\n4cDBP//+R+FChXlr2HBmf/lNtmVxh5fDkeVXbmBnY/ok0AYwInJcRI4DW4Em2DDEm9y3P/5Euzb3\nAzBi7EcM6PtCpo/xaPsH6dbrf7S4uylTp8+k53NdmTFrDkPffJ1tO3Zy8tSpa1zr1GmWlDTLtadZ\nUsotWb77cQFt27QCYOTY8fTv2yfDMstW/MEPCxbx2ssvAfBI+3Y827svLZo1ZcqMWfR49hlmzJ7L\nkEED2W4MJ0+F2pohMxxX8b/cwLbG1Bhz2BjT1RhT0RhT2hhTGmvhhh7GmON2nRdg3YaN1KtTm5On\nTrH/wEEGvvk2nbs+x6nQMLr2yPgvJEDLe1sw47NJ3H7rLVyIiaG6CBfjLwJQqlQIR4/ZGiGJZklJ\ns1x7miWlXJNl4ybq1a7FyVOh7D9wiNcGv8MT3XoQGhZGt55XfklYtfYvpsyYxaRxIylatIiV5Z7m\nTP90PLffchMxMTFUl6rEX3RlKVmSY8ezJ0t+kN0D57OAu+08wanQUIoWKYKPjw8lQ0JY+N2lYZmW\n7R7m80/Gp1k2teGTSZOn8vIL1j/CuPh4AE6cOEnJVCY0XGuaxaJZ7KNZLLk7SwkWfDs3aV/LBx9l\n6qSPUrz/3LnzjPl4EpMnjMXfz++K430yZRr9XugFQFycleX4iZOpTmbKKbllWcCsyu7a294fPxUa\nRnBwUIanf2XQW8TGxrJth6Frjz78uGAxc778mm49+3Dm7FkANm7+hwrXX08J1wSFVve24Imu3fHx\n8aFsmTJ2R9EsmsXuKJolN2cJCkw9SbLfoq++OYTY2Fh+XvI7EZFn6P/6W0m31Rw/cdKV5V8qXH8d\nJYpfyvLksz3x8fGmbJnStmdxl6evgORwpvaVzCYicqsxZq277489E5Z9lVNKKRs4Ey7mdBWumYKB\nJW1ruVrU7JDl3/dLtn6T4y2q7cO8IhIA9AFKGmP6ikgzYJMxJsLucyullPIMuWVWblZlxzDvdOA0\nkHhndElgTjacVymllIfQ2bwZ8zfGTAJiAYwxXwKFs+G8SimlVLbIjtm8XiJSCddd0yLSEn0Em1JK\nqWQ8fTZvdjSmfYBPgUYicgz4B3g1G86rlFLKQ9g5K1dERgO3AglAX2PM+mT7egOdgXhgvTGmn4h0\nxVp4yIk1FbyhMSYgvXPY3pgaY7YDLZJvE5Gl2Hy/qVJKKSUiTYDKxpjbRaQa8Dlwu2ufP9AfqGiM\ncYrILyJyszHmc9f7Ess/ktF5bGtMRaRXOrvL2XVepZRSnsfG2bzNgR8AjDE7RCRQRPyMMeew5vLE\nAAEich5rPk/4ZeUHA49ndBI7B6n7AXWAkFReaT04XCmlVD5k42ze0kDyBZVDXdswxsQAQ4G9wD7g\nL2PM7sQ3ikgj4KAx5mRGJ7FzmPdB4CPgRVeFk4hIUxvPq5RSSqUlqfV1DfO+DlQGzgLLRKS2MWaL\n6y3PYt3emSE7F7r/D+upMXGp7H7ZrvMqpZTyPDYuJ3gUV0/UpSxwzPXn6sAeY8xpY0w88AfQMNl7\nmwKr3am/rXORjTFRxpiEVLZvtPO8SimlPIuNzzP9FegAICINgCPGmPOuffuB6iJS0PVzI2CX671l\ngLOuRjZD+rh1pZRSeZYxZo2IbBCRVcBFoLeIdAEijDE/isgIYLmIxAGrjTGrXEXLABleK02UrQvd\nZ5YudK+U8nS60L17Hqr/VJZ/33+/aWaOrymoPVOllFI5ztNXQPLs2iullFK5gPZMlVJK5bjc8pDv\nrNLGVCmlVI7T55kqpZRS+Vyu7plO7zklp6uglMfw8C/2KXj6kF9yhQvm6l+zmdJ5Sj/bjp1bHvKd\nVXnnU1ZKKeWxdJhXKaWUyue0Z6qUUirHefrQvjamSimlcpwO8yqllFL5nPZMlVJK5TidzauUUkpd\nJR3mzQIRaZoT51VKKaXskFPXTAfn0HmVUkrlQg6HI8uv3MC2YV4R+SqNXQ6gpl3nVUop5Xk8fZjX\nzmum/sAfwKrLtjuASjaeVymllMpWdjamnYBPgHHGmPPJd4hIpI3nVUop5WF0Nm8ajDERQMc0dje3\n67xKKaU8jw7zpkFEfIGuQAugjGvzUeBnYIZd51VKKaWym1uNqYiUAiq4fjxgjDnhRrEvgD3AKOAk\n1rXScsDDwDTgqUzXVimlVJ6UW2blZlW6jamIPAq8htWzPOTafL2IHAHeN8Z8nU7xMsaYy4d59wAr\nRWRFViuslFIq78mzw7wiMt21/2ljzD+X7asLDBCR1saYp9M4RIKItAd+MsbEucoVxOqZxlyDul/B\np6AvzXq0pkDRQnj7eLPh+1XERcdyS6emJFxM4GJcPMsmLSDm3IUU5W7p1JRSVcvj5eVg0/y1HNiw\ni1r3NaTirdU4bg7z9zyr7a90e3WKBBRly8/r7ai+ZtEs2Z6l6fOtKVi0EF4+3mxMzPJ4UxLiE4iP\ni2f5J1dmubljU0pXLY/Dy8Hmn6wsNe9rSMVbqnHCHObvL11ZbqtO4WJF+S+bstz1/P1WFm9vNv2w\nmtjomBSfy/JPFl6RJah8CVr0fYj/Fq9j+++bAah5bwMq3lKN4zuPsC4HssRejOMHs4wL8TFcdCbQ\n5PoGhBQJ4sedy0lwJuDt8OYhuZuiBQqnKLfl5C5WH/4Hb4cXd1VoRJXg6/nryBa2hu7h+oDStLjx\n1qT3nY+L5tZydWzPkp+k1zP93hjzY2o7XI3rEyLSLp3yTwJDgZEiUsS17RywBJuGeKs2qUXE0TDW\nff0HhYsVpc0bnQg/dJJlkxZwLvQMDR66nWrN6vLPT38llSlT/ToCyxVn/pBZFCxaiPbvPc2BDbuo\neEs15g+Zzf0DH8Xb1wen04k0qcPiD9O6fVazaBYPy3JnLSKOhbHelaX1664sExdwLuwM9R9MPUtQ\nueLMH2pleehdV5abq/HT0Nm0evVSlqpN6vDziOzJUuXOWkQeDWf9N64sr3Uk/NAplk9amJRFmtbl\n3wWXsngX8OG2J5tz9L8DKY51483CT+/MoeUrjyTLUpufR6Q3EHft/HPCUKJIIHffcDNnY8/zxb8L\nKBdQkoala1AjpCLrjm5lzZF/khpHgOi4C6w8uIHu9R8m5mIcKw6sp0rw9WwL3UvXug8ya8tC4i7G\n43A42HzC0LnW/dmSJTPy8jDvTyIyCGs49yKAiFQDHjbGvAuQVmPr2ncY6Coi/kBp1+ajl98mcy1d\nOBtN8HUhABTyK8yFs1H8/vH8pP1Fg/w5Zg6lKHNs+yFO7j4GQEzUBXwK+AJwMS4egOjIKAoUKUjV\nO2uy9beNOBOcdlU/Bc2iWeyWWpal45NlCfbnuLtZ4l1ZzlhZqtxRk21Lsi9LzNlogstbWQr6FSL6\nbBRLJ1zKUiTIjxPmcIoyF+Pi+XnEN9R94JaU2+MTALiQQ1mK+Bbi5PlwAKLjYijiW4j7K92Jj5c3\nAEV9C3H8fGiKMnsjjlAxsDy+3r74evvSukoTALwdXkllYi7G8s+JndxUpiZejtz3wLC8fGvMm0A9\noCAQ5dp2FKgrIi8YYz5K78Ai0gj4CAgETmFNQCorIkeB3saYLVdb+cvtXbuDqk1q89io5yhQpBA/\nj/gGgPK1b+T2p5pz+kgYu1dtu6Jc4i+1ak3rcnDzHgAcXg4cXg6KBBYFp5NSVcoRuv8kTZ5rRdjB\nk2z9ZcO1rr5m0SzZm+UvK8ujI60sv4y8lOW2p5oT4UaWQ4lZHFdmCTtwkibPurL8an+WKnfW4pER\nz1GgSEF+HWVlKVf7Bm57sgURR0LZvfqyLE5IiL94xbESsxQO9AOnk5JVyhF24AR3PtuS8IMn2frr\nRluz1AypzOYTOxm/bi4X4mPpVKsVvt7Wr2qn08m6Y1tpcn3DFGUiLpwlNiGOeVt/5kJ8LHdVaMiN\ngeVwAgnOBM7GWr/CD589QWm/EszfuZxSRYtzS7natmbJT9L7evIA0NEYk9iQYow5A3QBHnPj2GOB\nrsaYGsaYu4wxTYwxlYG+wISrqXRaKt9eg3OhkXz58mQWvjePxk/fA8DhLfv4asAUIo+FU6/tramW\nrdCwMnJXbVbPWALAtt830+aNTuxbt5N6bW9jw3erqNP6ZlZOXkyJG0pRJNDPjgiaRbNkW5ZKrixf\n9Z/MovdTZvl6wBQijoVT94E0sjSoTNUmtVk908qy/ffNtH7dylK37W1s/H4Vde6/mZVTsjPLGb4e\nMJnFw7/k9i5WliNb9vPNK9bncnkPNC07lm7m/tc6sn+doe4Dt7Lp+1XUbnUzf0z5meLZkGXLyV0E\nFvSjz02deLJOGxbv/hOwGtLvzVJuDCzHjYHlrigXHRfDYzXuo13VpszfuRyARmWqM/Pfn6heoiKr\nDm2iyfUNWXP4H9pWbcrxc6GcjbFtoDDTvBxZf+UG6TWm0caYKyYKGWOigQR3jm2M2ZFK+Y2At/tV\ndF+pquU4/O8+AMIPnaJokB83NKqStH/fOkOpqlf+JSxf+0bqtb2NRR98RdyFWMDqgfz0zhwOb9mH\nTwEfwg6cxMv1qZ0PP4tfiQA7ImgWzZJtWUpXLcfhLZeyFAm8MkvpNLLUbXsbiz9MluWvHSwYNocj\nybI4vLPxc6lyZZYKDZNn2UmpKuXdOtbev3aw8N25HNmyH++kLNavyuzIcujMcSoFXQdAqaLFORsb\nhdPp5MedyyleOPCKXilA0QKFuS6gNA6Hg6DCARTw9iUqLpqaIZV5um47KgWVJy7hImX8SpDgtH59\n+xcsSkTMWVuzZIanL3SfXmPqJyJFL98oIkFY6+5mZK2IzBeRriLygOv1nIj8Athya8yZExGUrFwW\nAL8SAcRdiKXBQ40Jvt66llKyUlkij4WnKONbuAC3dGrKzyO+IS469opjNmzfmPXfWt8MvXys7wB+\nwf5ERZyzI0ISzaJZsiVLJVeW4gHExcRS/8GUWSJSyXJzx6b8MjL1LA0easwGVxZvV5aixf2JOm13\nltOXPpfiAcTFxFH/wduTZSlzxeeSQiq/kOs/1JiN31lLi3v7uK49BgfYniWoUDEOn7Vu5Y+4cJYC\n3r78d2o3Pl5e3FXhyoYUoFJgefZFHMHpdBIVd4G4i/EU8b0023fFwQ00rdAIgIuuxvRMzHn8C1zx\nK15lkcPpTP2iuoj0A1piXd/c5dpWF2uI9lNjzBcZHVxEmmAtHVjKteko8JsxZo07lfus8weZuuLv\nU9CXu7q3onBAURxeDtZ/8wex0bE07tIiaar/sokLiDkXzd29H2D5p4uoemctGrRvTOSxcBwOcDph\n+ScLOR9+llJVy1G2RgU2/bAagBot6lO5cU0ijoSycsrPmalapmkWzZLZLJn9gu5T0Jcmz7WicLGi\neCXLcvtTLazbSWITb/OJplmvB1jx2SKq3GFlOXMs3JoF4YTln6aepXqL+lS5vSanj4byR6azZC6M\nT0FfmjzbisLFiuDwcrDhmz9dWZqTcDGB+NjEW2OiadqzDSsnLyaoXAluebwZfiUCSLiYQNTpsywZ\n9wOxUTGUqlqOMtWvZ/OP1q+q6s3ruT6XMP6YmrkshQtmbqG52ItxzN+5nPNx0SQ4nTSrcBNLD/zN\nxYSLFPAugAMIKRJEq8p38O2OJbSr2gwfL282HtvOxhM7cAB3Xt+AqsHWOjsHI4+xP/JoUo923dGt\nbDm5i5AiQTxQ9a5M1a3zlH62dQNfbNYvyzO8xi0bnePd0zQbUwAR6Q0MBAKwerEngfeMMVPdObhr\n9m/y5QSPAL8aY3a7Uz6zjalS+VkuGe26JnLL0N21kNnGNDezszHte/fLWf59P3bpqBz/C5PmMK+I\nBBljJhhjrgOuw1rRqFLyhtQ15JtW+UHAZ0BRrJWP9gIlgDki8tK1CqCUUkrltPS+Mi0QkbeMMUtc\ns3hTEJF7gLeAO9Io3wq4wxiT4tuGiLyHdc10TBbrrJRSKo/xysP3mXYAJovIKKwnvSTevX0d1rXU\ng673pHfsMljXSZMrCx7+/5pSSqlrytOH9tNsTI0xx4A2IlIPq/Gs7tp1COhijNmcwbHfAH4TkTCs\nRRvAalz9gZ5XVWullFIqF8nwyrir0cyo4Uyt3BKgpojcSMrlBA+kU0wppVQ+lGefGnOtGGP2AfuS\nbxORdumt66uUUip/8fC21P7GVET8uNQzPeZa6D7Q7vMqpZRS2cW2xvSyhe5DubTQ/RGgt13nVUop\n5Xny/DCviLwODMBauAFc654YYzJaXzdxofsU6/OKSAOsVZSaZL66Siml8iJPfwSbOw+1exLrUWwF\nXC9f138zPHZ2L3SvlFJK5QR3hnm3AocTHxCeCWtFZD7wA5dujSmNdW+qLQvdK6WU8kx59j7TZGYA\n/4rIBiA+caMxpmt6hYwx/ZItdJ/4IMGjwNvuLnSvlFIqf8jz10yxlv37Ajic2YMbY1YCKzNbTiml\nVP7i4W2pW43pbmPMENtropRSSnkodxrTv0RkCLCKlMO8S22rlVJKqXwlPwzzNrnsvwBOQBtTpZRS\nCvca05ddt7MopZRStsgP95mOtL0WSiml8jUvhyPLr9zAnZ7pQRFZDqwFYhM3GmMG21WpRNP+1ttR\nlcqPEpwJOV2Fa8aJM6ercM10pp9tx84lbWKWudOYXvHUF6WUUkpd4s7zTIeISHHgRmPMehHxMsbk\nna+NSimlcpynr4CU4TVTEemINcQ73bXpYxFJd/UjpZRSKj9xZwLSy0BdLq2v2x943rYaKaWUynfy\nwwSkSGNMlIgAYIyJFpHYDMoopZRSbrOzTRSR0cCtQALQ1xizPtm+3kBnrEWJ1htj+iXbVwj4Dxhq\njJmZ3jnc6ZmGikgXoLCINBCRD7jUS1VKKaWuml09U9cDVyobY24HngU+SrbPH2u0tbExpglQU0Ru\nTlb8TSDMrfq78Z4ewE2APzAFKAx0c+fgSimlVA5rjvUoUFzP2A4UET/XvlggBggQER+s9i0cQKzh\n2GrAQndO4s4wb0tjTJ/kG0SkB/CJOydQSimlMmLjCkilgfXJfg51bdttjIkRkaHAXiAKmGeM2e16\n3yigN/C0OydJszEVkfpAA6C/iBRJtssXGIw2pkoppTxPUqvtGuZ9HagMnAOWikhtoB6w2hhzwDVf\nKMOWPr2e6QWgFBAI3JlsewIwILO1V0oppdJi432mR7F6oonKAsdcf64O7DHGnAYQkT+ARsC9QEUR\neQAoD1wQkUPpPS0tzcbUGLMd2C4iS40xa68qymVEZLgxZuC1PKZSSinP5WXfbN5fgbeBySLSADhi\njDnv2rcfqC4iBY0xMVgN6UJjzLTEwiLyFrAvo8eOurMCUpYa0suGhi93W1aOqZRSKm+yq2dqjFkj\nIhtEZBVwEejtukMlwhjzo4iMAJaLSBzW0O6qrJzHnQlIWRUBHLlsmxNr7LmUjedVSimlkhhjXr9s\n05Zk+yYDk9MpO8Sdc2TYmIpIfWPMJncOdpn+QEljzKBUjrksC8dTSimVR+X5tXmxpgdnmjHmI8CI\nSNFUdv+WlWMqpZTKm7wcWX/lBrY+z9QY84WI+IlIZdemY8aY88aY97JUW6WUUioXsu15piLSCGvZ\npkCsm2QdQFkROQL0Msb8l9ljZqRQ4YIMHtEf/wA/fH19+HzCHGIuxNKjXxfi4y8SHRXNkP4jOX8u\nKkW5F157jlr1hIQEJ2OGfYrZuptHu7Sjeas7+WfDViaOsCZ23ftAU4KLBzJv+g/XuuqaRbNolqvM\n8vaIAfgX88PX15ep42cTcyGGni8/Q3x8PFFRF3j75Q+vyFKxSgU+/OQt5n7+Hd/OXgDAo0+1o0Xr\nJvyzfisTRnx+KUuJIOZN+z6bsrxCQDE/fHx9XFli6ZWUJZq30sgy4pO3mfP5tymy3NP6Lv5Zv5Xx\nI6YCcN8DzQguEcjcbMiSGZ4+zOvu80yLAoI1gcgYY6IyKAYwFujqWr4piWtq8kSgSRbqm67W7e/h\nwJ5DfDpmJsElgpgw632izkXzVr8POXzwGE89/ygPdrqf2ZO/SSpT76ZalK9Qhu6P9adCxfK88X5f\nuj/Wn7tb3sHzHfszdtowChYsQIIzgdYP30O/bm9e62prFs2iWa5Sm4fvZf/eQ3wyegbBJYKYOOsD\nos5HM7jfcA4fOEaXHo/xUKf7mZUsS8FCBXl5cE/WrUo5JaR5qzvp/tjLfDT9XVcWJ20evpeXul0x\n/cO2LAf2HmLS6OkULxHExFkfEnU+mjf7DefwgaN06fEY7Tu15ovJX6fI0n9wryuytGjVhOce68dH\n099LkaVvtzeyJUtmeHhb6tbzTB8EdmOteDQZ2Ckirdw59uUNKYAxZiPgndmKuiPi9BmKBQUAUCzQ\nn9PhZ4g4fYbA4GIA+BfzI/J0ZIoyjW6ry8olawA4sPcwfgF+FClamLjYOABOh0VQ1L8oj3Z5kG9n\nLeDixex5Lrpm0SyaJRNZwiMpFujKEhRARHgkkacjCQwOtLIE+BF5+kyKMrExsfTt9iahp8JTbI+L\ns7KEh0VS1L8oj3VpxzezfsrGLGeuyBJxOpIg1+cSEOBHxGWfS2xMLC92G0ToqZRrsidmOR0WgZ9/\nUTp2eZBvZs3Ptiz5iTvDvAOAOsaYUwAiUhb4BlicQbm1IjIfa4HhxKfMlAY6ACuyVt30/b5oJa3b\nt+Cr3ybjF+BH/+fe4vy5KCbO/oAzkWc5G3kuaQgqUfGQIHb8tyvp54jwSIJLBOHwcuDt7UWJkGCc\nTie161dn57Y9vP7ei+zasY+vZ863I4Jm0SyaJQuWLFpJ64fv4ZslU/ELKEq/Zwdz/lwUn8wZQWTE\nWc6eOZc0ZJvI6XQmfQlIzsvLy5UlCJxO6jSowc5te3jj/ZfYtX0vX8380eYsK2jz8D18s+Rz/AOK\n8lKyLGdcWca7mcWRlMX6XOo0qIHZtodB77/EzmzIkhm55bmkWeXObN7YxIYUwBhzFGuV/XS5ngk3\nEqgAtHa9ygBvp3LPzzVxb9umHD96kkfveY7/PfkaL7/Vi36De/JKz6F0atmDfzZs4+En2qR7DIfD\nAU4n389dzMdfDGfZL6vo0uNRPh8/m8e7tee918chNStRomSwHRE0i2bRLFlwX9tmHD9ykg4tutH7\niYEMeLsPLw/uxYAeQ+jYsjv/rN9KhycecOtY381ZyIQvPnBleYwpH8+m87MdePe1MUjNytmYpSu9\nnniVV97uTf/BvRjQ420ea/kc/6z/j0cykWXiFx+y9Jc/6dKjI5M/nsUTzz7MsNfGUC0bsmSG4yr+\nlxu40zM9JyIvc+l2lvuAs24e/yRWrzTxPKHY+CzUOg1q8NcfGwDYs3M/ISWDKV02hK2bDQDrVm/i\n3geapihz6kQ4wSWCkn4uUao4oafCObxoJb8vWkn568tQpfqN7Ny2Fx9va3T65PEwSpctSejJlMND\nmkWzaJYcytKwBmuTZSnhyvLf5h3JsjRz61hLFq1kyaKVlK9QhirVKrJz2x68va1+x8njoZQuV8rW\nLHUb1mQgMbpOAAAgAElEQVTtH9ZDTqwsxSlVtmRSlr9Xb+I+t7OsYMmiFZSvUDZZlsTPJZQyNmfJ\nT9zpmXYDqgAzgOnADbjxPFMRGQR8BhQF9mA94qYEMEdEXspaddN3+MAxatarBkDpsiWJirpA6Klw\nKlS6DoDqtatyaP/RFGX+/nMjzVreAUDVGpU4dSKMC9GXOt5d/9eZyeNmA+Dja30nKFW6hO1/ATWL\nZtEsmctSK1mW6KgLhJ4M54YUWS5fkO2S1GaSPvu/J/hs3BcA+Pr6AlCqTAlCT7j1rOgsO3zgKLXq\nVQcSs0QTlixLjdpyxeeSXOpZOjP5iiwhnLI5S2Y4HFl/5Qbu9EwbGmN6ZOHYrYA7jDHO5BtF5D2s\na6ZjsnDMdP0wbxFvvP8SE2YNx8vLiw/e/JjY2FheG/YCcXHxnIk8y7uvWacdMuYVhr06mv8278D8\nt5tP543kYkICo96emHS8Og1rcGj/EcJDTwPw24IVfPblSPbtPsTxoyevdfU1i2bRLFn0/dyFDBre\nj4mzP8Tby4vhb35EbEwsr7/bl7i4OM5EnmXYQCvL0NGv8s7A0VSsUoEXX3uO0mVLEh9/kWb3NebV\nXu9w7ux56jasycF9l7L8umA5k78azb7dB23P8t3chbw5/GUmzf4Qby9v3k+WJT4unsjIswwbOBqA\nd0YPZOjAUa4s3SlTtiTx8fHcfd8dvNJraIosYa4svyxYxpSvxrBv9wHbs2SGp18zdTidznTfICK/\nAa2MMfGZObCI/AU85LrGmnz79VgPYL09o2PcVuX+9CunlMqTEpx5Z7apk7zza+zv3b/Y1uJ9+vjw\nLP8f9fycgTneErvTM40AtonIRlKugPRUBuXeAH4TkTAuXSctA/gDPbNQV6WUUnlUnl+0AVjgemWK\nMWYJUFNEbuTSg1mPGmMOZPZYSiml8jYPb0vdakzLGGOGZ/UExpgrliMUkXbGmNxzg5NSSil1Fdxp\nTGuJSGVjzO6snEBE/LjUMz3mesJ5YFaOpZRSKm/KD8O8dYDtrmufsVgL1juNMdenVyiDhe57X1Wt\nlVJK5Sm55VFqWeVOY+reUhtXSm+h+wnYsNC9UkoplRPcWbThONAG6OmaPFQaOOHOsbN7oXullFKe\nyeFwZPmVG7jTM50IRAKNXT83AF4COmZQLtsXuldKKeWZckmbmGXu9EyruRatjwIwxkwCymZU6LKF\n7tu4XmWxcaF7pZRSKie40zNNXPnICeB6UHhhdw5ujFkJrMxa1ZRSSuUXnr6coDuN6dci8jtQUUQ+\nwlpzd4K91VJKKZWf5JZrn1mVYWNqjBnvWme3KdZzTDsaYzbYXTGllFLKU7jTM8UYsw5YZ3NdlFJK\n5VMe3jF1rzFVSiml7OTpw7zuzOZVSimlVDrcakxFpLWI9HH9uZKIePZXCKWUUrmKw5H1V26Q4TCv\niHwAVMG6X3Q88DhQEvifvVVTSimVX3j6rTHu9EzvMsa0B84AGGPewVoFSSmllFK4NwEp2vXfxEUb\nvN0sd9Wi4qKy4zRK5QkOR96ZApGQcDGnq6CymYd3TN1qFFeLyDSsx6f1A9oDy22tlVJKqXwlz8/m\nNca8ASwEfgfKA6ONMa/aXTGllFLKU7g7XPs7sAHrAd+ISEVjzF7baqWUUipf8fCOqVuzeT8GugCh\nrk0OrOunFW2sl1JKqXzE04d53emZNgVCjDExNtdFKaWU8kjuNKY7gFi7K6KUUir/8vCOadqNqYgM\ndf3xHLBCRP7k0rNNMcYMtrluSiml8glPX7QhvZ5p4o1e+12v5Jx2VEYppZTyRGk2psaYIQAi0tcY\nMzb5PhEZYnfFlFJK5R8e3jFNd5i3GXA38ISIBCfb5Qs8A7xlc92UUkrlE3l5Nu8OoIzrz8nX9ooD\nOtpWI6WUUsrDpDfMewyYIyKrjTH7s69KSiml8hsP75i6tZzg/mt9UhEJvNbHVEop5bkcDkeWX7lB\nTj1m4rscOq9SSil1zaU3Ael1Y8x7IjLIGDMsswcWkV5p7HIA5TJ7PKWUUnlXLulgZll6E5C6iYg/\n0FFECly+041FG/oBS4Bjqezzdb+KSiml8rrcMlybVek1pk8AzV1/zsqTeh8EPgJevHxdXxFpmoXj\nZahw4UIMG/0aAcX88fX15dOPZnDhQgwvDHiO+Ph4os5H80a/9zh39nxSmYa31GXkhLfZvXMfDoeD\nnTv28OGQ8Tz+zMPc27opm9dvYezwzwBo1bY5xUOCmDX1Gzuqr1k0S7ZmKVS4EMNGDXRl8eGzj7/g\nwoUY/jegG/FxF4mKimZQv/cvy1KHEePfYvfO/TgcsGvHXj4cOoHHn27Pva2bsmn9FsZ9MNmV5W6K\nlwhm1ufZ87m8O+Z1Aor54+Prw6fjZhBzIZYXXrn0ubz+0rspsgDc/2ALnu7ekfj4i0wc/Tl/Lv+L\nzs88zL1tmrFp3RbGDv/Uel+7FgSXCGLW1K81i0pVerN51wBrRGSZMWZVZg9sjPlPRNpg3UpzuZcz\nezx3tO3Qkn17DjJ+5FSKhwQzZe4Yos5FMfDFYRw6cISuvR6nw+MPMP3TeSnKrVu7mVf6pFyH4p5W\nd/F0h//xycwRFCxYgASnk3aPtKL309nzKFfNolns1q7Dfezfe5DxIz+neIkgJs8dTdT5aF57cRiH\nDhyla89OdHi8DdM//TJFufV//cMrfYam2Nbi/iY8/cgLTJr5YbIsLen99MBsydL2Eetz+XjEFIqH\nBDN13ljOn4ti4AvvcOjAEbr16swjj7dl2qdzk8oEFPOnxwtdePT+ZyniV4ReLz3Dn8v/4p7WTeny\ncB8++WJkis+lV5dXNIuNPLxj6tZC9+EishRohLWM4FqgtzFmtxtlrweai0ji/apHgV+NMRuzVNsM\nRJyOpEo168lwgYEBnA6LICoqmqDixTh04AgBAf7s33PwinKpDS/ExVnfAcLDIvAL8OOB9vfy5Rc/\ncPFiVjrpmadZNIvdTodHUlluBCAwqBinwyOJPh9NUHAghw4cJaCYP/vczRJrLdsdHnYaP/+iPPDw\nvXw580cuXkywN4RLRHgkVSS1zyXQ+lxSyXLrHY1Y8+d6LlyI4cKFGIa9MdqVJfFzOY1fgB9t29/H\nvJnfZ9/fsTyUJTPy8jBvoo+BUcByrMlD9wCTXP9Nk4gMAu4FFgF7uTTxaI6IzDXGjMl6tVP3y4Jl\ntO3QkvnLZuEf4Mf/ug7k3LkoPp83lsjIs5yJPMu4Dz67olylKhUY89kwihXz55NxM/h79Ua8vLzw\n9vamRMlgnE4ndRvWYsfWXbz9wQB2bt/DnOn2TkjWLJrF7iy/LlxO2w73MX/pTPwC/Hih2+ucO3ue\nqV+OITLiLGcjzyUN2SZXsXIFxnw6lIDAAD4dN4O/V2/Cy8uBt7cXJUKK4wTqNqjJjq27eWt4f3bu\n2MPc6d/bmuWXBcto90grflo+G/8AP/o88yrnzkUx7ctxSZ9L4jBnonLlS1O4cGHGTX4X/wA/Phk3\nnb9Xb8Lh+lxCShZ3fS412b51F29/+Ao7t+1hzvRvNYu6gsPpTH/NehH53RjT/LJtS40xd2dQbhVw\nhzHGedl2H2CFMaZxRpWre0PTTC2of3+7FjS4uQ7D3hhNZbmRIR++ytkz55gw+nO2bNpG34HPc+LY\nSebOuPQPO6Rkceo1qsVvi1ZQ7royTJk7hjZ3daZFqyY89uSD/PzTUipUvI6fvv2ZF1/tTs+nXmHo\nyIF8/OFkTp0My0z1MkWzaJbMZnE4Mnen2/3tmlP/ptq8O2isleWDAZw9e44Jo6axZfN2+g7szvFj\np5iXTpbJc0fzwF2dad6yCY899SC//LSUCjdex/xvf+HFV5+jV5dXGTriFT4eMTVTWRISMtdzuv/B\nFjS4yfpcqkhFhoxwfS6jpvLvpm289FoPjh87ydxkX1Ce6dGJeg1r8eJzb1DuujJMnTeWlo0f4742\nzej41EPW53JjeVeW7vR8agDvjBzIR3b/HcvFWf49sMK27uPPAyZm+QEqLUf0yvFurTv/+gqISIPE\nH0TkJtzr0fpwaTnC5Mpi9VKvuXqNarF65d8A7Db7KFmqOFWrVWTLpm0A/LVqA9VrS4oyp06G8dui\nFQAcOXSMsNBwSpYuwS8LltH1sRdZ88d6ChUqwI6tu/H29gbgxLFTlClfyo4ImkWzZF+WhrVYvXJ9\nUpaQUiWoUq0iWzZvd2XZSI1aVdLPciqckqVD+HXhcro91pc1f6ynYKECmG3JshwPpUw5e7PUb1Sb\n1SvXAbDL7CXE9bn86/pc1v65nhq1qqYoExZ6ms0b/kvKEnU+isCgYvyyYBnPPPoCq1euo2ChguzY\nugsfn8QspyhTvrRmsYGXw5HlV27gTmPaH2toNlxEwoHpwEtulHsD+E1EVorIt67XamAhYMvV70P7\nj1Cnfg0AypQrRdT5aE6dCufGStcDULNONQ7uO5yiTKu2zXnq2UcBKB4STHDxIE4eD03a3+PFLkwc\nMx0AX1/rjp7SZUM4dcK+b6aaRbNkR5aDB45Qp371S1miogk9mTyLcHD/kcuy3M2Tzz5iZSkRRHDx\nQE4eP5W0//kXuzApMUsB6zt36TIhtvbkAA5e9rlEn4/m1MkwbqxcAYBadatxcH/Kz2XNynXcfLvV\nTygWGEDhIoWJOB2ZtL9H36eZOGaalSXxcylTklMnQrFTXsqSGQ5H1l+5QYY9TGPMX0A1ESkGOI0x\nZ9w5sDFmCVBTRG4EEr/+HDXGHMhybTPwzZyfGDLiFabMG4u3lxfvvDGamJhY3ho+gLi4OCIjzvLW\nKx8AMPyjN3mz/3CWL1nN8HGDaHpPY3x8fRj2xuiki/P1G9XmwL5DhJ0KB2Dx/N+Z8e149u46wLEj\nJ+yKoVk0SzZlWcCQDwcwZe5ovLy9GPa6lWXw+y8TFxdPZOQZ3n5lBADvjxvE4AEfsHzJat5PzOLj\nzbBBY5ImGdVrVMvKEnoagJ/nL2XGNx+zZ/d++7PMns+QEa8ydd5YvL29Gfr6KGJjYnlreH/i4+KJ\njDjD4AHW5/LBR4MZ1P99Tp0MY8miFcz+YRJOp5P3Bl960mRqn8vM7yawd5dm8UQiMhq4FUgA+hpj\n1ifb1xvoDMQD640x/VzbawE/AKONMRMzOkeG10ztICLtjDE/ZvS+zF4zVSo/y+w109wss9dMVfaw\n85rpkoGfZPn3fYvhPdKsl4g0AfobY9qKSDXgc2PM7a59/sC/QEVjjFNEfgHeBP4DFgA7gX/daUxt\n/9cnIn4iUtn1KurarAvdK6WUyg7NsXqYGGN2AIEi4ufaFwvEAAGuybGFgXDgAtCK1FfwS1WGw7wi\nUsb1OLZMEZFGWCsgBQKhWJOOyorIEaB3Zo+nlFIq77Lx2mdpYH2yn0Nd23YbY2JEZCjW7ZtRwLxk\nayjEiKScTJged2blzgbSvQ0mDWOBrq5vAklcM4MnAE2ycEyllFJ5kMMr22YSJZ3INcz7OlAZOAss\nE5HaxpgtmT2oO43pThGZCazG6hIDYIz5PINyXpc3pK5yG0XEO3PVVEoplZfZ2DM9yqVJsGDdnpk4\n2lod2GOMOQ0gIn8ADQFbGtOCWAvd35JsmxPIqDFdKyLzscaqE+fOlwY6ACsyWU+llFIqK34F3gYm\nu0ZGjxhjEp8SsB+oLiIFXQ9kaYR1+2ZybjXzbs3mFREvoKQx5rh7dU8q1wTr4m/SrTFYa/Oucae8\nzuZVyn06m1fZzc7ZvMvf/CzLv++bvtM93XqJyHvAXVgdw95AAyDCGPOjiDwHdMV6KMtqY8xAV6M7\nCqjg2n4EaG+MiUjrHO4sJ3g3MBWIMcZUE5ExwBJjzOWt9zWnjalS7tPGVNnNUxvT7ODOv773sG52\nTRxjfhfrPhyllFLqmvD0FZDcaUzPGWOSlskwxoSSbCKSUkopdbUcDkeWX7mBOxOQokXkLsAhIkFA\nR6wbWpVSSqlrIpe0iVnmTmPaC+v5pTcBu4E/gefsrJRSSinlSdxpTCsZY9ok3yAiDwK2LVivlFIq\nn/HwrmmajamI3ABUAkaKSD8u3Wvji7W60Q+2104ppZTyAOn1TMsAjwE3AIOTbU8APrGxTkoppfKZ\n3DKRKKvSbExdCyusEZFFxhjthSqllLKNh7elbt0as1lEvhGRZQAi8qyIVLG5XkoppfIRh5cjy6/c\nwJ3G9DNgZrL37nRtU0oppRTuNaa+xpj5WNdKMcastLdKSiml8htPXwHJnVtjEJFArCfFICI1sZ5G\nbrugwoHZcRql8oQENx5a4SkSnLo2r/Is7jSmQ4C1QBkR+RcoATxha62UUkrlK3l2Nm8iY8xyEakP\n1AJigJ3GGF1OUCml1DXj4W1pxo2piJTFeqB3MVwLN4gIxpihNtdNKaVUPuHpPVN3JiAtBuoDBbBW\nP0p8KaWUUgr3rpmGGWOesb0mSiml8i0P75i61Zh+LyKdgTVAfOJGY8xB22qllFJKeRB3GtM6QGcg\nLNk2J3C9LTVSSimV73j6NVN3GtNbgSBjTIzdlVFKKZVPuTODJxdzpzFdBxTCui1GKaWUuubyQ8+0\nPLBfRLaT8pppE9tqpZRSSnkQdxrTd1PZlnfWLVNKKZXjPLxjmvEotTFmBbAB2Od6HQVG2lwvpZRS\nymO4swLSK8DrQEHgHNYi97NtrpdSSql8xNOvmbozf6oDUBJYa4wJAR4H/rO1VkoppfIVT38EmzuN\n6VljTCzWcoK4nm3aztZaKaWUyl88vDV1ZwLSadcKSP+JyDRgG1D2ak4qIh2NMfOu5hipKVS4IK8N\n74t/QFF8fX2YMfErWne4h2JB/jgcDvyL+bFts2H0kE+SyrRq35x72zbF6XTicDioWrMSrW96nIef\nbEPTlo3ZsnE7n42aCUDz1k0IKlGMb2b8dK2rrlk0S45keeODvvgH+OHj68OMiV/SusM9BAYFgMNB\nQDE/tm42jHp7UlKZ+9s35952zcDpBIcDqVmJVo060eHJNjRrdQdbNmzjE1eWFm2aEFQ8kK9nzM+W\nLIM+6Id/MT98fX2YNmEeDzxyL8WCAnA4HAQU8+e/zTsY+daEFOUGDOnNjVUrEBcbx8i3JnBo/1Ee\neaptUpZJI6cDcE+buwgqHshXM37ULCpV7jSmT2EN834P9MW6VabTVZ63O3DNG9OWD93Nwb2HmTpu\nNsEhQYyZNpQubf6XtH/AsD4s/Oa3FGUWf/c7i7/7HYA6jWrQ9L7GADS973b+1/k1Rkx5mwIFC+BM\nSKBV+7t5tXv2PCxHs2gWu7V6qDkH9h5hythZFA8JYuz0d3iydZ+k/a8O68OCy7Is+u53Frmy1G1U\ng6YtXVlaNqb34wMZNTVZloea80r3IdmS5f6HWnBw72E+G/sFxUOCGDfjPZ64v2fS/oHvvsBPX/+S\nosydzW+lqF8RenV6hbLlS/HiG8/zas+hNGvZmF6dXmH01KFJWe5v34L+z72lWWzk8ModPcyscqcx\nfcEYM9z15/fcPbCIrCP1W2gcQFV3j5MZkafPULFKBQACivkRcfpM0r7yN5TFz68IZuueNMt36fUY\nQ18eBUBsrHVLbURYBH7+Rbi3XTN+mLOYixcT7Kj6FTTLJZrFHpGnz1CxqpXFv5gfEeEpsxT1L4r5\nb3ea5bv06siQl62J/XGxcQCcDovEz78I97VrxvdzFmVblojTZ6goNwAQUMyfiPDIpH3X3VCWon5X\nZil/Q1m2/bsTgKOHT1CqbAgOhyPpczkdbmVp+WBzvpu9ULOodLlzzbSWiFTOwrG3Ys36fSSV17Ys\nHC9DyxavolTZEGb9PJGxM4Yx6cPpSfsefrIN381emGZZqVmJE0dPEen65ejl5cDb24vgkGCcTie1\n6lUjOvoCA4b1of0Tre2ofgqaxaJZ7LN08Z+UKhvCnJ8n8dHMd5n44bSkfY88+QDfzlqQdpZalTlx\n7FIWh5cX3t5eFA8JsrLUr8aF6Au8OqwPDz/ZJhuy/EHpsiHM/eUzPvrifSZ88PmlLE+15dtZVw6b\n7925n1vubIDD4eC6G8tR9rpSFAsKSPpciocE43RCrfrW5zLw3Rfo8OQDmsUmHn7J1K3GtA6wTUSO\ni8hBETkkIu48MeZ5oBIQaow5kOy1Hzh0FXVOU4s2TThx9BRPtOxFv2cG0/fN7gB4+3hTu351/lm3\nNc2yrTvcw88/LE36ef6XPzN6+jus/G0Nnbt3YPrEeTz2zIOMGDSeqjUqUTwkyI4ImkWzZFuWe9rc\nxYmjp3i8ZU/6Pv0mfQc/n5SlVoNq6WZp0+Eefv7+90tZ5v3M2OnDWPHrGp7o3oHpE+bRsetDfDBo\nPFVrVKR4yWB7szzQlONHT9Hpvu70ffoN+r3VIylL7QY12LzuyhsQ/vpjI9v+3cn4WcN55MkH2L/n\nMAA/zF3MuBnvseLXVTz5/CNMGz+XTl3bM/yNj6zPRbPYwuFwZPmVG7gzzJva15cM/5W7FsZ/IY19\nj7px3kyr1aA6f6/aBMDenQeSfhnVu6km27fsSrdsvZtrMW7YZ0k/L1u8imWLV1Hu+tJUkhvYvX0f\n3t7eAJw6EUqpciUJO3XajhiAZkmkWezMUo2//0wtSy23sox959Okn5cu/pOli/+k3PWlqVztBnZt\n34e3t/Vd/dTxMEqXDSHsZLhNSaBOg+r8/cdGAPaY/RQPsRqJ+jfVYrtr+DM1Uz+azVTXbfPzfv2M\niPBIli7+g6WL/6Dc9WWoLDeya/tevH0ufS6ly5bULDbIJW1ilrmzAtIBoChQwfWqCsy9mpOKiC23\n1hw5cIwadQWAUmVDiI66YJ2vVhX2mH1plgsOCSLqfHSq1xG69O7I9PFWXF9f67tHSOkStv8F1Cya\nxfYsB49Rs641fSF5lmq1K7Nnx/40yxVPJ8vTvTvy+cdWFh9XlpJlShBqc5bDB45Rs17yzyUagGq1\nq7J7R+qfSyW5gYHvWt/3b7mzAWZryuuQz/TpxNSPrcYp8XMpWTqE0JNh2CkvZclPMmxMRWQc8C3w\nIzAK+BL4wt0TiIifiFR2vYq6NgdmpbIZ+emrXyhdriRjZwzjjQ9eSprSH1wikNNhkSneO2hEv6S/\nVMVDgjgdHnnF8Wo3qM6h/UcJD40A4PdFfzB+znAuxl/kxNFTdkTQLJol27LM//IXSpcrxbiZwxj0\n4UuMfGuiVdcSQZwOi0jx3jdHpswSEeZGloV/MHHuB8TH2Z/lxy8XU7pcST6e+T6DR/RnxOAJSXU9\nHZ4yy9ujBuDr68Mesx+Hw8FnX43iiece4eP3pya9p07DGimyLFm4gklzRxAfH69Z7OLhF00dTmf6\na9aLyBpjzG0isswY00xEGgIPGWMGZVCuEfARVsMZijWLtyxwBOhtjNmSUeWaVn9QF9RXyk0JGfxb\n9iQJzos5XQWVij/NAttarv8+mZvlv8C1enTK8RbVnWumic8xLSgiDmPMBhFxZ6H7sUBXY8yO5BtF\npAEwAdBHuCmllAI8/z5Td2bzGhHpBawEfhORCbg3TOt1eUMKYIzZCHhnrppKKaXyMg8f5XWrZ9oD\na/ZuBNARKAW870a5tSIyH/gBSByYL421cP6KzFdVKaVUnpVbWsUscqcx9QJuB2pgrWj0L9Z1z3QZ\nY/qJSBOgOXCLa/NR4G1jzJqsVVcppZTKfdxpTKdh3RKzGmsS0SCs3uVzGRU0xqzEGh5WSiml0uTh\nHVO3GtNqxpibE38QEQew1r4qKaWUUp7FnQlIR0SkULKfCwJ7baqPUkqpfMjh5cjyKzdwp2fqAPaI\nyCqsxvcWrGebzgQwxjxlY/2UUkrlA7lljd2scqcx/d71SmT/U4uVUkrlL57dlmbcmBpjZmRHRZRS\nSilP5U7PVCmllLKVpw/zujMBSSmllFLpcOepMfNEpEV2VEYppVT+lB8eDv4d0MP1KLZ5wDRjzGF7\nq6WUUipf8fBxUnceDv6VMaYDcDOwC5grIou0t6qUUupa8fSeqVvfBUSkCPAw8KyrzE/ACyIyzMa6\nKaWUUh7BnWum04CdWIs1vGyMaWyMmQS0A1rZXD+llFL5gKf3TN25ZroJ6GOMOZ+4QURuNcasFZFn\n7auaUkop5RnSbExFJBAoDnQCfnItcA/gC8wEqhpjNtlfRaWUUnle7uhgZll6PdPbgJeAesDSZNsT\ngF/srFSiwj6FMn6Th8gtQxHXglceyuLw9H/BycRejMvpKlwzTpw5XYVrJi/9HbOTnQvWi8ho4Fas\n9quvMWa9a3tZYDbWs7odQEXgVax5QTOBIKAAMNQY82t650izMTXGLAYWi0gPY8wnVx9HKaWUSoNN\nX9JFpAlQ2Rhzu4hUAz4HbgcwxhwFmrne5w0sA+YDzwA7jDFviEgZrA5l9fTOk94w79DU/pzIGDM4\ns6GUUkqpbNYc+AHAGLNDRAJFxM8Yc+6y9z0NfGuMiRKRUKC2a3swcCqjk6Q3m/diOq/4TARRSiml\n0uVwZP2VgdKkbAxDXdsu9ywwFcAY8yVQQUR2AcuB/hmdJL1h3iFp7RORERkdWCmllMqFrmh+ReRW\nYHtib1VEOgMHjDGtRKQOViN7U3oHzfDWGBG5B3gPa2YvQEEgHBiQqeorpZRSabBxkuZRUvZEywLH\nLntPG2BJsp8b45poa4z5V0TKiojDGJPmzDh3VkAaBvwPOAk8gNVC93OjnFJKKeUeL0fWX+n7FegA\nICINgCPJ101wuQn4J9nPu7Fm/yIiFYCz6TWk4F5jesYYsxaINcZsdU080sZUKaXUNWPXCkjGmDXA\nBhFZBYwFeotIFxFpl+xtpbE6jIk+BW4QkeXALOD5jOrvzgpIviJyB3BaRLoA24Ab3SinlFJK5Thj\nzOuXbdpy2f66l/18HngsM+dwpzF9HqvVHgCMB0phXUNVSimlrg0PX9siw8bUGGMA4/rxXnuro5RS\nSnked2bzdsJaXimIZN8djDHX21gvpZRS+YinL7nqzjDvEKybWQ/YXBellFL5lJ1r82YHdxrTXcaY\nlZ0IejwAACAASURBVLbXRCmlVP6VD3qmq0XkPawllZKWETTGLE2zhFJKKZUJ+WGYt4Xrv7cl2+Yk\n5WPZlFJKqXzLndm8iY+nSXcppdS4HnfTHCjj2nQU+NUYszuzFXVHwcIF6f9uL/wCiuLr68OcT77j\nvoebERDoj8PhwL+YH9v/2cn4d6amKNf1pcep2aAaXl5efDX1B9YsXU+7zq24875b2bbJ8PmYOQA0\nvb8xgcWL8cMXi+yofipZeuIX4IePjzdzPv2Olu3vJiDIHwD/Yn7s+GcX44ddmaVGfcHb24uvpvzI\nmmXrade5JXfeeytbNxmmjZ37//bOOzyqou3Dd0hCeiUJSej1gdAFBeldetcXQQWxIVjRzwYI8iog\nKrbXglSVJk0Bkd470vuAdAghJCGEGkKy3x/nZNlUiMluKHNfV67szjnPmfmdObPPtDNjaqmLf6Af\nf0xe6BAtAz5+GW9fL1xcXZg+Zg4tOzfBN8AHJyfw8fXm4O7DfPfxhDR2JcoWZeCXA/jj17/4a4ax\n0lf7Ho/RoGUd9u9UTPpqOgCNWtfFv5Afcx2mpS9e5jM2fczvtOzcGJ8A8xnz9eLg7n/4Pp2W597u\niVQpi8Vi4adPf+HIgeO07/EY9U0tP6fR4svcyYscouWd4a9Y82XKj7No3aXZrXzx8+bArsN8M2ys\n1aagmytvf9If/0J+uLq6MnXMbP5eu4NOT7Wm4WOPsm+7YvyXUwBo0qYe/oX8+f3XBXbX4u7hxv8N\nfwUfX29Ty0xadWmGX4AvWLUcSqMlFdeCrvz0x2im/DiTZfPW0OmpNjR67FH2bj9oo6U+AYX8mOMA\nLfdTvjxI3Mls3moYSwh6AxVEZDCGQ9x8G7tBGK/S/AUcxZgJXASYKiLTlFJf5jbx6WnRsRGnj0Xy\n87e/ERDkz8jxg3mp41vW42989BKLZ69MY1OlVgTFyxTlrac/xNvXi//NHMnGFVtp0LI2bz8zhE/G\nfEBBN1csKRZadGrE4JdH5nWyM9fSoSGnjkXyy7czCAjyZ8S4QfTtdGvjgteHvsjiOem1VKR46SK8\n/cwQQ8uMEWxcuZX6LWrzdq+hfPzj+xR0cyUlxUKLjo0Z3M8xWpp3aMjpY5H8+j9Dy/CxA3m5862l\nnV8b+kIGLW7uBXnx3V7s2rw3TXj9FrV5p/dHDPvxPauW5h0bMaT/pw7R0syqZSYBQf58MvYD+nV+\nx3r81aEvsCSdlkoPVSCsWGHe6fURRUuG8dpHL/JOr4+o37I276bT0qxjQ4b2H+UQLS07NubUsTNM\n+mY6gUH+fDrhQ17ocGtxszeH9WXh7OVpbOo0rsWhvUeYNWk+waGFGDF2MH+v3UGDlo8y4OkPGf7T\nQGt5adm5CQP7OuaV9BYdG3PqWCSTvplGYJA/oyYM4fkOb1qPDxj2cgYtqfTs241L8Zes3xu0qMOb\nTw9mxE+DKOhWEEtKCo91bsIHfT+xuw64v/IlR9zbvbx31M37P6AP8LX5/TdgIsZCwNnRGqifvjVr\njr+uBvLcmSZcuETJcsUAo/Z28UKC9ViREmF4eXtyeP/RNDZ7tu5H7TkMwJVLV3F3dwMg6YYxPBwf\ndxEvb0+adWjIn9OXkJKcktfJzpSE+EuULGe8feTj501CGi2hePlkpuUAao/R6L9y6SpuqVqSUrUk\n5KOW1HzxSpMv4SVC8fL25J/9x9LY3EhMYki/T3m8T4c04TdNLRfjEvD09qRZ+wYs+G1pPmq59SOc\nlZZqtSuxaeU2AE4fP4uXjxcenu4k3UgCjGfM09uTpu0b8JdDtSRQqvytZ+xiXCblZV/aZ2zN4o3W\nzyFhQcRExQDYaDGeseYdGjFv2mKH5ktOtQAULRlOsVLhbF6z3Rp2Mylt2W/eoSHzpi3S+WJn7vXZ\nvHeyNm+SUmp36hel1CHubD9TF25179oSjp3qIGsWbyQkPJhxf37JqAkfMu7zydZjHZ9qxbxpmXed\n3Ug0HrhWXZuyZe0OwMjYAs4FCAwKwAJUrF6e69cSeeOjl+jQo5U9kp9OyyZCwoMYO380n44fzLgv\nptzS0rM186YuzlbLY12a3NLiZGoJ9sdigYrVynH9WiKvD32RDj0es7uWtYs3ERwWxE/zRjNi3GAm\njJ5qPdahRyvmT8uoxWKxWH/UbLmVL/5gsVChWnmuX7vOa0NfoL0DtKxbvImQsCDGzPuC4eMGMWH0\nrXzp0KMVf2aiJSDIL00FIuFCAv5BfjgVKJBGS2q+vOogLasXbSQkLIgJC75m1MShjP38V+uxTk+1\nYe7UrLvNR/86jHdGvsoPn/4MQAGbfLEAEdWFxGvXeXNYXzr2bG1vKaxetIHCYcFMXPANn038iJ9s\ntHR+qg1/ZKHlxf97hjGjfk4zkTRt2bdQqbpw/VoiA4a9TCeHaLl/8iVH2HFDU0dwJ870poiUwph0\nhIi05s6c4UBgqYisEZHZ5t8GYAHwzm1s/xVN2tYjOvI8z7d7k/de+Jj+A/sA4OziTER1Yc/WA1na\n1mlSkxadGvHD8IkA/DVjGSPHD2bdss3857mOTP1hNl17teOrIWMoG1GKwOAAe0iw0rhNPaIjY3ih\n/QDef+ET+n3wrFVLxerl2bstGy2NDS0/jpgEwMKZyxg5bhDrl23hiec7MuXHOXTp1Zavh/5EmYqO\n0XL+bAwvdhjAwBc/oe/7va1aIqqXZ++2g3d8rYUzlzN87EDWL9vC4891ZNqY2XTp1Y5vho6lTIWS\nBAb720mFQaM2dYk+G8NLHd5i0IvDedlGS8U71OJUwAkshpZPxg5kw7K/6fZcB6aNmUPnXm351kFa\nmrStT/TZGPq0fZ33nh9G/0HPWbVUqpF9eRnw9Id89NpnvPfpqwAsmLGUUeM/ZN3SzXR/vhOTf5hJ\n197t+fLDHynrgGesadv6nDt7nmfbvsa7z3/EK2m0VGDP1v0ZbJq1b8j+nYroszFpwhfMWMpn44ew\nbukmuj/fmV9/mEm33u0Z/eEPlK1Y2u5a7qd8yQn2WujeUdxJN+/bwFxAROQicBx45nZGSqllQCXT\nEafuJReplLLb4g8R1YXt641G9PFDJ60/RlVqVeTQ3iNZ2j1Utyr/ea4TA/sO59rV64DRyl2zeCNh\nxQpTWkpw5OBxnJ2dAYg5F0tIeBBx5y/YSwoRNYRtG4wdgY4fttFS8/Zanni+I4P6jrDRsok1izcR\nVqwwpcoX5+jB4zi7GFpiz8UREmZfLRWrl2f7BjNfDp+yaqlcsyKH9mbsesuOtYs3sTZVi5Tg6MET\nODsbdcKYc3GEhAUTdz4+bwXYEJFOS4D5Y1S5ZoUs8yU2Op6AQrccY2BwAHEx8ZxdvIl1Vi3FM2gJ\nDguyq5ZKNYSt63cCcOzQSQKDDC1Va0VYhwvSU7ZiKeLjLhJzLo6j6gTOzs74+vuwetFGVi/aSHgW\n5aWwnctLpRoV2LZ+V4601G74EKFFQqjTqBbBoYHcSEwiJiqO1Ys2sHrRBsKLhVJaSmaiJdjOWu6f\nfHmQuG3LVCm1WylVFSgKFFNKVVNK7bqdnY39MaXURvPvBEC6rW/yjMhTUVSoVg4wxg1SnUn5SmU4\nmoUP9/Ty4LkBPRnyyiiuXr6W4XjPl7sx+buZALi4GnWP4MKFiIu27wN49mQUFapmoqVyGY5locXD\ny4M+b/Zg6CufZa6lb1emfD8LuKUlKLSQ3QvT2VPnkKplAQgOC+La1UQAylcqzbFDt69bZVbzfLJv\nlwxagkMLEWtnLZHptFw386VcpTIcO3QyU5sdG3dTr8UjAJSpUJLY6AskXku0Hje0zAZs8yXQro4U\nIPJkFBWrlgeMZ+y6zTOWVXmpUrMiXXu1B8C/kB9uHm4k2Eze6dnvcX79bgYArtZ8CSLWzuUlMl15\nSdUilctwRB3P1Gb4/33Faz0+4I2nBrJw9nKmjJnFzi23Jrw91e9xfjG1pHnGouPsqOT+ypcHiSyd\nqYj4isgoEZknIm8DF5RSCVmdn0PssoXbXzOXExIezKcTPuT/RrzCt8PGARAQ5E983MU0577z6au4\nurrQsNWj+Pp78/7nrzNy/GBGjBtEUOFAwKghnjlxlguxhu2qhev54tdh3LyZnKFrKM+1zFpO4fBg\nRo4fzNsj+vPtsPGmFj/i49JmwzsjX8ElnZYR4wYxYtwgCplaItJpWb1wA5//8hHJN2/aXcvCWUa+\njBg3iLeH9+O7/9rmS1otb4/oj4urC2UqlGT4uIE069CQ9j0e45OxA/Hy8bRqiTwRRbyNls9+HsrN\nm8mct7OWRbNWUDg8mOHjBvLW8Jf57r+38uViumfs7ZGGFrX7H/7Zf4xPJw3h+Xee5sfhk6znRNQo\nz5kTZ61a1izcyKifh5DsAC0LZi6jcJFgRk0cwrsjX+XrYT+ZWjKWl/dGvY6rqwt/zliKf6Avn08a\nyrD/vZvm1axKNYQzx289Yyv/Ws+Xk//LTQc8YwtmLqVwkRA+mziUd0e+xldWLQEZtXz6utWhZEWl\nGhU4czySC7FGhWbVX+v4cvLHDin791O+5Aj7bQ7uEJwslsxfHRWRyRjvha4BumDsTj44LyIVkRVK\nqaa3O691le45eq/1buZu6dfPCwrcR1qc7vX5+DbcSE7K7yTkGRbum6J/Xz1ji/fOsJuYsyuW/+tM\nD2vaLN9vcnbVs5JKqacARGQhkPlLWlkgIv2yOJT6vqlGo9FoNAb57g5zR3ZjptZqrlIqGXJcVRwA\nVAWC0/0FAa45vJZGo9Fo7mPu59m86Z1nTp1pJ+Ab4HWlVKLtARFpnMNraTQajUZz15KdM60rIrbT\nE0PM706A5Xabgyul9opIO2xauDa8lUmYRqPRaDT3JNk5U8ntxZVSV7MI355ZuEaj0WgeUO6SWbn/\nliydqT0XV9BoNBqNxpa7Zezz33InKyBpNBqNRmNftDPVaDQajSZ33Ost0ztZ6F6j0Wg0Gk02aGeq\n0Wg0Gk0u0d28Go1Go8l/7tfZvBqNRqPROIp7fcxUO1ONRqPR5D/amWo0Go1Gkzuc7vFuXj0BSaPR\naDSaXKKdqUaj0Wg0uUR382o0Go0m/9FjphqNRqPR5A49m9eOPNfg0fxOgiYT6nevmt9JyDMun76Q\n30nIM5b/eSi/k5BnXLyaePuT7hFKFPbN7yTcG2hnqtFoNBpN7tCzeTUajUajecDRzlSj0Wg0mlyi\nu3k1Go1Gk//oMVONRqPRaHKJdqYajUaj0eQO/WqMRqPRaDS5Rc/m1Wg0Go3mwUY7U41Go9Foconu\n5tVoNBpNvuPkdG+37bQz1Wg0Gk3+oycgaTQajUaTO/RsXo1Go9Focss9PpvX7s5URLyBUPPrWaXU\nFXvHqdFoNBqNI7GbMxWRWsA3gD8QAzgB4SJyBuivlNpjr7g1Go1Go3Ek9myZfgX0UUodtA0UkYeA\n74CGdoxbo9FoNPcQesw0awqkd6QASqntIuJsjwhvJCcxa99yrt1MJDklmSalahHiFcjsAytISUnB\nuUABHq/UHO+CnmnsFh3ewImLZ0mxWGhU8iEigkuz4eQu9kQfoYR/GK3KGpuU74o6xOUb16hXvJo9\nkn/falmwbj1LNm3GCScsWDh04iR/fj2a4eMncub8eTzd3RnW9yW8PT2sNhaLhS8mT+XYmTO4urjy\n1lM9KBZamFnLlrNy6zaqlC1L325dAFi6eQsXEhJ4okVzu2tZsmMrK3bvwAmwAP9EnmZoj978smIJ\nzgUK4F7Qjbc7P4GXu3sG2xs3k+j3/Vc82agZzao9xNxN61m7fw8RxUrQp0VrAFbt2cmFy5fp/Gh9\nu2txcXOlycvtcPNyp4BLAbbPWc+Nazeo06MJKckpJCfdZMX380m8fN1q4+zqQpO+bfHw88LZ1Zlt\nv6/n1M6jVG5VizK1KxClTrN5+ioAytaNwMPPiz0L/7a7Flc3V9q80Ql3Lw+cXZzZMGM1x3ceBaBk\n9TI8/mFPPusyLINdk2dbEi5FsaRYWD5+EeeOnKVmu9pIvQjOHDjF6l+WAVCxYWW8/LzZOn+T3bXc\nSE5izoEVZtlPoXHJmgR7BvC7WmmWfWe6VmyGd0GPDLZJyTf57u8ZNC5Zk+qhwsbTu9kbfYQSfmG0\nLFMHgN3nDnP5xlXqFrN/2c8R2plmySYRmQf8AZw3w0KBbsBqe0S4PfIgQV7+tCxTh4TEK0zYPpdi\nfqE8El6JyoXLsOn0Xtad3GV1KABHL5wh+soFXqrVlatJ1/luywwigkuzN/oIL9XqwsQd80hKvomT\nkxPbzh6kV7V29kj6fa2lbf16tK1fD4Bdhw6zcus25q9ZS4CvD4NfeI4/165j9+HD1K1W1Wqzbucu\nrly7xnfvvUPk+fN8M30GI1/tz6pt2/nuvXd468uvSbxxAycnJxau38Co1191iJaWNWrRskYtAPae\nOMbafXsYt2QB73TtTnhgEDPWrmLhts10q9cog+201Svw8bxV+Vl/YC+f9+nLoF/Hk5iURAEnJ5bu\n3Mawnr0dokUaViE+Mpa/Z6zBw8+L9oOeJO7keVZ8P5/LMQk81LkeFZtUZ6eNAynxUFmij55l94It\neBfype37/+G3nUcpXVuY+9Fk2rz3H5xdXbBYLEijKvz16QyHaKnctDpxp2NZO2UFXgHedB/2DONf\n/R5nF2fqdK3H5bhLGWyKRhQnICyQKe9NILBIIVq/2pEp701A6kYw9f2JPD70KVwKumBJsVClaXVm\nDpviEC07ohRBnv40L12bS4lXmLhrPsV8C/NwWASVQsqw5cxeNpzaZXWOtqw+sQ0P11sVuX3nj/LC\nQ535edef1rK/PeogT1dp6xAtOeIef8/UbqlXSg0APgdKAO3Mv3BgqFLqA3vE6VnQnatJRi36WlIi\nXgU96CANqRRSGgAvV3euJV1PY1PKP5wnqzwGgLuLGzeSb2KxWHAuYDSevQp6cP3mDTac2k2dopVx\nLuCYDL+ftNjy858L6NWuDRt27aZ57doAtGtQP40jBTgdHU3FUiUBCA8OJjoujpSUFFxdjPpfgI8P\nl69dY9byFXRu0hgXZ7t0dmTL1NXLebJRU/w8vbh4xZhXd/n6NXw9vTKcezrmPKdjz/NwuQrWsNQ0\n+3l5cyXxOnM3r6fdw3Ws+WVvrl+6iru30bpx9/bgesI1ln07l8sxCQB4BXpzJZ0TOrr5ILsXbAHA\nO8jX6qRSkpKNayZcoaCnG1Va1WLf0u1YUiwO0XIt4SoePre0XE24CkCdbg3Y/tffJN9MzmBTompp\nDm82Os/izsTi5uVOQfeCJN+8CcDV+Cu4ebpRs31tti/822FaPF3duZqUCMC1m4l4uXrQrlwDIoJL\nm8c9uHbzega7mKvxxFyNp3yh4tYwZyez7LsaZX/j6d3UDs+fsn87nAo4/eu/uwG7zuZVSq0B1qQP\nFxE3pVRiXsdXtXA5tp9VjN4whWs3E3mmWltcnQ2JKRYLm0/vpWmph9PYODk5Wc/ZGrkfCSqBk5MT\nFouF5JQULiVexQk4GR9FuHcQc/avINQniLrFqqaPXmu5DQePnyAkMJAAX1+iYmPZtGcvP8yaTSE/\nP97s+WSaVlvpIkWYtWw53Zo15XR0NJHnY7h4+TIpFgs3k5OJvXgRJycn9h05Srnixfh00i+UKVaU\nbs2aOkTL4cjThPj54+/lzfOPteW9SWPx9vDA292D3s0fy3D+uCUL6NemI8t2brOGpVgsJKckc+Hy\nJZyAA6dOUiY0nK/mzqZ0aCgdatezq4Yjmw5SvmEVuo9+kYKe7iz8bCYARauWot4zzblwJpbD6/dl\nattxyFN4BfpYbXAyftQ8/b3BYqFw+SLEHD9HoxdaE3symr2Lt2V6nbzi4Pp9VG5ajRe+fwU3L3dm\nfTyVgLBAgkuGsH76Khr3bpHBxivAm6gjkdbv1y5ewSvAGydTi3egNxYLFKlQjHNHo2j1Sgeij0Wx\n3axM2IsqIWXZEaX4avNUrt+8wVNVWqcp+1vO7KVxyVoZ7Bb9s4F25RuwI0pZwyyYZf/GVZyc4NTF\nc4R5B/HHwVWEeheiTtEqdtVytyAio4E6QArwhlJqqxkeDkzBGLVxAkoD7wJngZnAXjN8t1Lq9ezi\nyK/qySR7XHRn1CH83b0ZULcnz9XowHxl+PEUi4VZ+5ZROrAopQOLZGq7//wxtkcepH35BgA8UrQS\nE3bMpVJIGVaf2E7T0rVYe3InXSKaEnnpPAmJ9n3D537SksqCtetoXdfolrZYoERYKF+/PYBS4WFM\n/mthmnNrV65EhVIlee2z0cxevpISYcbbVR0bNeTNL76k4UM1mPLXInq1b8tvi5fxbu9nOHziJDHx\n8Q7Rsnj73zSvXhOAHxfOZ3D3pxnTfwCVipfkzy1px9VW7NpOxWIlCPEPSBPepmZt3v95HHUrVmLm\nulX0aNSMORvX8kbHrvxzNpLYSwl21VC2XgSXYxKYPuAn/vxkGvV7twTg9O5j/Pb2WOLPxlK9Q8au\nRIC5H01m0Rezada/AwAHlu+g/cAeHN2iqNHxUbbNXk+1do+weuxCgkqGGk7WjkQ0rELC+YuM7fc/\npn/4Cy1ebEPTPo+xcsKSO79IAaPiuXPRNrr/txdq4wHqdKvP+umreaTToyz63zwKlwnDO8C+Wnad\nO4S/mw9v1O5B72rt+fPwOsAo+3MOLKd0QFFKB6Qt+zujDlHMLxR/d5804Q+HRzBp13wqBZdizYkd\nNClZi/WndtGpQmOHlv38REQaAmWVUnWB5zHeMgFAKRWplGqilGoKNAdOAPPMw6uUUk3N49k6Usin\nRRuUUk/a47on4s9SLtDo4gj1CeLSjatYLBbm7F9BkKc/TUtlrM0BHI49yZrj2+ldox1uLgUBo2VY\ntXA5Yq9eJOpSDOE+waRYUgDwc/Mm/volfN0ydudpLVmz89AhXu/RHYBAP1+qlS8HwMOVKjFp3p8Z\nzn+uYwfoaHzu8cFgAnx9afpwLZo+XIvT0dEcOX2G8sWLk5xidOEFBwQQFRtHkL+/3bXsOX6Ml9sY\njuT4uSgqFDXyqnrpMqzasyvNuX8fVkTFx7Hl0AFiEhIo6OJCkK8fDStXpWHlqkTGxXAsKooyYeEk\npxj5EuTrR3T8BQr5+NpNQ2j5opzafQyAuFPn8QrwpmSt8hzfegiAY1sUNbuknQgVVLIw1xKuciXu\nEnEno3FydsLdx4Mjmw5yZNNBfAv7U6hECLEnzlHA7Eq8EpeAT7AvV+Mv201LkYrFOLbjCAAxJ6IJ\nLRNOfPQF2g0wJql5B/jQ/b/PMH3wL1aby3GX8LJx8t6BPly5cJmD6/dxcP0+/EMDCCkZSvSxKAo4\nG1ouxSTgG+LP5Qv203LyYhRlA4sBEOpdiMuJRtn/4+BKCnn607hkzQw2h2JPcOH6JVTsCRISL+NS\nwBlfN2+qhJSlSkhZo+xfjiXMJ4gUi9Fd7evAsn9H2G8CUjOMuTsopQ6KiL+IeCul0mdib2C2Uuqq\niIDRIr1j7PmeqSvQB8Pbh5nBkcAi4GelVMZBjFxSyNOPUwnnqBRSmgvXLlHQ2ZXd5w7jXMCZpqUf\nztTm+s0bLPpnI31qdMDdxS3D8RXH/qZV2boA1h+6i9cv41PQvg/g/aQFIDb+Ih5u7tZxwtqVK7F5\nz15a16vLoRMnKBZaOM35R06fZtayFbzb+xk2791H+RLF0xyfNH8BL5uzeZPM8bDoCxcI8vezu5a4\nSwl4uBW0jm0GePtwKiaaYkEhHDpzhvDAoDTnv9vtVt1x6qplFA4IpFqpMrfCVi+nT4s2ANxMNrTE\nJMTb1ZECXDx3gcJlwzm+9RDeQb4kXb9BzS71SIiOJ+5kNCFlw4k/G5fGJqxCMbyD/Ng4eTkevp64\nuhXk+qVr1uM1u9Rn09SVABRwMcfrCvlyxY7OB+DC2TjCpSiHNx/EN9iPuMhYxr/ynfX4i2NeS+NI\nAY7vPEK97o3YvXQ7hUuHcjn2EkmJSdbj9bo3YtWkpWm0+NqME9uLQA8/TiecIyK4FPHXjbK/J/of\nnAs40yST7l2AJyrd6sZeeXwrAe4+aVqvq05spWVpo1co2WI8YwmJl+8eR4pdX40JBbbafI8xw/5J\nd97zgO14QISI/AEEAsOUUsuyi8SeLdNfgSPAF0A0hpcvAnQFJgLP5HWEjxSpxJz9Kxi37Q9SLBY6\nVmjE0iObuZmSzLhtf+Dk5ESwVwAdpCG/7V1C14hm7Dn3D1eTrjN97xIsFgtOTk50i2iGn7s3x+PP\nUsjTHx83Yyyvamg5xmydTbBXIAEePrdJjdZiS+zFiwT43oqna9MmDJ8wiQXrNuDp7sYHfXoD8NFP\n43j/2V6ULlIEC9B3+EjcXF0Z9Hwfq+3uw/9QrHAIhfwMx9nskVr0GzmKkmFhhBYqZHctcZcv4ed1\nq0XzSrtOfDNvDi7Ozvh4ePJGx64AjJo9nTc7drNOmsqMfSePUyQwiEBv4940rFyVt8b/QPHgkAzd\nwnnNgeU7afxiG9oP6oFTASfWjF9M0rVEGjzbkpTkFG7eSGLlD0aPQbNXOrDyxwXsX76DRi+2ocPg\nnjgXdGbtxMXW64VKUS5GxXHtotF1+M+G/XQc+hQXzsRaJzXZi12Lt9H61Q50/7gXTgWcWPJjup4O\nm7lD7Qd04a9v5hKpThN15Cw9RjyLJcXC0p/+sp5TpGIx4iLjuBJvaDmwdi89R/Yh9tR5Es5ftKuW\nh8Mj+OPgKibsmEsKFtqXb8CyY1tITklhws55OAHBngG0K9+AmfuX0blCE1yymbR2Iv4shTxsyn5I\nWcZu/51gz4AM3cL5iuNm82bw2iJSBzhg01o9jDFZdqaIlAZWikgZpdTNLC9qsdhnhpqIrFZKZXw/\n4DbHbJnV72vHTJ/T5Ij63R0zYckRXD59Ib+TkGcs//NQfichz7h4Nc/nJ+YbJQrbt4fBkfxnzJt2\naz5eOX3kX//eexUtk2W6RGQIEKmUGmt+PwJUtV3aVkQ+BvYrpaZmcY3NwBNKqRNZxWPPqkCK8+D+\nkwAADfFJREFUiHQxu3tTE+QmIj2A+6ekaDQajeZuZgnG+gapK/CdyWSN+IcB62QHEekhIm+Zn0OB\nEOBMdpHYs5v3aWAY8LmIpHbMXwKWAb3sGK9Go9FoNAAopTaKyDYRWQ8kA/1FpBcQr5Saa54WijEc\nmco8YKqIdARcgb7ZdfGCHZ2pUuo0xgSkDIjICsAxLwRqNBqN5u7HjssJZrJQ0J50x6ul+34Z6JCT\nOOw5m7dfNoczf0FSo9FoNA8keqH7rBmA0aV7NpNjrpmEaTQajeZB5R5fm9eezrQTxkoTr6dfOlBE\nGtsxXo1Go9Hca9wla+z+W+y50P1ejMXtkzI5/Ja94tVoNBqNxtHYe6H7q1mEb7dnvBqNRqPROJJ8\nWZtXo9FoNBpb9AQkjUaj0Whyi56ApNFoNBpN7tAtU41Go9Focss93jK9t1Ov0Wg0Gs1dgHamGo1G\no9HkEt3Nq9FoNJp8x+keX7RBO1ONRqPR5D96ApJGo9FoNLnD6R6fgKSdqUaj0Wjyn3u8ZepksVjy\nOw0ajUaj0dzT3Nvtao1Go9Fo7gK0M9VoNBqNJpdoZ6rRaDQaTS7RzlSj0Wg0mlyinalGo9FoNLlE\nO1ONRqPRaHLJffueqYhUBv4ARiulvr9Dm6LArxiVjLPA00qpJBFJAtYCToAFaKaUsus7RSIyGqgD\npABvKKW22hxrDnwC3AQWKqU+zsomG03+wDTgklLqCXtqyWtNZvhrwOeAv1LqqiPSnxX/UleOn09H\ncxtdbsAYoJJS6uF8SmKOyO6eZ5VPdxPp059V2U5nk2UeavKW+7JlKiKewDfAshyaDgO+VUo1Ao4A\nfczwC0qppkqpJuZ/ezvShkBZpVRd4HkMLbZ8DXQG6gMtRaRCNjZZafoRo4LgEPJSk4g8DYQAZxyV\n/qz4l7r+7fPpMO5A12fADozK5V3PHdzzDPnkqLTdCVmkP6uynWpzuzzU5CH3pTMFrgOtMWprAIhI\nRRFZLiJLRWSOiPhmYtcYmG9+ng80Nz87emmOZhg1UJRSBwF/EfEGEJFSQKxSKtJ06gvMdGZm40PW\nmp4D1jtEjUFeafIG5iilBjkw7dmRE11/medneD7vQrLUZfJ+6vF7hCzveTb5dDeRWfobk3nZTuV2\neajJQ+5LZ6qUSlFKJaYL/hZ4USnVAlgKvJKJqadNN0k0EGZ+dheRySKyVkTetE+q0xAKnLf5HmOG\nZXbsPEY6C2cSHkoWmpRSV/I+2dmSF5pigNB8SHt25ERXNBCWxfN5t5Gdrvx4fnLFbe55pvlk/1Td\nOVmk3yuL36tUss1DTd5y346ZZsIjwFgRcQIKAn/f5nzb1uhbwGTz8xoRWa2U2m6HNN5JWu70WGbh\nd9Pil3ml6W7j3+i6F7iX055T7kWtd5Lme1HXPcOD5EyvKKWa2gaISB1gBMa4z1PAZRFxM2uARYBI\nAKXUTzY2y4EqgD2daSRpa5Dh3OreiSRtDbQIxthhYiY2kWShKR/IK0223Vx3w3hdTnXl1/3PKdnp\nut+4V/Pp0m3K9oOUh/nOfdnNmwW7RKQVgIj8R0SaKKU22UwqisQY3O9qnt8VWCQi5UVkimnnAtQD\n9tk5rUuAbmacDwFnUrvVlFInAB8RKW6mp515/tJ0NpGmTQZNNvE44bjaal5oOpOue/FuqGn/G122\n3A0aMiNLXTY48vnJS9Kk+Q7z6W4ku7INd5aHmjzivtw1xnxwvgBKAEkYrZyBwKdAMnAN6KGUik9n\nFwr8ArgBJ4BnlVLJIjICYzA/GZirlBrpAA3DgUZmnP2Bh4B4pdRcEakPjMJomc1SSn2ZmY1Sak9m\nmky75YAfRo12HzBMKbXqLtfUTym1V0Q+AFoAtTG66zcqpd6zZ9qzI6e6sng+u6R/HvOb2+iaARQD\nIoBtwE9Kqen5ltjbkMU9nwccy+75u1vIIv09gZ/J+Hs1DeitlErM7DchXwQ8ANyXzlSj0Wg0Gkfy\nIHXzajQajUZjF7Qz1Wg0Go0ml2hnqtFoNBpNLtHOVKPRaDSaXKKdqUaj0Wg0uUQ7U41Go9Focol2\npg8gItJaRFabC/9vFpFpWSz8f7vrNBKRtebnL0WkRt6n1hrXoyJyxHzH1Db8XRFpfRvb1uaWcw5H\nRHpmc2y8iHQRkV4i8uxtrvOoiJTM8wTeASLypIPiWSkiTUWkmoh8/S+vMVNEWuR12jSa2/EgLSeo\nAUTEFWMPxAilVLQZNgJjF5l/86K6BUApZe8NAJoBM5RSw20DlVKf3oHtm8AhwKGLIoiIM/AhMCWT\nY48D7kqpOXd4uWeB34DjeZbAO+cjEflNKZXiiMiUUruA1/+l+UvAZhGplt/73GoeLLQzffDwADwB\nH4ydJlBKvZ96UERqYzjVRCAOeAbDYf4CBJh2s5RSo2wvKiIrgf9irLTyHnAaqISxWstjSqnrIjIQ\neByIAnYB4Uqpp9NdpzbGpt83zHhfBQIxnD0icsV242YRmYixL+tyjBVtFmFshuwNtAU6AQ2AyWbr\nzxVjJRkX8/MrSqldZvp3AtWBpqbthxirZR3C+JF2Br4Dypj3YZq5olEvjL0wLRgrSh0w0zsOKCEi\ni5RSrdLlw0Cgt6lhCOCslPpQROKBjzG22woFngDKmfftYXPXoiPA92ZeegMfKKVWmPciESiPsTpO\n8fR5qZS6IiKfAHVN+9VKqXdFpJEZ7wmgFHABeBJjk4eywHIR6ZzVKk0iMhJjS7BEjNV5emFstP0N\nUMu8N6OVUrNEpBPwjnlvXTA2tT5pc61GwMdKqQZmviwz01sOGKKUmmZum/YrxqbXfwNtgLZKqaMi\nMh+9f6fGwehu3gcMpVQCMBTYKSJLROQDESlvc8qvwHNKqSbAagynEgL8rpRqhrF58ge32RexDvCe\nuSlxMvCYiJTFcEi1MdY+rUPmC9X/DLxuxvUl8J1Saj0wCfjV1pFmQgQw0dwseRfwH6XUjxjOu4e5\np+MU4CVz04P+wHgb+0umbndgLNDKvFYMxprMr2Osb9rMTP+TIlLZtH0YeFIp9QhQEmgFDAGi0ztS\nc4nHUKXUzkw0+AK7zTh+A55XSv2B4egHmEs+/gB8rpRqDnQExotIaln2NNeaPksmeSki3YAi5prU\ndYByItLWtH0IeFspVQ/D+fZSSg01jzXNxpH6A/2AR837NQdj+7yeQIhS6lGMykEvc9cmf+AJU+NC\nMt8O0fbZ8FJKtcVwkO+YYcOA6Uqphhhr0JazOX8Zxv3XaByGbpk+gCilRonIWKAlRitsk4i8D8wC\n/JRSB8zzvgEQEU+goYj0w2gxumG0FrPigFIq1vx8wjy3GrAldU9GEZmL0Qq0IiJ+GD++qTvyrAKm\n5UDaedNh2sabipOIBAOC4XxSFzv3tvm8wfwfAZxUSsXBrZa7iLwHFBGRxuZ5bhitNoD1SqnrNteJ\nALJaB7UYRss9K1bZaChjq8H838RMd6rDScSo8Fg1iEghMs/L74A6IrLCvJ4vRkt0D7BPKRWVqgcj\nz2zjznTtUaVUvIgswtie8HfgN6XUGbOXYZV5zkWgvZmGc8AvZgWgMLAxm3uR/n6k5ml1jLW2UUot\nFhHbBdxPYFRoNBqHoZ3pA4iIeCilLmC0fH4TkZkYXaszMboy0/MGUNBssSAi5zM5x5ab6b47YfSC\n2I65JWdil/7HOssf8BzEa0sicD39VnwAIgJGRSE1HZndh0SMDQHSjHOa3by2vTw5TXd6bHVktivL\ndaCzmYe26YC0GjLreUrEWJR+dDrbRuRCg1LqCbOHox2wymwBZ0iDuSvLb0B1s0u2P1DzNpfP7H6k\nf54cMp6r0WSF7uZ9wBCRlsDGdN20ZYB/zJbYeRGpaZ77loi8jNHq2W+GdcAYa3PLYdQHgZoi4mL+\noHZIf4LZBX1WRB42g1oAm3IQR1bbgaUArub1j6fO/hVje73BWaQ1XETCzfO+FJH2GGOz/zHDCojI\nFzazhGuLiLvZyq0H7DbjLZjJ9U8BRXOgy6rB/LwO6G6mI0hEMkwcM/MyJl1e9jVtu5qToxCRwSKS\n2vqtICKFzc/1MbrK08edAREpJSJvKKUOmU76d6AqRis5ddtDPxHZhDHungycEBF3jG7qnD5LYIxL\n1zWv3QJj7DiVEuTPRC3NA4x2pg8YSqklGOOBy0VkhYiswug27G+e8jTwjTnxoz7GuNtE4FkRWYbx\nQzXF/LNtuWTVikmd7bsHY4LQVowxtZ1kbEmCMeHpC7Mbsp9NurLiTtKwGJgvxmbwzwDvi8hqU9eS\n9LbmLNDngDnmef7AAoxJP5dEZAOGo7hgM46417zeJkCZ140EokTkbxHxsLl+FEalIU039200LAXG\nmJN3XgM6i8ga4E+MMcLMbNPn5WSzVb0O2CAi6zEqSkfN8/cDI8R43ckbI+9T799Wc9JPZpwGaojI\nJvMZKQnMBmYAx8x4FmOM854HpmI8B9Mwtj1rKiJds9Ce1f0YCrwiIssxthg7za3nqTkZ9/bUaOyK\n3oJN4xDMllBv4BelVJIY7xFG3uGrLXc1ZjdvM6XUMzmw6YbRVZvle6iOxOzm/a85oeeux2xxuyml\nNpit6f0YFQN/jDHYGnojbI0j0WOmGodgblpcHNgiIglALMbrIQ8k5isirUSkSw7eNc1XROQPjAlL\nqaSOq05SSv3i4ORcBr42x4ldgRfNZ+xH4GXtSDWORrdMNRqNRqPJJXrMVKPRaDSaXKKdqUaj0Wg0\nuUQ7U41Go9Focol2phqNRqPR5BLtTDUajUajySXamWo0Go1Gk0v+HxnOojIC/ulYAAAAAElFTkSu\nQmCC\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x7f6f7403efd0>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Cross-validated performance heatmap\n",
+    "cv_score_mat = pd.pivot_table(cv_score_df, values='score', index='C', columns='intercept_scaling')\n",
+    "ax = sns.heatmap(cv_score_mat, annot=True, fmt='.1%')\n",
+    "ax.set_xlabel('Scaling of intercept (intercept_scaling)')\n",
+    "ax.set_ylabel('Penalty parameter of the error term (C)');"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Use Optimal Hyperparameters to Output ROC Curve"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "y_pred_train = pipeline.decision_function(X_train)\n",
+    "y_pred_test = pipeline.decision_function(X_test)\n",
+    "\n",
+    "def get_threshold_metrics(y_true, y_pred):\n",
+    "    roc_columns = ['fpr', 'tpr', 'threshold']\n",
+    "    roc_items = zip(roc_columns, roc_curve(y_true, y_pred))\n",
+    "    roc_df = pd.DataFrame.from_items(roc_items)\n",
+    "    auroc = roc_auc_score(y_true, y_pred)\n",
+    "    return {'auroc': auroc, 'roc_df': roc_df}\n",
+    "\n",
+    "metrics_train = get_threshold_metrics(y_train, y_pred_train)\n",
+    "metrics_test = get_threshold_metrics(y_test, y_pred_test)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAfcAAAFvCAYAAABXQIIJAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAIABJREFUeJzs3XecVNX9//HX7GwFFpaFXXovBxRR7KJisGNNNGIwUaNi\nV/Sn+I0xamKLEWskUWOisURNNIIFY0WMRrCAikg5ClKl7bK9787M7497Z5hdtsyW2d2ZfT8fDx7M\nbeeeObMzn3vOPfccTyAQQEREROJHQkdnQERERNqWgruIiEicUXAXERGJMwruIiIicUbBXUREJM4o\nuIuIiMSZxI7OgNTPGOMH1gI1gBcoAH5trX2/len+Bhhlrb3QGPMeMNta+1Uj+8+01v7Nff0ucENj\n+zcjH0uBbkAyMBJYA3iAVdbaM40xG4AAUI7z/suBu621/3KP94cdA7DFWnucu+02YLq77UvgUmtt\nUWvzXM97OBgos9Z+08R+Y4F+1tqPjDE/Bk6x1s5sozxcAdwCPGytvbst0pSWMcZcCWRba3/bhmme\nBFwHHAesZ/d3woPzvfgKuMpau9PdPx24EzgR8Ln/ngfusdb6w9K9DrgAJwYkAm8DN0Xje9JWjDH7\nAM8Ch1prKzo6P52dgnvnFQCOstZuAzDGTAZeN8aMtdbuaosTWGuPbWy7McYL3Av8zd3/uLY4r5vW\nge45hgHfWWv3qrNLADjHWrvE3W8MsMQY87W1djUQqOcYjDE/A44B9rXWVhljXgJuAm5sq7yHuQD4\nH9BocAd+gvNd+8ha+wrwShvm4QycH+W/t2Ga0gLW2j+3ZXrGmB7AY8Bka23AGFP3O+EB/gg8APzC\nXf4PzkXvRGttpTGmN/AvYAxwoXvcPcAU4Dhr7XZjTBrwMPA6cFRbvoe2ZK1dYYyZD/we54JHGqHg\n3nl52F0rxVq72BizFjjMGLMCWIzzpZ1krZ1qjDkceBDoDeQAP7fWrjfGpAJPAwcDGwAbTNMYs97d\nb7Ex5jzgNzhB9VPgYuBNoJcxZhVwErAI+DnwA7AEuNvdrzdwnbX2JWNMCs7V9WHASpyac39r7QUt\nLIPg+//OGLMQJ3CvDt9Wx0rgcmttlbv8AbDHRYwx5nzgFKASOBKnXG4H7sFpSbjFWvs3Y8xvgcHW\n2ovd434LDAaWAucBpxpjsnB+ZP/k5i8JJ+hfCEwDfg1UGmMycC4EfmGtPc794X0M2BenheYZa+0c\n9zx+N/3rgH7Avdbah+q8h3twynmcMWaIWyaD3PSeA+bi1OLOYPfneoW1ttwYswh4CzgdGAXchvM5\n/gKntneytXZjnfM1+NkaYwYBjwLGPde11tq33Iu3ev9W3DRvBc4BUnAueq6z1u4xslZ9+wFDgM+A\n/a21W40x5wBXAYcD3wOPAGe7+/3FWnurm59IvzsDgWeA/u55/2mtvaWR9aG/Fffz+CswHKhyP79n\nmyqPOi4HFlprt4StC/9OBIwxC4D73VUnAQNxKgV+d598Y8zPgfXGmLuBXOBqnIvf7e4+5W6rQ70X\n7w38NhwG/M1aO8bd56jgslsOg4CJwAvuex0SrJQYYx4Eyq21NzX0+RtjzgJuxWmdqAJmWWs/xPmb\n/tYY83trbW59+RWH7rnHliScYATQF/jC/XHqAbwG3Oh+2f4IvOjudyGQjROwzgSOr5uo+4NzLzDF\nWjsO6I7zA3AhUGOt3ctau6HOYX3dbROB/wfc5a6/GOdHbyhwCU7ttq2GQQx//xhjnjHGrDTGfGCM\nOQycq3tr7Qp3ey/gLODVBtI7HvgtMBoYD8wGjgBm4jR1B9XNf8Ba+xecwPJ/btD9CU5Q2ctN60Dg\nbGvtAmA+8Edr7Q110rsbyHPL/EjgCreFJmgva+3+OAH4927NLMRa+ys3DzdYa293V08DTrTWPowT\n2E4AJgF7Axk4n1XQke77vRCYA2yy1o7HuXi6sJ7ymknDn+0zOH+PBifI/MO9eIEG/laMMecCP3XL\napT77/K6J21oP2vtJrcM7zXGdMO5kJkZdnFwqNtCNAG40m3WDeYnku/OtcB/rbUTgH2AkcaYfo2s\nJ6w8Hgfedz/bU4CHjTFDGyuPevwU52+nXm6N+0LgY3fVFODt8OZ3AGttDs7fyRTgUGCztfa7OvtU\nWWvfqOccDf02hL9X6lmeBkyz1v4ReB+nDIJ+DLzYxOf/Z/f4vYArgNPcfObhXGCc2kCxiEvBPUYY\nY6bh1OCCX+REdjfvHonzhX0fwL0vPdoYM9jdNs9aG3C/GAvqSf544GNr7Q53+RycmkxjvMBT7usv\ncGpH4ASLf7vn2wTs8YPREsaY/d20g+k9Dsyx1u6N80PwujGmZ9j+z+G0MHyHU9uszypr7TprbbW7\n3ztuYFiBUwOKmLV2HnCgtdbvthp8jnNB1ZiTcGqXWGvzgXnUvvgK5vsLnJpNdgPphAf9T920guk/\nba2tcN/X3+uk/7obCFYAacC/3fUNvf8jqeezdQPrj4CH3PfyPfARcLJ7XEN/K6cAT1prS9x8PIFz\nAVpXY/vNxWly/hfwvLV2Vdhxz7j5yXHzE7xwivS7sxM4wa3ZV1lrf+5+Rxpaj1seiTi14EfdNDfh\ntHod3UR5hLi3xPbH+TsK95wxZpUx5ltgF87fePCCLROn5aE+O9ztme7rSLXktwFq/x2+jHOBGvwe\nV1mn3059n+sZYfm93Bgz1Fq72Fo7Oyztz3BaDqQRapbv3D4wxtTgXIRtwLmSLTPGAPistSXufhk4\nP0jBHzYPTqebLJwvc2FYmvlAjzrn6YvTYQ9wruIB3PM0xGetLQ++xvnBAqeZMS9svx9wmrFb4jlj\nTLBD3XbgLGvtVjePl4Xl9yVjzM04P95vuet+boxJxql1PAf8rJ70i8PfD1AS9rpZF77GmL7AXPfH\ny49zIfZQ40eRhfN5BOUDA8KWCwGstX631u6laeFlX1/64RcIwffvc89T3+cZrqHPthfO39xi92/G\ng1PDWxhMr4G0M4DZxphL2N1BbGc9521wP7dsHgf+wu4aZVB4XvPd/AfzE8l35wGcv4NHgAHGmEes\ntb+rZ/2frbW3hZ2rj5u38L+v8LJvqDzCZbrnqFse51hrlxhjknBuJb0ellYuDV+U9nPTyqV538eW\n/DZA7bJ/Bbjf/T6ezu6WkcY+/9NwWs+WGWM2Af/PbZbH3WdSM95Dl6Tg3rmFOtQ1YStOLfTguhuM\nMfk4P75BWfUcn8vuWk2wx21aM/MaVETti4cBDe0YgVDnoXDGmO7AIGvtt2GrE4FqY8xUYIe1dpV1\nOtT9FfiwbhrNUPfHt3cD+92Fc29wb2ttjTHmHxGkvQMnEATvqfahebWqSNMPam36DX22O3H6DBwQ\nFmiAULNuQ7YCr1prH2nivA3u57Ya/B9Oh7A5OE9JBPUNe51J7YATnna93x3XHGCOMWY08JYx5iNr\n7cJ61v8v7JhcIGCM6WWtDV5YN7fsG+pT4gGw1lYb56mQ+4ED3G1vAs8bY5Lc1igA3D4hBwHn43yG\n2caY/WzYUy9ua8PvgDtt7Z7ouYTVksN+G+p+LzIbeiPWue//GU7flx/j9OuARj5Xa+16dncAPB+n\nx39LKwldkprlO7eGvuB1t32KU4M4GMAYM9IY84y7bQlwmjEmwa1dnlRPWv8BJhtjhro1xMdwvljV\ngNcNppHm7TPgTGOMx+1UNK2R99BUWg2tH4LTc34EgDHmeJwfz09xmu6DtQRwagBfR5CHhs69DZjg\nvp+65VeNU/sAp1a2wg3s++Lcf+9Rz37hFuDcuw7W/M+g/tsmLbUApxd1mvvjfVEj6Tf2txZU72dr\nrfXhNNFfAU7ANcY8YZxOdvWlHVx+FTjXvXeMMeYS9z5sXY3tdzvO7YTrcGrg4Z/P2W5e++F8HsGL\nvIi+O8aYx4wxwc6Y63H+FgINrQ8m6JbHW8ClbjqjcJr/32uiPMLtwgmg9V2MBz0LpBinwxtuzfYL\n4Gn3ogdjTKa735PW2s3uxca9wDNuvoIXSI8D+9k9HzH7D3B4Pb8N29xy6+veQjinkXyC0zR/MZAU\n7BNDA5+rm+Y77oUEOJ9ReD+CLBq+/SAuBffOq6lOaOE/JhU4HVPmGmNW4nyRgk1ff8W5Wl+H8yM4\nr24a1tofcILMIpzHaPw4TY/bcHp9bzJOh7VA3WPr8RhQgfOM/lyc3rIRv5cI0sdauwa4BljgNqf+\nFjjNbWqdg9NT+mtjzBpgKk5HsKY01DnoJaAU5/08ze5yBaez0z3GmPuA+3DuEa7E6RR0HTDTGHMm\nziNGlxljXqxznpuBTGPMapxe/b+31i5rIj9N5TvEWvtvnB/nZTgXOJtwPpPmpB+usc/2CuAo970s\nBda5f1cNnss6jwW+Dnzhfo6n4jxvXfd91LufMWYizgXRnW6fglnAn8MuRlfiXJCswOnQuKZufpr4\n7jwG3OWe8xtgsXtvvqH14S4Hprrl8TJwUVPlUec9+3CeRjioof3c+9S3AncY50kGcG4/7QC+cvP3\nX5we99eEHXcbTjB/zc3f5zi3vc6gjoZ+G6y164AncZ6z/5DdFy4NmY/TByP0/Wnoc7VOL/g3gc+N\nMd/g1NrDO3geglNpkUZ4NJ+7RJMxZg7gtdZe39F5kbbVmT9bE/aYZ0fnpaWMMb8CxlprL+rovHQW\nxnmc9DucJ0lUe2+E7rlLmzLGnIpTmzgcZ/S5k3Fq1hLj9Nm2u0eBlcaYgcGOpMLVOE9FKLA3Qc3y\n0tbewGnmW41z/+8tt3lYYl8sfbYx3yRpnaFgL2X3Y3NdmjFmAs6tg193dF5igZrlRURE4oxq7iIi\nInEmpu6519T4Avn5ZR2djbjWu3c3VMbRp3KOPpVx9KmM20dWVnokj6rWElM198TESAboktZQGbcP\nlXP0qYyjT2XcecVUcBcREZGmKbiLiIjEGQV3ERGROKPgLiIiEmcU3EVEROKMgruIiEicUXAXERGJ\nMwruIiIicSbqI9S5g/2/gjMH8CN1th0L3AXUAG9aa++Mdn5ERETiXVRr7saYbsDDwHsN7PJH4CfA\nEcDxxphx0cyPiIhIVxDtZvkKYBqwre4GY8wIYJe1dqu1NgD8BzgmyvkRERGJe1FtlrfW+oFKY0x9\nm/sDOWHLO4GR0cyPiIjEj6LSKqpr/K1OJ0CAvKLKiPYtKa+mtKKaxIT26bKWlJjAtKz0Zh/XmWaF\na/asNyIi0rYCgQC7CivwOwts21VGTkE5Kcl7ThLTMz2VouKK0PKOvHISEiDBU//PeXF5NXmFFeQV\nV5KS5CXR2/jPfo0/wNothfTtlUpRWRVV1U4g9wCBlr7BNpA4ZA3ezO3tdr5pRz7Y7GM6MrhvBQaE\nLQ9y1zUqqwVXMNI8KuP2oXKOvmiVcXWNn0CgeeGlqLSKiqqa0HIgANt3leKtUwOsrvHxv+Vbyeqd\nBkBltY/XPvye8cMz60139YY8Mnum0kA8bZZAAPKKKpresQERBb0e7r8IpfSBYiAxIQGvW+aJXqfM\nfP4AiV4PnjZ484FAgIQET4MXJuHKA8UA9PD2bPV5m9LS99aewb1WDq21G40x6caYoThB/RTgnKYS\nyckpjlL2BJwfQ5Vx9Kmcoy/SMg4EAlRU+fZYX1Hlo7C0khXrdvH1ul3kFJRTVFYdjaxGZPWGvHoD\njwcnIGdnpLX+JB7o2yuVgp5f0b1fDuDBHwjg8UCSN2GPQONJ8BDw777IKfUXAZCe2KvR0zhBtOWB\nq6Ol0ZtJ2ftwxuhTOjorDYpqcDfG7A/cDwwDqo0xZwKvAeutta8ClwP/xGlhecFauzaa+RGR+Ffj\n81NZ7SN/Uz7rN+cDsCO/DAKwZOUOMnumhGp+ldU+Vq7Pa/Y5khITGJrdg7SUyH9CK6p8JCUmkN17\ndxAuKa8mq1ca3dNqp1NaXsOQ7B70zUgFnBr16EG9SEhom2A4b+0Cvty5osHtSRX5VAGZqb0bTceb\n4MEXFtxTYiDodRWe5jYtdbCAajvRpRpl+1A5t862XaWUV/ooLqvibwtW0bN7MgkJHn7IKW3wmKaa\njJMT97yn7A8ESPB4SEpMICXJ69ScY7OyWUtehXPR01jwjiRI6++4fWRlpTf7r64zdagTkRg0b+0C\nlm5bTn31hGqfn0CA3feDA8666ho/niabZQP4/AE8daJpoG5XKgN5gAcPaYNqB+RAwKllw+77pL2S\n9qwBx2rzcEtlpqqGHe8U3EVkD9t2lVJUWgXAzvxyduSXk5SYgAcnOL+xZCOJQ9aQmLkdT4rTActf\nmdqscwQC4AkEGg2sCR4PgUAArze805mzf2KCB0+CB78/QLfUJLx1AnbdJuNYuE8q0lYU3EXinM/v\nZ+2WQmrCAt3mHSXkFJaTW1DBpp3F9HM7Y327pbDWsQ01ZafsCwluUPfWdCNQMIBhNQcxatCeHakK\nS6o4eHx2WH4C9E5PISsjrVn3rJtLTcbSlSm4i8SoYC/vzTtLKK2oxm4qIK+ogqU2h17dk0P3hkt7\nf93wveZ0599GnN1T+jirEzweEhI8+BPLAEihB94ET1jt2EOSN5VJ/SaqJizSCSm4i0RJZbUPn6/+\nDqul5dW8uOZ1vt7VcI/luvwBqKzyUVXjw+PxUF2z5+NbpDq16goIPT+dlOQE6CR/91rPVAcCAZKT\nnMebEr0NjbaVoqZskRik4C7SDBVVNXy/tYj124rwJiTwQ24JqUmJeDywJaeExMQEtu8qI7ew4YFA\ngk3dCS28V12XNyGBRK+HxIQEEhM99QRrBWiRrkbBXaSO3IJyFn31A91SEvl+axEZPVJYandS3MwB\nTHqkJdG/Tzd6pCYBsDNtGcXJm6jxOo9rJfq6k141lOzyAyJKzx8IkFNQzpETB3LIXv1ISfLSLVVf\nYRHZk34ZpMsqLK3is1U7qKj2UVRSxeacEr7dXNDkcQP6dCO9WzL7jupD/z7dSPB46J2eAkBqSiI9\nUpNISU7YY1jRWxa/gb+ynMyU3hw+7ABOHHR8VN6XiIiCu8SVQCBAfnEluYUVlFfW8N7SzWzJLaW8\nsobu7uNSjTWZBw3s252Dx2UztH866d2SSE1OpG/P1Honz2hI3VHACioLyUjpxR2Tf62e3CISVQru\nEtMqq3y8+r/1eL0ePl+9k50F5Q3uW1VdSXq3JHqnp1BQUklyopch2T3YZ2QmIwf2IiXZy/D+6Y10\nLmueL3euCAV0gIyUXkzK3qdN0hYRaYyCu3R61TV+yitr2JFfxjNvWwpLqsjKSGP9tqIGjzlwXDYJ\nHuiemsSYwb3Yf2yWMwhLFEYia2ic7vCauohIe1Jwl04nv7iSlxat5ZNVOxrcp6S8utYIZBedPJ5+\nvbsxpF8PUpIibzpvrvoCeUPjdKumLiIdRcFdOoWisir+s2Qjy+xOdhVV7rF9UFZ3vAkeevdIYfrR\no+mf2a1DxgOv29QOGqdbRDofBXfpED6/n3U/FLFw2RbWbyuqt5Pb9Wfvx5jBvUiOYk08UsEau5ra\nRSQWKLhLVPkDAb7/oYgN24v47/KtpKclUVRWzdbcPafmTEnyct4JhnHDeoceLWuJpuaqbonwpnc1\ntYtIZ6fgLm2qusbHyvX5fPldDnZTQaO91wFGDEhn6qTBTBzVh57dkyM6R1PBO5K5qptLTe8iEksU\n3KXVvvl+F3PnraC6xt/gPiMG9OSQ8dnsNTyTAX274cGzx5zakarvvnc4BWIR6eoU3CVihSWVbNxR\njN8P324u4K3PNtW7X3ZGGuOGZTB5wgAGZ/Vo9RCpjQ0GIyIie1JwlybZTfk89tpKCkuqGtxncFZ3\nLv/xBAb06d6m5563dgELN30I7G5m1yNmIiKNU3CXWlasy+WmRz6mf2Y3ikqrKKusqbW9V/dkJozI\nZFBWD0orqjnxkKF0dydGiYZgjf2YoVPUzC4iEiEFd8HvD7D4m+08+Z/VoXXb88pIS/GGBorp2T2Z\ni0/di72HZ7ZbvuatXUBeRT6Zqb0V2EVEmkHBvYtbsnI7f319Va1144f15hfHj23zJvbmCtba1QQv\nItI8Cu5dUHWNj807S/nDc19Q49vdw/3so0fzk6PHUlbS9Kxp7UW1dhGR5lNw7yL8gQCfrd7B1+t2\n8cnK2mO2exM8PH7Dj/B4PHRPS+rQ4B7eM76xx91ERKRhCu5dwPdbi7jzmaV7rJ84qg+nHj6cUQM7\nLoDWfcwtfAAa9YoXEWkZBfc4V1ZRXSuwn3b4cMYOyWCvduwY15i6A9JoABoRkdZTcI9jxWVVXPPw\n/0LLf/u/qS0eFa61NOe5iEj7UXCPU35/gOv//HFo+e5LDm3XwN5Yc3s4Nb2LiLQ9Bfc4dOczS/l+\na1Fo+e5LD6Vf725teo7mTt6i5nYRkfaj4B5HAoEAF92zKLSc4PFw/dn7tnlgB03eIiLSmSm4x5GX\nPlgXen3+iYaj9hsU1fPpXrmISOek4B4n3vxkI2996szSdtaPRkUlsOsZdBGR2KDgHsMqq3w88OJX\nfLelsNb6Ew8ZGpXzhTfFqyOciEjnpeAeo3x+P5c/8N9a69JSvMy9dgoeT9v1iq+vtq6meBGRzk3B\nPcbkFpRz7z+/JKdg9xCxN/xsP0YPziApMaFNz1V3LnXV1kVEYoOCewz5v0cXk1tYe9z3Oy46mEFZ\nPdr8XOGBXXOpi4jEFgX3GLB+WxF3PbMMfyAQWnftWRPZZ2SfNm2CB3j2q5f5eOOy0HPqCuwiIrFH\nwb2T25pbyh1P7x4bfvrU0VHrMAfwyeYvKKgs1HPqIiIxTMG9E3vgxa/45vu80PLN5x3IyIE92yz9\n+kaZU6c5EZHYp+DeCeUXV3LrE59SWlETWveX2UeRlOhtk/SDQb2+8d77pGUwse+ENjmPiIh0DAX3\nTih8wpeDx2dz2eltG2yDz6vX1/SelZVOTk5xm55PRETal4J7JxEIBHhp0To++npraN11Z+/LhBF9\n2vQ889YuIK8in8zU3mp6FxGJUwruncQ36/N467NNoeVphw6NSmAPPt6m59VFROKXgnsn8eCLywEY\n0Kcbt114MIne6A1Io8fbRETim4J7B9u8s4TfPvlZaPk35x6owC4iIq3StlFEmqWsorpWYJ/104l0\nS237663g424K7CIiXYNq7h3oqoc+Cr1++Joj6ZGW1GZp153wJTO1twK7iEgXoeDeQX79+Ceh13Mu\nP6zVgb3ugDThz7BrwhcRka5Fwb0DPPDiV+zIKwPg2AMG07dXWqvTDJ9rHdDwsSIiXVjUg7sx5gHg\nUMAPXGutXRq27Urg50ANsNRae12089ORfH4/F8/5ILS81/DenHPc2FalGayxa9hYEREJimqHOmPM\nFGC0tXYyMBN4OGxbOjAbONxaOwXY2xhzcDTz09E+XL4t9HrUoJ7M/tmkVqcZHtjV9C4iIhD9mvsx\nwCsA1to1xpgMY0wPa20JUAVUAj2NMaVAGpDXcFKx75WPvgecAWrO+tHoVqWlGruIiDQk2o/C9Qdy\nwpZz3XVYayuB24HvgfXAp9batVHOT4f5fM1OisuqATj98BGtTk81dhERaUh7d6jzBF+4zfI3AaOB\nYmCRMWYfa+2Khg6OVdU1fh595RsA+vVOIzmp5bO7qcYuIiJNiXZw34pbU3cNBII3nscD66y1+QDG\nmI+AA4BGg3tWVnoUshld59/2duj1X39zHB6Pp5G9a3v2q5f5ZPMXoeWcMufORVa3TA4dsn9UyiMW\nyzgWqZyjT2UcfSrjzinawf0d4HfAX40x+wM/WGtL3W0bgPHGmBS3if5A4I2mEoy16Ui/3VxAXlEF\nAL/95UHk5pY06/iPNy5r9BG3ti4PTfnaPlTO0acyjj6VcftoyQVUVIO7tXaJMWaZMeZjwAdcaYw5\nHyiw1r5qjLkX+MAYUw0sttZ+3GiCMaayyscfnnNq3YdP6M+w/pF/QGp+FxGRlor6PXdr7U11Vq0I\n2/ZX4K/RzkNHqK7xcfkD/w0t/+IE06zj1WFORERaSiPURYE/EODS+3YH9htmTCKlBZ3oVGMXEZGW\n0KxwUfC7Jz8Pvb7ixxMYP6x3s46ft3ZBaGx4ERGR5lLNvQ0FAgEuumdRaPnas/Zl4qg+zU4nOAGM\nmuNFRKQlVHNvQ7MfWRx6/aNJg1oU2IM0RauIiLSUau5tZNuuUvKLKwG4+sx9mDQmq0XpBJvkM1Ob\n15QvIiISpJp7G7ntKec++4QRmS0O7KAmeRERaT0F9zbw0fKtVFX7AbjqjNYHZTXJi4hIayi4t1Jh\naRV/f3MNAGf9aFSrx41XL3kREWkt3XNvpWfftqHX0w4d1qI0gqPRBQO7muRFRKQ1FNxbwef388W3\nzoy2d8w8pMXpBEejqztuvIiISEsouLfCxyu2h14P7NOtRWmE947XaHQiItIWFNxb4aVFawH42TFj\nmjWNK6gpXkREokfBvYWWr82ltKIGgKP2Hdjs49UULyIi0aLg3kLzPvwegNRkLynJzeshr6Z4ERGJ\nJj0K1wIl5dVs3lkCwB9nHdHs4zVQjYiIRJOCewvM+uNHAPRISyIpsWXPtWugGhERiRYF92YqKa8O\nvW7N428iIiLRouDeTF+vywVgwshMenVP7uDciIiI7EnBvZk+WbUDgAnDMzs4JyIiIvVTcG+GGp+f\nb77PA+DQvfu3KA2NHy8iItGm4B6hQCDAJfd+EFpO75bUonTUU15ERKJNwT1Cz7/7Xej19Wfv1+wR\n6cKpp7yIiESTgnsEXl+8gYVfbAHgih9PYO8Rut8uIiKdl4J7EyqqapjvjkY3alBPDhyX3cE5EhER\naZyCexM++HJr6PVvzj2wVWmpM52IiLQHBfcmvPI/p9Y+66cTW52WOtOJiEh7UHBvQmKCU0Tjh/Vu\nVTrhk8WoM52IiESTgnsj8ooqKKusoUdaEilJLRtDPki1dhERaS+a8rURwdHoAoFAi9OYt3ZBrbnb\nVWsXEZFoU829EcvXOuPIX3b6hBanEQzsGSm9VGsXEZF2oZp7A/KLK/luSyEAQ/v1aFVaGSm9uGPy\nr9siWyIiIk1Szb0BLy1aC0ByUgLp3TT7m4iIxI6Igrsxpo8x5kD3dZe4IAjeb591ZusfgRMREWlP\nTQZqY8w6T9gGAAAgAElEQVQM4BPgKXfVXGPMRdHMVEfbuL049Lq1j8CJiIi0t0hq4dcB+wI57vJs\n4JKo5agTeGGhM0nMAWOzWjVBjIiISEeIJLgXWmvLggvW2nKgKnpZ6lj+QIBvNxcAMOPYMR2cGxER\nkeaLpLd8rjHmfCDNGLM/cDa7a/FxZ+Y9i0KvM3umtiqt8FHpRERE2kskNffLgIOAdOBvQBoQl/fc\nv1m/K/T6xp/v36q05q1dwMJNHwIalU5ERNpXJDX3E621V4WvMMZcBjwWnSx1nKffXAPAEfsMYOyQ\njFalFRxu9pihUzQqnYiItKsGg7sxZhKwPzDbGNMtbFMScCtxGNx3FVUC8Ivjx7YqHU0SIyIiHamx\nmnsF0A/IAI4MW+8HbohmpjpCZZUPgERvAsmaJEZERGJYg8HdWrsaWG2Med9a+0n4NmPMmVHPWTvL\nLaoAYECfbk3sGRnV2kVEpKNEcs99qzFmDtDXXU4BjgZejlquOoI789voQb06OCMiIiKtE0lv+WeB\nPOAwYBmQBZwbzUx1hNCkrhqzRkREYlwkwb3GWvsHYIe19s/AacCV0c1WB3Cju2K7iIjEukiCe5ox\nZjDgN8aMBKqB4VHNVQcI1tw9Cu8iIhLjIgnuc4BjgHuBr4BcYHE0M9URAgFV3UVEJD402aHOWvtK\n8LUxJhNIt9bmRzVXHUixXUREYl2DNXdjTIIx5lJjzFx32lestTVApTHmz+2Ww3YS2N0uLyIiEtMa\nq7nPBTKBJcBlxpi+wErgcWB+O+StQ7T2nrsmixERkY7WWHDfz1p7OIAx5glgI7ABONtauyzSExhj\nHgAOxRnZ7lpr7dKwbYOBF3CGtP3CWntFs99BGwm4XepaO327RqcTEZGO1liHutCc7dbaUsAChzQz\nsE8BRltrJwMzgYfr7HI/cK+19lDA5wb7DhFqlm8FjSkvIiKdQWPBvW64q7TW+pqZ/jHAKwDW2jVA\nhjGmB4AxxgMcAbzubr/aWrulmem3udbU3FVrFxGRzqCxZvmBxpgLw5YHhC9ba5+MIP3+wNKw5Vx3\n3Vqcke5KgIeMMfsDH1lrb4o4521s95NwrWuXV61dREQ6WmPBfQm1Z4P7JGw5AEQS3Ovy1Hk9CHgQ\n2AS8YYyZZq19s7EEsrLSW3DapuWVVQPQrVtyi87x7Fcvk1eRT1a3zKjlsb3Eev5jhco5+lTG0acy\n7pwamxXugjZIfytOTT1oILDNfZ0LbLDWbgAwxiwE9gYaDe45OcVtkK095eeXAVBeXtWic3y80emK\nMLHvhKjlsT1kZaXHdP5jhco5+lTG0acybh8tuYCKZIS61ngH+CmA2/T+g9s5D/f+/ffGmFHuvgfg\ndNrrEG0xcYya5EVEpDOIZMrXFrPWLjHGLDPGfAz4gCuNMecDBdbaV4H/Bzzldq5bYa19PZr5aVQb\n3XMXERHpaFEN7gD1dJJbEbZtHbXv63eYtnrOXUREpKM1GdyNMfsCTwA9rLXjjDG3AO9Yaz+Neu7a\nUUufc5+3dgFf7lxBQWUhGSm92jZTIiIiLRDJPfc/AReyuyPcv4AHopajDtbcmnt4YNfz7SIi0hlE\nEtyrrbVfBxestd8CNdHLUscItGLmmIyUXtwx+dfqTCciIp1CJMG9xhgzArfLmTFmGnE8d1rcvjER\nEekyIulQdz3wKmCMMYU4k8ecF81MdSR1qBMRkVgXSXCvstZONMZk4YwvXxTtTHWEtpg4RkREpDOI\npFn+dWPMZ8AMICXK+ekwiu0iIhIvmgzu1tqxwOU448AvNsYsMMacHfWctbOtuaUAeNQuLyIiMS6i\n4Wettcustb/CGXBmI/BsVHPVAZ5791sAEr2RBfd5axdwy+K7KagsjGa2REREmi2SQWwGAGcCZ+FM\n0/pPYK8o56td5RdXhl6feMjQiI7R8+0iItJZRdKhbinOwDXXW2uXNrVzLHr1f+sBmDSmL96EyOfS\nCT7fLiIi0pk0GNyNMQOstduAqbiD1hhjRga3W2u/j372oq/G5+fD5VsBmHbosA7OjYiISOs1VnO/\nHzgHeBunM3n4zegAMLK+g2LNe0u3hF6PHtT02PAaS15ERDq7BoO7tfYc9+VJ1trV4duMMYdFNVft\n6MVFawE460ejmtjTCewLN30IOHO36167iIh0Ro01y2cAfYAnjTHnsLvmngQ8DYyNfvaiq6Bkd0e6\now8Y3OT+X+50Zqs9ZugUjSMvIiKdVmPN8ocB/w/YD3g/bL0fp6k+5n21NheACSMySUnyRnRMZmpv\nBXYREenUGmuWfxN40xhzmbX2sXbMU7v553vfATBpbFYH50RERKTtNNYsf4G19u/AIGPM7XW3W2tv\njWrO2kFVjR+AQ8b36+CciIiItJ3GHur2u//XAL56/sW0nIJyADJ6JNMttenH/eetXUBeRX60syUi\nItJqjTXLP+3+f5sxJt1aW2yM6YfTke7j9spgtGzJKQFgQJ/uEe0f7EynHvIiItLZNTkcmzFmLjDd\nGJMJLAauAh6Ndsai7QubA8BB47MjPkad6UREJBZEMtbqJGvtE8B04Clr7dnA6OhmK/oWr9wOwOC+\nPTo4JyIiIm0rkuAefL79FOB193VMz+vu8/sJuBO4jxrUs2MzIyIi0sYiCe7fGmNWAenW2q+MMecB\neVHOV1QVl1UDkJWRqvnbRUQk7kQyK9xMYB9glbu8EngtajlqBxu2FQMwdkhGB+dERESk7UVSc08D\nTgX+bYx5FTgeqGz8kM7t/S+cyWKaM72riIhIrIgkuv0V6An8xX3dz/0/Zn2/tQiAg5vRU15ERCRW\nRNIs389aOyNseYEx5oMo5adddE9LpKyyhvHDend0VkRERNpcJDX37saYbsEFY0x3IDV6WYq+6ho/\n2b3T1JlORETiUiQ1978Aa4wxS93lA4Bbopel6CsoqWJQ38hGphMREYk1TQZ3a+2Txph3gf2BAHC1\ntfaHqOcsSsoqagAoLK3q4JyIiIhER6PB3RhzEjAO+J+19tX2yVJ0rdnkTP4ybmjkj8EFJ43JTNU9\nehER6fwavOdujPkd8BtgIPBXY8zP2ytT0bRxu/OMe2pKJHckHJo0RkREYkljHepOAI6y1s4GpgAX\ntE+Wois1xQvAhBGZzTpOk8aIiEisaCy4V1hrawCstYWAt32yFF01Nc409d1Tkzo4JyIiItHRWHAP\nNLEck4Ljyid6I3sMLni/XUREJFY0duN5L2PMMw0tW2vPi162oue9Zc7Qs6nJTd9zn7d2AQs3fQjo\nfruIiMSOxiLcr+osL4xmRtpLSrKXyiofQ/s1PY97sCPdMUOn6H67iIjEjAaDu7X26fbMSHuprPIx\nalDPiEenU0c6ERGJNV1qWrTgADZJ3i71tkVEpIvpUlFu3dbCiPdVRzoREYlVEQV3Y0wfY8yB7uuY\nvSD4dnMBACMG9mxyXw1cIyIisarJQG2MmQF8AjzlrpprjLkompmKlq/X7QJg7ODIhp7V/XYREYlF\nkdTCrwP2BXLc5dnAJVHLURRt3lkCwNghjQd3NcmLiEgsiyS4F1pry4IL1tpyIOamVCsprw69Tmti\nXHk1yYuISCyLZPaUXGPM+UCaMWZ/4Gx21+JjxmOvfgPAqEEN32+ft3YBX+5cQUFloZrkRUQkZkVS\nc78MOAhIB/4GpAEzo5mpaCgqdWrup04e0eA+wcCekdJLtXYREYlZTdbcrbUFwFXtkJeo2plfRvfU\nRCaO6tPofhkpvbhj8q/bKVciIiJtr8ngbozZTD2Txlhrh0YlR1GwZWcJVTV+0rtpJjgREYl/kdxz\nPyLsdTJwDE7TfESMMQ8AhwJ+4Fpr7dJ69rkbONRaOzXSdJtj1YY8APr0qj/b4ffaM1J6RSMLIiIi\n7SaSZvmNdVZ9Z4x5G3iwqWONMVOA0dbaycaYccCTwOQ6+4wHjiSKPfAXr9wOwAkHD6l3u+61i4hI\nPImkWf7oOquGAKMiTP8Y4BUAa+0aY0yGMaaHtbYkbJ/7gZuA30WYZrN5E5x+g6aR59t1r11EROJF\nJM3yt4S9DgBFOD3oI9EfCG+Gz3XXrQVwH7FbBNRtHWhT1TV+ALql6p67iIjEv0iC+/XW2i/a6Hyh\neVaNMb2BC3Bq90PCt7W1LTkl9OqeHK3kRUREOpVIgvt9QN2m+UhtxampBw0Etrmvjwb6Ah8BqcBI\nY8z91trrG0swKyu9WRkIBJyO/kVlVQ0e603wtCjteKVyaB8q5+hTGUefyrhziiS4bzLGfIAzeUyo\n05u19tYIjn0H5176X93R7X6w1pa6x78MvAxgjBkG/L2pwA6Qk1McwWl3KyipBGDCiD71Hjtv7QJy\nyvLITO3d7LTjUVZWusqhHaico09lHH0q4/bRkguoSIL7evdfs1lrlxhjlhljPgZ8wJXuffYCa+2r\nLUmzue56xrnlH9jzUX1A48iLiEj8aTC4G2N+bq19zlp7W2tOYK29qc6qFfXss5GWN/03aleRU3M/\ne+roBvfROPIiIhJPGhtbPibnbA+3I8+ZzC412cugrB4dnBsREZH2EcnEMTFr/kffAzC8vzp8iIhI\n19HYPffJxphN9az3AIFYGFt++y6n5n7GlPrH3Jm3dgF5FflkpvZuz2yJiIhEVWPB/UvgZ+2VkWgo\nLHM6948YWH/NXZ3pREQkHjUW3CvqGVc+ZlRW+SgsqaJHWlJo+Nn6qDOdiIjEm8buuX/WbrmIgk07\nnWcvgwPUiIiIdBUNBndr7a/aMyNtLbewAoBjDxzcwTkRERFpX3HbW76wxLnf7vPXP3hNsDOdiIhI\nvInb4P791kIARg7ouce2eWsXsHDTh4A604mISPyJ2+BeWlEDQGbP1D22BXvJHzN0ijrTiYhI3Inb\n4O53m+MH9OlWa334s+0K7CIiEo/iNrhv3VVKoteDx7O7t7ya40VEpCuIZFa4mFRcVr3HOjXHi4hI\nVxCXNffcgnIAeqen7LFNzfEiIhLv4jK4P/HGagBGDdzdU16PvomISFcRd8E9r6gCu7kAgKn7OwPY\n6F67iIh0JXEX3AtLncFrkhMTGD/Mme1N99pFRKQribvgXl3jB+C4g4bUWq977SIi0lXEXXAvdqd5\nTfLG3VsTERGJSNxFwK++y3VeuI+3qyOdiIh0NXEX3D+3OwE40GSrI52IiHRJcRXcA4EAVdXOPfc+\nvVLVkU5ERLqkuAruwSb5Xj2SSUnyAupIJyIiXU9cBfetu0oBmDS6bwfnREREpOPEVXDPL64E4JC9\n+nVwTkRERDpOXAX3r9ftAqB7WlIH50RERKTjxFVw31VYAcCgvt31CJyIiHRZcRXcM9xZ4DweT6in\nvB6BExGRriZugrs/ECC/uJJBWbtr7eopLyIiXVFiR2egrWzYVgxAScZyFm5aC6jWLiIiXVNcBHe/\nP8CdzywlccgaqnpvADRwjYiIdF1x0Sz//bYiALyZ2wEFdhER6driouaek18OQLeURLrpPruIiHRx\ncVFzLyytInHIGioo6eisiIiIdLi4CO4BAqEmeXWiExGRri4ugntBcRUA6Yk91SQvIiJdXlwE99zC\ncveVp0PzISIi0hnERXBPSnTehjdBwV1ERCQugvuaTQUAeBTbRURE4iO4p7uzwHkU3UVEROIjuFfX\n+ElQYBcREQHiILj7/QF2FpSr1i4iIuKK+eC+cYczYYzP7+/gnIiIiHQOMR/cq2ucoJ6aHBcj6YqI\niLRazAf3Gp8T3HXPXURExBHzwf3jFdsAPQYnIiISFPPBvaDEGXpWNXcRERFHzAf34Kh0yUkx/1ZE\nRETaRMxHxBqfn8Qha8ivLOjorIiIiHQKMR/cK6t9JGq6VxERkZCoPz9mjHkAOBTwA9daa5eGbZsK\n/B6oAay1dmZz01+/rZjUbA+Zqb013auIiAhRrrkbY6YAo621k4GZwMN1dnkMOMNaeyTQ0xhzYnPS\nDz7jDoFW51VERCReRLtZ/hjgFQBr7RogwxjTI2z7Adbabe7rHKBPcxIvLqsiccgaPCkVbZJZERGR\neBDt4N4fJ2gH5brrALDWlgAYYwYAxwH/aU7i5ZU1eHW/XUREpJb2HrN1j4fRjTHZwGvA5dba/KYS\nyMpKD71eu70EgORADy49bEbb5bKLCy9jiR6Vc/SpjKNPZdw5RTu4byWspg4MBILN8Bhj0nFq67+2\n1i6MJMGcnOLQ67Ub8wDnWffw9dJyWVnpKst2oHKOPpVx9KmM20dLLqCi3Sz/DvBTAGPM/sAP1trS\nsO0PAA9Ya99tSeLllTWAhp4VEREJF9Wau7V2iTFmmTHmY8AHXGmMOR8owAn8vwBGGWMuxuny/ry1\n9m+Rpr9hezGkQ2JCzD+uLyIi0maifs/dWntTnVUrwl6ntSbt4NCzCQmquouIiATFdJXX53eeb1ez\nvIiIyG4xHdyDc7krtouIiOwW08F99Ub3yTlV3UVEREJiOrh3S2nvx/RFREQ6v5gN7tU1fsoqa9RT\nXkREpI6YjYxlFdWApowRERGpK2aDe3BGuCSv7reLiIiEi9ngnl9S6bxQZzoREZFaYja4l1Y4Q88S\nUMO8iIhIuJgN7svX5gKQ6I3ZtyAiIhIVMRsZi0qrAA09KyIiUlfMBvegpMSYfwsiIiJtKmYj467C\nio7OgoiISKcUs8F9e14ZAB71lhcREaklJsdv9fn9+AesIjVzBwWVlWSk9OroLImIiHQaMVlzL6uo\nwZu5HU9yBRkpvZiUvU9HZ0lERKTTiMmae2h0ukA37pj86w7OjYiISOcSkzX3jduLOzoLIiIinVZM\nBvcvv3MGsPHqGXcREZE9xGRw//ibbQAkJ3k7OCciIiKdT0zecw8OJ6+hZ0UkXv3pTw9h7Wry8nZR\nXl7O4MFD6NmzJ3feOafJY998cwE9evTgyCN/VO/2uXMf4KyzZtC//4AW5++TTxazfPnnXHrpNQC8\n++5b3HXX73jttbfp2dN5gun3v7+NqVOP4bDDjggdd9ZZp/Hssy+yevVKbrnlRkaOHEUgEKCyspJD\nDjmMiy66FICCggIeeuheNm/eREKCh6FDh3PNNbPp2bMnAKtXr+TRR+dSXV1FdXUNhx9+JBdccHGz\n38c333zN3LkPkpSUxMSJ+3HJJVcA8OKLL/Duu28BcNJJp/KTn/y01nFr137H/fffjceTwKhRY7j+\n+l9RWFjAzTf/ipqaGm6++TYGDRqMz+fjuuuu5p57HiA1NZWXX34Rn8/H9Okzmp3X5oi54F5S7szj\nnqTALiJx7KqrrgWcQL1+/TquuOKaiI+dNu2URrdfffV1rcpbdXU1jz46l3nz/k1xsfOb/N57bzN4\n8BAWLVrI6aef0cjRu2+nTpp0AHfc8YfQ8jXXXMHXX3/FxIn7cccdt3LCCdM4/vhpAHzwwUJuumk2\nf/rT45SVlXL77bdw9933M3z4CHw+H7feeiMLFrzCKaf8uFnv5b77/sDtt/+eoUOHc889d/LNNyvI\nzMzkrbcW8MQT/8Dn8zFjxhmccMI0unXrHjru4Yfv59pr/w9jxnH77bfwySeL2bZtK6ed9hOys/vz\n+uuvcNllV/H66/M5/vgTSU1NBeDMM6dz6aUXcPTRx9G3b99m5bU5Yi64B8eUR7fbRaQL+vLLZbzw\nwj+oqCjnqquu5YsvlvLBB+8TCAQ47LDD+eUvZ/Lkk4/Tq1cGI0eO4uWXX8Tj8bBp0wamTj2WX/5y\nJldffSnXXfcrFi16j5KSYjZt2si2bVuZNet6DjnkMP7xj6dYuPAdBg4cRE1NDTNmnMt+++0fysOi\nRe9x4IEHkZqaSnFxNUVFRaxZs4obb7yV5557uong3rBx48azZctmMjIyKCkpDgV2gB/96Bjmz38Z\na9ewevVKpkyZyvDhIwDwer3cfPPtoQAa9MwzT/L555/i8XgIBAJ4PB6uv/5Ghg0bHtonL28XQ4c6\nywcddCiff/4JF1xwMY888gQej4fExERSUlIpLS0NBfeamhq2bduGMeMAmDz5CJYu/YxevXoxbNhw\n+vTpQ3FxEWVlZXz00Yfcf//DtfJ16qk/Zv78l7j44stbVE6RiLngXugG98QE1dxFpH28+P5aPl+z\ns03TPGhcNtOPHt2iY9evX8cLL8wjMTGRL79cxqOPOoHorLNOZ/r0c4Ddo3euWbOK559/GZ/Px1ln\nncYvfzmzVlo5OTncd9/DfPrpEl59dR7jx+/NvHkv8a9/vUJJSTE/+9lPmDHj3FrHLFv2OYcfPiW0\nvGjRe0yePIVDDjmMOXPuIjc3N6JaaSBsyu6ysjI++2wJxx13Ihs3bmDMmLF77D969Bg2btzApk0b\n2GuvCbW2paWl7bH/eeddyHnnXdhoHgYMGMjy5V+x77778fnnn5KY6ITF4IXCZ599QkZGBllZ2aFj\nCgoKSE9PDy337p3Jrl25jBkzli1bNlNZWUH//gN57rmnmT59Bn/84/1UVFRw/vkX0b9/f/bddxJv\nvPFak+XTGjEXIQtLK0kcsoZKT0lHZ0VEpEOMHj0mFIRSUlK48sqLufrqSykqKqCoqKjWvmPHjiM5\nObne4AcwceJ+AGRlZVNaWsIPP2xm9OgxJCUl0bt35h5BFCA3N5fs7N3B7t133+LYY48nISGBo446\nmvfff6eR3AcIjhr+1VdfMGvWZVx55cXMmPETpk8/h9Gjx+DxePD5/PUe6/V68Xg8+P31bW++G2+8\nhSeffJzrrruanj171rrg+OabFTzyyMP87nd3NZpGsFXgqKOO5tNPFzN//r85+OBD2br1B4qKChkz\nZiznnvtLnnnmCQCys7PJyWnbi8W6Yq7m7vMF8GZuB9DIdCLSLqYfPbrFtexoSExMAmD79u3885/P\n8/TTz5OSksp55529x75eb+NPFYVv3x3YIrnv6eyTk7OTVatW8qc/PQhAZWUlPXqkM336OWRkZFBc\nXLsi5vP5SElxasXh99wvu+xCRo1yynjo0OE8+eTje5zxu+++5eSTT6OkpJhVq76p1WxfWFhAeXkF\n/fv3D62LpFl+xIiR/PGPjwDw6qvzKCkpDp3r3nvvYs6ch+jbN6tWPjIyMigsLAgt5+TspG/fvqSm\npnLXXfcCcM89d3HRRZfy/vvvMmHCRLKz+7Ft29YIyrVtxFzNPfiMe/eEnpwxuvFOIyIi8aywsIDM\nzExSUlKxdg07dmynurqqVWn27z+A9eu/x+fzkZ+fz5o1q/fYp2/fvuTk7ACcWvuZZ07n739/nr//\n/Xmef/5lioqK2Lr1Bw444GDee+9tfD5faN999tm33vNeddW13H//PQAMHTqMvn2zeO21+aHtH3yw\nEK/Xy8iRozn++GksWfIxa9asApwOfvfeezfLln1WK83zzruQuXP/wsMPPxb6PzywA9x99+2sW7cW\nn8/H22//h8mTj8Tv9/OHP9zBnXfOoV+//tSVmJjIsGEjWLFiOQAffriIQw6ZHNr+3XeW7t27M3jw\nEDIzM9m+fRs7d+4INe3n5OTUauaPhpiruackOdcjXq961IlI1zZmzFhSU9O44oqZTJy4H6effgYP\nPHBPqKm9IcH78fXNqtm7dybHHns8F198PsOHj2CvvSaQUKeP0/77H8jy5V9xxhmnsnDhu9x88221\ntk+bdjILF77DuedewIYN33PllReTnJxMZmYfrrvu/+rN04QJExk0aDCvv/4Kp576Y2677W4efHAO\nr7zyMl5vAgMHDubWW+8EnPvr9933MHPm3EVVVRUJCQkcf/w0Tj75tIjLLuiUU07nrrt+h8fj4fjj\nT2TEiJF8/vknbN++lXvv/X2oxn/FFbMoLCxk27at/PjHZzJr1nWh7XvtNYEDDjgolOY//vEUs2ff\nBMCUKUfzm9/cwGuvzefaa28AnNsR++9/YLPz2hye8PsLMSBwxbNzyU1eRUZyBncdcVNH5yfuZGWl\nk5Oj4X2jTeUcfSrjlnvzzQUcd9yJeL1ezjvvbB588M+1mqarqqq45JJf8vLLL4UehZPIXXbZhdxx\nxx8irr1nZaU3uzYbc83yhYkbAZjYZ89OHiIi0nq7duVyySXnc/nlF3HCCSftcc85OTmZyy+/mvvu\nu6+Dchi75s17iaOPPjbqzfIxV3Of8dz1VPv83D/1VrqlxtxdhU5PtZ32oXKOPpVx9KmM20eXqLlX\nu49HJCXGXNZFRETaRUxFSJ9/dyuDgruIiEj9YipCVlbVAODV6HQiIiINiqkouSOvDIBEPQYnIiLS\noJjqkRYM7iIi8a41U74Gbd++jcLCQowZx0MP3cc555xLdna/Fufp448/Ytmyz5g163oAXnnlFW6+\n+WZef/1devToAcAdd9zCCSeczMEHHxo67owzTuZf/3qF5cu/5LbbbmbEiJGhaV4PO+zw0FSt+fl5\nPPTQvfzwww94PDB8+EiuuWZ2KO2VK7/hscfmUlNTTVVVNUceedQeY+VHYuHCd3nppRdISkoiO7sf\nN930W7xeL48//ghLl35GYmIiV1xxDRMm1B4F9bvvLA8+eC8JCQn06tWL3/72LkpLS7nlll/h9/u5\n+ebbQpPtXH/91cyZ8xApKSm8+OILeL1ezjxzeovKvSViKrhv31UKgDdBNXcRiW+tmfI1aOnST6mp\n8WHMOK69dnar8lNZWcnjjz/C448/FVr3xhtvMGjQYD74YCGnnHJ6ROkccMBBobHa/X4/s2ZdxsEH\nH8bee0/gtttu5pRTTufYY08AnCB8002zefjhxygtLeHOO2/lnnseZOjQYdTU1HDLLb/izTcXNDnF\nbV1z5z7AP/85n9TUVO6++3b+97//0q9ff77++isef/wpiooKufHG63nkkb/VOu6BB+Zw3XW/YsyY\nscyd+yBvvfUGVVWVnHHGdDIyMnjjjde4+OLLefXVl5k27RRSUlIAmD59BhdffD5HH30svXtnNiuv\nLRVTwX3Zmp2QBomay11EurBHH53LypUr8Pv9nHXWz5g69ViWLPmYJ598nJSUFPr2zeLKK6/hqaee\nIGg+g1cAAA+nSURBVDk5mX79+vHss09x44238Pbb/6GiopyNGzewbdtWrr32Bg466BCeeeZJFi16\nj0GDBlNVVcW5515Qa6jY999/l0MOOTQUsAoKCli9ejWzZ9/Eiy++EHFwD5eQkMC4cXuxZcsm0tLS\nqKysDAV2gGOOOY75819i7drvWL78S6ZOPZahQ4cBzhCwt9565x7TvD711N9YtuzzWuPJ33DDTQwZ\nMjS0T3p6OkVFhaSkpFBSUkyvXhls3rwJY8YD0LNnL1JTU8nNzan1jP/998+lW7dugDO+fFFRITU1\nNYwZY8jI6E1xcRGlpSUsWfIx991Xe5rXU045nfnz/82FF17S7HJqiZgK7nZjHoxTcBeR9jVv7QK+\n3LmiTdOclL1Pi+bH+OKLpeTn5/GnPz1OZWUlM2eeyxFHHMW8eS9y7bU3sPfeE/jvf98nKSmZE044\niezsfhx22BH84x9Ph9LIzc3lvvseZvHi//Haa/MZM8bw2mvz+ec/51NQUMCMGWdw7rkX1DrvsmWf\nM3XqsaHl999/l2OPPZZDD53MnDl3kZ+f1+xaaVlZKUuXfsZJJ53Kpk0bGDvW7LHP6NFjQ9O8hs8p\nD/VP8/rLX85ssqn+mmtmc/75M0hPT2f8+L3Zb7/9WbduLS+88A+qqqooKipi3brvyMvbVSu4BwN7\nWVkZ77zzJnfffT9ff/0VW7Zspri4iP79B/Lss09x9tk/56GH7qOyspILLphJdnY/9t13Evfdd3e7\nBfeYipJZvZ2CTVCzvIh0Ud988zUrVixn1qzLmD17FoEA5OXt4uijj+Oee+7gueeexpi9yMjIqHVc\n+IBl++47Cdg9zeuWLZsYM2YsiYmJ9O3bl/Hj99rjvLm5OXtM83ryySfj9XqZMmUq77//bqP5Do5j\nv2zZ58yadRlXXDGTGTPOZMaMXzBy5KhGp3lNTGy7aV7/f3v3Hl1VeeZx/JsQQmHEwDJklIvKQPvI\noGUAZdJIi1wKAUSLggKjqSgXhVWhOo5QL11FboMQtfaGbQcHRqmIAl4Qh1ItN5lZbXE5XSwepAIz\npaKQwBLrSgCT+WPvxJOQnFxIzsnZ/D5/5ey9z95PnrVznvPuvfM+ZWVlPP10IStWPM+aNRs4c+Y0\nu3btpEePnowadT2zZt3N8uU/omdPo6Y53j777DPmzLmP22+/k65du3HddUPYsWMbr7yynn79rubo\n0Y8oKjpGr15/z6RJt7Nq1bNAYtq8xkqpkfv/HjlJu0tU2EUksW7qeX2L6UKZkdGaG264iYkTb6uy\nfOTI68nNvZatW9/iwQdnV7Yercm5tnk9cuRD3PeyYMECzpz5nJKSEvbv38fNN98aXp4+e9a6iv7z\nFffcy8vLmT59Mj16fBkI2rxWFMJY77+/j7Fjx1NUVMSePX9k6NDhletOnDhBaWlJlc5tdV2WLy4u\nolWrjMrWsP37D2Dv3j3k5uYxbtwExo2bAMDUqQVV2scCnDlzhrlz72f06BsYPjwfgHbt/oaFC4Nc\nL1o0j7vuups339xIv35Xh21eD9cjr00vpUbuQI3fpEREzhe9e1/Jjh1bKS8vp6SkhKeeWgYERS0z\nszU33ngTgwYN4dChg6Snp1e2W43n4os7c+DAnygrK6O4uIh9+/aetU12dqfKkefmzZu45ZaJrF+/\nnhUrnmf16pcpKjrGRx8dCdu8bqocZW/a9Dp9+/Y7a39paWnMnDmLZcuCfu7du/8dF16Yxeuvv1K5\nzZYtm2nbti2XXXY5+fmj2Lbtt7gHsZ06dYolSxawe/fvq+z3jjumnNXmNfZ+e4cOHTlx4jiffPIJ\nAHv37qFbt0spLi7iwQe/C8D+/e+TkdGarKyqVz9Wrvw3BgzIZcSIUWf9Pnv37iErqwOdO3ehY8fk\ntHmNlVIjd9CT8iJyfuvTpy9XXdWH6dODe+Ljxt0KBJfY7733Htq3b09WVgduu+0OMjIyWLz4MbKy\nOsRt85qdnc2gQUPCNq+Xh21eW1XZJmjzupu8vIFs2bKZefMWVVmfnx+0eZ00qYCDBw8wY8YUMjMz\nyc7uVNnqtKbfJScnh40bX2XUqDHMn7+YwsIlvPTSGtLT0+nW7VIeeWQeEIyQly59iiVLFnL69GnS\n09PJzx9Nfv7oBuUvIyOD2bMf4IEHZpGZmUmXLl0ZPHgY6enpdO/egylTCmjVqhVz5z4KwDvvbOfY\nsWOMGfMt1q1bS7dul7Jr107S0tK45pp/rHw24bnnVjJnzsMADB48lIce+hfWrVtb2eI2EW1eY6VU\n45gx928o7zhgO+2+1JrH8uYmO5xIUiOIxFCem59y3DBvvPEaw4ePJC0tjYKCCTz99M+qPCBXWlrK\n9OmTeeaZZ8nMzASU44aYNu0OFi1aykUXZTf4vedF4xgREWl6R49+zNSpBcyYMYVRo8ac9eR7mzZt\nmDZtBsuX/zhJEaauF1/8FSNGjGxUYW+sFLwsr+8jIiJNraDgTgoK7oy7TV7eQPLyBiYoougYP35C\nwo+ZcpVS/wYnIiISX8oVdxEREYkv5Yq7xu0iIiLxNfs9dzMrBHKBMmC2u/8uZt0wYAFwBnjD3ec3\ndzwiIiJR16wjdzP7BtDT3fOAKcAPq23yFDAWGAgMN7Mr6typhu4iIiJxNfdl+aHAegAPphXqYGYX\nAJhZd6DI3f/i7uXAxnB7EREROQfNXdwvBo7GvD4WLqtp3cfAJfF21qbP25w8/UmTBigiIhI1iX6g\nLt5F9XpdcM/KzKJvzlVNFI6IiEj0NPcDdX/hi5E6QGfgw5h1sSP1LuGyWq0teEJ33BOgU6f2yQ7h\nvKA8Nz/luPkpxy1Tc4/c/xMYB2Bm/YDD7v5XAHc/BLQ3s0vNLAO4PtxeREREzkGzN44xs4XAIOBz\nYCbQDzjh7hvMbCCwBCgH1rr7E80ajIiIyHkgpbrCiYiISN1SboY6ERERiU/FXUREJGJU3EVERCKm\nxfZz15z0za+OHA8GFhLk2N19SnKiTG3xchyzzSIg190HJzq+KKjjPO4KrAZaA39w9xnJiTL11ZHn\nmcA/EXxe/M7d70tOlKnNzK4kmNW10N1/Um1dg+peixy5N8uc9FJFPXL8M+Amd/86cKGZ5Sc6xlRX\njxxjZr2ArxP8x4g0UD1yvAx43N1zgc/DYi8NFC/PZtYe+GfgWnf/BtDbzAYkJ9LUZWbtCPL661o2\naVDda5HFHc1Jnwi15jjU390rJhw6ClyU4PiioK4cQ1B8vpfowCIk3mdFGsEH4avh+u+4+5+TFWiK\ni3cunwJKCQYBGUBboDgpUaa2EmAkX0z0Vqkxda+lFvcmnZNeahQvx7j7pwBmdgnwTYKTSRombo7N\n7NvAW8ChBMcVJfFy3An4FHjSzLaFc25I49SaZ3cvBeYBHwAHgP9y9/0JjzDFuXtZmMuaNLjutdTi\nXt05z0kvdTorj2aWA7wC3OPuxxMfUuRU5tjMOgKTgcJwuc7jppFW7ecuwBMEE2n1NbORSYkqemLP\n5fYEV596At2BXDNTA5DmVefnRUst7k06J73UKF6OK/5gNwLfc/ctCY4tKuLleAiQDWwDXiYoPMsS\nG14kxMvxMeCgux909zJgC9A7wfFFRbw89wL+5O7H3f0MwTndP8HxRV2D615LLe6ak7751ZrjUCHB\nE5ubkxFcRMQ7j19y9yvDB5TGEjzJfX/yQk1Z8XL8OfCBmfUIt+0PeFKiTH3xPi8OAr3MrE34+mrg\n/YRHGC1VRuaNqXstdvpZzUnf/GrLMcFJUwy8Q3CSlQPPu/svkhRqyop3Hsdscxmwwt2HJCfK1FbH\nZ0UP4FmC8/h/3P2epAWa4urI81TgTuA0sNPd5yQv0tQUfmlaBlxGkMfDBLdFDzSm7rXY4i4iIiKN\n01Ivy4uIiEgjqbiLiIhEjIq7iIhIxKi4i4iIRIyKu4iISMSouIuIiERMi235KhI14f+zO7AzXFQx\nh8Bsd3+vlvd8H2jl7o+ew3EHARuAP4THbBP+PCuc6KUh+xoB9HP3RWb2NeBDdz9oZk8AK9199znE\n+X2CKXk/COPMAP4PmO7uJ+O87xLgCnd/q7HHFokaFXeRxPo4SZPVvBd7XDP7FTAd+Entbzmbu78J\nvBm+nAy8QDDF63ebKM6VsV9kzGwx8BAQb1KUwQRToKq4i4RU3EVaADMzYDnBzFQXAg/HTv1rZq2A\nXwJfJhjt73b375hZa+DHQA+gPbC6njM2bgeuCPc9GngE+CvwGTDN3T8MC+t1BO08DwPfBiYBw4CX\ngPHANWZ2H/AoMB9YBNzr7rvCfW8GlgJ7CL5ItAUuAB6qZ8+CncDUcF/XAv9K0BqzHTCDYEbFBeH6\nojAXjcmHSKTonrtIy3AxQUH/JjALqN6e9CpggLtf6+4DgXfD5j6zCOb5HgrkAhPN7Mp4BzKzLwFj\ngK1m1hb4OTA23McmYL6ZdSAonl9z90EEzW3+NtxFubuvB94F7ou5HF4O/AdB0a/oKngFwXTGPwWW\nuvsw4EbgF2YW9/MnnEN7El/cxsgG7g738UOCpkYHCaaXXeXuTzYmHyJRpJG7SGLlmNlvwp8r7rmP\nJ+iw9Xg4f3cmcFG19+0BjprZa8BrwBp3P2lmg4EuZnZduF0bgtabf6z2/q+Gx6045qvuvtbM+gBH\n3L2iw9fbBPe4T5jZJoIvAOuAF9z9cHCBoYrqrSdfILgqcD9wM/Ciu5eHcV5gZhXzXZcCOcCRau8v\nCOfQTgf6Ak8SjNYJt10WfjnJIuh/UF198yESaSruIolV4z13M1sNPOfu/25mvYFXY9e7+ylgkJn9\nA8Go+7/DIlgKzHP3l+s47ns1HZeg0FfvgV4eHvMWM/sKQQeqt83s5rp+OXf/yMw+MLNrgFuB2eGq\nEoKrA8fr2EXlPXcz2wAcCtu1AqwCprr7b8NbCTV10atvPkQiTZflRRKr+ki3Qg7B6ByCotgmdqWZ\n9TezAnd/190fA35PcP99e7g9ZpZuZsvCS+r1tQ/oZGZdw9fDgF1mdrmZzXb3fe5eCKwD+lR7bxnQ\nuoZ9PgfcBXR093fDZduBCWGc2eHT9XWZCfzAzDqHr3OAPeHzB+P5IkexcZxrPkQiQcVdJLFqa8NY\nCKwyszeAbUCxmT0es/1+YJyZbTezLQQPku0geHjspJntJLg3fdzdT9Q3GHcvISjEa8LL9kOAhwke\noOtrZrvM7NfA5QQP0cXaDCw3s29V+73WAROB52OWzQLGmtlWgtsKdT5M5+5/BhYDz4SLlhA8Eb8B\nWAF0M7N7CfI12cx+APwI+LSx+RCJCrV8FRERiRiN3EVERCJGxV1ERCRiVNxFREQiRsVdREQkYlTc\nRUREIkbFXUREJGJU3EVERCJGxV1ERCRi/h911jzQ0xU3FwAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x7f6f78c01390>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Plot ROC\n",
+    "plt.figure()\n",
+    "for label, metrics in ('Training', metrics_train), ('Testing', metrics_test):\n",
+    "    roc_df = metrics['roc_df']\n",
+    "    plt.plot(roc_df.fpr, roc_df.tpr,\n",
+    "        label='{} (AUROC = {:.1%})'.format(label, metrics['auroc']))\n",
+    "plt.xlim([0.0, 1.0])\n",
+    "plt.ylim([0.0, 1.05])\n",
+    "plt.xlabel('False Positive Rate')\n",
+    "plt.ylabel('True Positive Rate')\n",
+    "plt.title('Predicting TP53 mutation from gene expression (ROC curves)')\n",
+    "plt.legend(loc='lower right');"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## What are the classifier coefficients?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "coef_df = pd.DataFrame(best_clf.coef_.transpose(), index=X.columns[feature_mask], columns=['weight'])\n",
+    "coef_df['abs'] = coef_df['weight'].abs()\n",
+    "coef_df = coef_df.sort_values('abs', ascending=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'0.0% zero coefficients; 254 negative and 246 positive coefficients'"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "'{:.1%} zero coefficients; {:,} negative and {:,} positive coefficients'.format(\n",
+    "    (coef_df.weight == 0).mean(),\n",
+    "    (coef_df.weight < 0).sum(),\n",
+    "    (coef_df.weight > 0).sum()\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>weight</th>\n",
+       "      <th>abs</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>PVRL4</th>\n",
+       "      <td>-0.335244</td>\n",
+       "      <td>0.335244</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>FUT3</th>\n",
+       "      <td>0.291022</td>\n",
+       "      <td>0.291022</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>MMP7</th>\n",
+       "      <td>0.249358</td>\n",
+       "      <td>0.249358</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>HES2</th>\n",
+       "      <td>-0.244722</td>\n",
+       "      <td>0.244722</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>MLXIPL</th>\n",
+       "      <td>0.237639</td>\n",
+       "      <td>0.237639</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>GPR158</th>\n",
+       "      <td>0.236366</td>\n",
+       "      <td>0.236366</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>ATP10B</th>\n",
+       "      <td>0.232145</td>\n",
+       "      <td>0.232145</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>COL11A1</th>\n",
+       "      <td>0.216597</td>\n",
+       "      <td>0.216597</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>AFF3</th>\n",
+       "      <td>-0.214706</td>\n",
+       "      <td>0.214706</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>C9orf152</th>\n",
+       "      <td>0.195311</td>\n",
+       "      <td>0.195311</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "            weight       abs\n",
+       "PVRL4    -0.335244  0.335244\n",
+       "FUT3      0.291022  0.291022\n",
+       "MMP7      0.249358  0.249358\n",
+       "HES2     -0.244722  0.244722\n",
+       "MLXIPL    0.237639  0.237639\n",
+       "GPR158    0.236366  0.236366\n",
+       "ATP10B    0.232145  0.232145\n",
+       "COL11A1   0.216597  0.216597\n",
+       "AFF3     -0.214706  0.214706\n",
+       "C9orf152  0.195311  0.195311"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "coef_df.head(10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The results are not surprising. TP53 is a transcription modulator and when it mutated in a tumor, the cell goes haywire. This makes finding a transcriptional signature fairly easy. Also, the genes that the classifier uses is interesting, but not necessarily novel.\n",
+    "\n",
+    "1. TP53 is a [transcription factor](https://en.wikipedia.org/wiki/Transcription_factor \"TF wiki\") that regulates many genes including EDA2R. Studies have linked EDA2R (or XEDAR) to [increased survival in colon cancer patients](http://www.ncbi.nlm.nih.gov/pubmed/19543321) and [losing hair as a result of chemotherapy](http://onlinelibrary.wiley.com/doi/10.1016/j.febslet.2010.04.058/full)\n",
+    "2. SPATA18 is a gene associated with spermatogenesis and is a transcription factor for TP53. It's association with TP53 was [recently discovered](http://www.ncbi.nlm.nih.gov/pubmed/21300779) in 2011.\n",
+    "3. C6orf138 (or [PTCHD4](http://www.genecards.org/cgi-bin/carddisp.pl?gene=PTCHD4)) is also a transcriptional target for TP53 and was only recently discovered in [2014 to repress hedgehog signalling](http://www.ncbi.nlm.nih.gov/pmc/articles/PMC4239647/).\n",
+    "4. The list goes on and includes several other TP53 targets..."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Investigate the predictions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "predict_df = pd.DataFrame.from_items([\n",
+    "    ('sample_id', X.index),\n",
+    "    ('testing', X.index.isin(X_test.index).astype(int)),\n",
+    "    ('status', y),\n",
+    "    ('decision_function', pipeline.decision_function(X)),\n",
+    "    ('probability', pipeline.predict(X)),\n",
+    "])\n",
+    "predict_df['probability_str'] = predict_df['probability'].apply('{:.1%}'.format)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>sample_id</th>\n",
+       "      <th>testing</th>\n",
+       "      <th>status</th>\n",
+       "      <th>decision_function</th>\n",
+       "      <th>probability</th>\n",
+       "      <th>probability_str</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>sample_id</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>TCGA-B6-A0I1-01</th>\n",
+       "      <td>TCGA-B6-A0I1-01</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>3.975921</td>\n",
+       "      <td>1</td>\n",
+       "      <td>100.0%</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>TCGA-L5-A4OH-01</th>\n",
+       "      <td>TCGA-L5-A4OH-01</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>3.572769</td>\n",
+       "      <td>1</td>\n",
+       "      <td>100.0%</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>TCGA-49-6743-01</th>\n",
+       "      <td>TCGA-49-6743-01</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>3.558552</td>\n",
+       "      <td>1</td>\n",
+       "      <td>100.0%</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>TCGA-CV-5441-01</th>\n",
+       "      <td>TCGA-CV-5441-01</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>3.546549</td>\n",
+       "      <td>1</td>\n",
+       "      <td>100.0%</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>TCGA-AO-A1KR-01</th>\n",
+       "      <td>TCGA-AO-A1KR-01</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>3.192553</td>\n",
+       "      <td>1</td>\n",
+       "      <td>100.0%</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>TCGA-46-3765-01</th>\n",
+       "      <td>TCGA-46-3765-01</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>3.172224</td>\n",
+       "      <td>1</td>\n",
+       "      <td>100.0%</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>TCGA-61-1907-01</th>\n",
+       "      <td>TCGA-61-1907-01</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>3.072827</td>\n",
+       "      <td>1</td>\n",
+       "      <td>100.0%</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>TCGA-EW-A1P8-01</th>\n",
+       "      <td>TCGA-EW-A1P8-01</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>3.067012</td>\n",
+       "      <td>1</td>\n",
+       "      <td>100.0%</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>TCGA-AN-A0XU-01</th>\n",
+       "      <td>TCGA-AN-A0XU-01</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>3.041163</td>\n",
+       "      <td>1</td>\n",
+       "      <td>100.0%</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>TCGA-80-5611-01</th>\n",
+       "      <td>TCGA-80-5611-01</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2.997685</td>\n",
+       "      <td>1</td>\n",
+       "      <td>100.0%</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                       sample_id  testing  status  decision_function  \\\n",
+       "sample_id                                                              \n",
+       "TCGA-B6-A0I1-01  TCGA-B6-A0I1-01        0       0           3.975921   \n",
+       "TCGA-L5-A4OH-01  TCGA-L5-A4OH-01        0       0           3.572769   \n",
+       "TCGA-49-6743-01  TCGA-49-6743-01        1       0           3.558552   \n",
+       "TCGA-CV-5441-01  TCGA-CV-5441-01        1       0           3.546549   \n",
+       "TCGA-AO-A1KR-01  TCGA-AO-A1KR-01        0       0           3.192553   \n",
+       "TCGA-46-3765-01  TCGA-46-3765-01        0       0           3.172224   \n",
+       "TCGA-61-1907-01  TCGA-61-1907-01        0       0           3.072827   \n",
+       "TCGA-EW-A1P8-01  TCGA-EW-A1P8-01        0       0           3.067012   \n",
+       "TCGA-AN-A0XU-01  TCGA-AN-A0XU-01        0       0           3.041163   \n",
+       "TCGA-80-5611-01  TCGA-80-5611-01        0       0           2.997685   \n",
+       "\n",
+       "                 probability probability_str  \n",
+       "sample_id                                     \n",
+       "TCGA-B6-A0I1-01            1          100.0%  \n",
+       "TCGA-L5-A4OH-01            1          100.0%  \n",
+       "TCGA-49-6743-01            1          100.0%  \n",
+       "TCGA-CV-5441-01            1          100.0%  \n",
+       "TCGA-AO-A1KR-01            1          100.0%  \n",
+       "TCGA-46-3765-01            1          100.0%  \n",
+       "TCGA-61-1907-01            1          100.0%  \n",
+       "TCGA-EW-A1P8-01            1          100.0%  \n",
+       "TCGA-AN-A0XU-01            1          100.0%  \n",
+       "TCGA-80-5611-01            1          100.0%  "
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Top predictions amongst negatives (potential hidden responders)\n",
+    "predict_df.sort_values('decision_function', ascending=False).query(\"status == 0\").head(10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAeQAAAFmCAYAAAC81ukqAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAIABJREFUeJzs3Xd0VNXax/HvmZqeUEIooZcDUqSD9G7vHTs2vNxrb9j7\nVe+1l2tXFAVFEQuCKIJ0pHcOvQUSanomU98/kvCGJkMyM3vK81nLtTAzs88vZyU8nF01n8+HEEII\nIdQyqQ4ghBBCCCnIQgghRFiQgiyEEEKEASnIQgghRBiQgiyEEEKEASnIQgghRBiw+PMmXddfBXoC\nXuBuwzAWV3ptK7Cj/DUfcI1hGHuCkFUIIYSIWictyLqu9wNaGIbRS9f11sAnQK9Kb/EBZxmGURKk\njEIIIUTU86fLejAwCcAwjPVAmq7rSZVe18r/E0IIIUQV+VOQ6wL7Kv3//vKvVfaeruuzdV1/IWDJ\nhBBCiBhSlUldRz8NPw7cC/QH2uu6fkm1UwkhhBAxxp9JXbs58om4PnB40pZhGGMr/qzr+i9Ae2Di\niRrz+Xw+TZMebiGEEDHlpIXPn4I8DXgK+FDX9c5AlmEYRQC6rqcA3wDnG4bhouwpecLfJtI09u0r\n8OOyIj09We6VH+Q++Ufuk//kXvlH7pP/0tOTT/qekxZkwzDm67q+RNf1uYAHGKXr+g1ArmEYP+i6\nPhlYoOt6MbDMMIzvqhtcCCGEiDV+rUM2DOORo760qtJrbwFvBTKUEEIIEWtkpy4hhBAiDEhBFkIo\nlVeay5a8zapjCKGcFGQhhDI+n48bpgyn//ie7CzYoTqOEEpJQRZCKDNv9xzm7Z5DqaeUd5e/qTqO\nEEpJQRZCKPPK4pcASLOn8eXaz9lXvO8knxAieklBFkIosXDPAuZkzWJAw0E81P0xHB4HH6x8V3Us\nEQays/fQv38PtmzZdPhrU6b8zJQpP1e77eLiIhYtWgDA2LGfsWbN6mq3GShSkIUQSrxa/nR8b9eH\nGN7mOmrHp/PJ6g/JL81TnEyEgyZNmvLee28HvN3169fx118LAbj22htp27ZdwK9RVX6tQxZCiEBa\ne2ANM3ZOp3f9vvSsdwYAI08fxXMLnmLM2k/5V6e7FScUqul6G0pLHSxdupjOnbse/vrEiRP47bep\nmM1m+vbtz5VXXsO+fXt5/PGHsVqtnH56J1asWMZbb73P+PFjmTnzD3w+H2ec0Zsbb7yF1157meLi\nYho1asyqVSsYMGAwH330Hi+++Ap16mSQnZ3No48+wEcffc5LLz3Hnj27cbvd3Hzz7XTu3JUpU35m\n4sQJ2Gw2WrRoyT33PBiw71kKshAi5JbmLAbg0lZXHP7atafdwHMLnmLWzhlSkMNE4lOPYf9p0onf\nYNKo6fWdUpul519E0VPP+fXe224bxbPPPsF7730ClM3KnzlzOv/738cA3HHHCAYOHMI334xj0KCh\nXHHF1bz77ptUnJegaRr/+9/HaJrG5ZdfyBVXDGf48OvZunUz559/EatWrUDToH//gcydO5uLL76M\nOXNmMmDAYKZNm0Lt2uk8/PDj5OXlcueddzBmzDjGj/+S//73DdLT6zBlys84nU5sNtsp3YMTkYIs\nhAi5DYcMAPSarQ9/rWZcLRolN2bNgVX4fD7kEBrRoEEmut6a6dOnAXDo0EF27drJnXeOxOfzUVLi\nYM+ePWzfvpUhQ4YB0KdPP9avXwuA3W5n1KhbMZvN5Ofnkp+ff9zr9Os3kHfeeZ2LL76M2bNn8cAD\noxk//ktWrVrOypXL8fl8uFxO3G43Q4eeyejR9zNs2NkMHXpmwIoxSEEWQiiw4dB6AFrV0I/4erva\nHfhl609kF+2hXlJ9FdFEJUVPPfe3T7Pp6ckcDPLhEjfeeAv33vtPLr30CqxWK7169eH++0cf8Z4v\nvvChaWVToir+IZednc348V8xZsxX2O1xXH/9lSe8RtOmzdi/fz979+ZQVFRIZmZDrFYr118/gsGD\nhx3x3muvvZFhw85mxozfufPOkbzzzkekpKQE5HuVSV1CiJDbcNAgI6Euqfa0I77ePr0DAKv2r1AR\nS4ShGjVq0rfvACZNmkhxcTFLly6mtNSBz+fjjTdewel00qBB5uGn4gUL5gGQl5dLzZo1sdvjMIz1\n5ORk43I50TQNj8dzzHXOOKM3H3zwLn369APgtNPaMmvWTKDsyfz999/B5/PxwQfvUrNmLa688hra\ntetATs6eY9qqKinIQoiQKnQVsqtwJ60qdVdXaFe7rCCv3r/qmNdE7Lr66uvYty+HjIy6XHHF1Ywa\ndRsjR46gVq1a2Gw2Lr/8an744TvuuWcUACaTiVatdOLi4vnHP25hxozfufDCS3j11ZfQ9TZMn/4b\n48ePPeIa/fsP5Pfff2XgwCEADBo0lISERO64YwQPP3wfHTt2RtM0EhISGDlyBHff/Q80TaNlS/2Y\nvFWl+XynNiAfAD45P9M/ctaof+Q++Sdc7tPyvUsZ9u0Abml/Oy/0/c8Rr+0uzKLj5204t9kFfHrW\n2BO0EHzhcq/CXbjcp61bt1BUVEi7dh34/fdfWbZsCQ88cPQhhWqlpyefdFKEjCELIULKOFgxfnzs\nE3K9xPrUiqvFqv0rQx1LRLCEhAT+858X0DQNk8nEI488qTpSlUhBFkKE1PFmWFfQNI22tTswa9cM\n8kpzjxljFuJ4MjLq8u67H6mOUW0yhiyECKmKGdYtaxx/7K19+Tjymv3hs6WhEKEgBVkIEVIbDhnU\niqtF7fjax31dZlqLWCUFWQgRMiXuErbnbzvuDOsK7WrJTGsRm6QgCyFCZnPuJrw+73EndFVontaC\nBEuCTOwSMUcKshAiZDaWT+hqVaPVCd9jNplpU6stGw6tp9RTGqpoIoxkZ+9h2LD+3HnnSP75z7I1\nxxWbdPjj4MED/Pe//wZgxYpl5ObmAjB69P3BiBswMstaCBEyxqETL3mqrF3tDizJWcSGQ8bhSV4i\ntjRu3Jg333wPgPz8fEaMuIaePXv5tXd0zZq1Dm+vOXnyj1x11bWkpaXx73//N6iZq0sKshAiZDYc\nPPGSp8papLUAYEvuJinIgpSUFGrVqs26dWsZM+YjXC4XJpOZ0aMfp3btdJ599nEOHDiAy+Xi5ptv\np1Gjxjz22EPcfvsoZs2aydatW3juuZe4+eZreeON93jzzVd4443/AfDppx+SkpJCly7dee21l8t3\n40rk0UefxG6PO6bt7t17Bu37lIIshAiZTbkbSLalkJFQ92/f1/xwQd4ciljiBJ6a9xg/bT7x8Ysm\nk4b3FI9fPL/5RTzV6+THL1beRHLPnt3k5eUxZcpPnHfeRQwaNISZM6fz8cfvc/nlV5Gbm8fbb39A\nUVEh8+fPBUDToFu3HrRs2Yr77nuYjIy6gEbz5i04cGA/RUWFJCYmMWfOLF566TWeffYJHnzwURo0\nyOT777/lu+++oWfPXsdtO1ikIAshQiarMIvMpIYnPVqxWWpzADbnbQpFLBGGduzYzp13jsTr9WK3\nx/H448/w8svPc/vt/wSgc+eufPbZxzRu3JSSkmKee+5J+vYdwJAhZ5KdfeSBD0dvEd2rVx8WLJhP\nu3btsdvt1K5dm3Xr1vDSS8/h8/lwu120adOWxo2bHNN2MElBFkKERIEznwJnPvX9OFaxYXJjLCaL\nPCEr9lSv5/72aTaYe1lXHkOuYDJpQFlxLeu21rDb7XzwwWesWrWCX375mXnzZnPTTbf+bdv9+g1i\n4sRvyM09xIABgwCIj4875nrAMW2PHv1EYL7B45BZ1kKIkNhTWPbUUj8p86TvtZqtNE5pwhZ5Qo5Z\nxzv3qHXrtixZsgiAZcuWoOunsXGjwbRpU2jf/nTuu+8htm/fdsRnTCZTpeMWyxpt164927ZtYcGC\nuQwYMBiA5s1bHT66cfr0aSxdupgNG9b/bduBJk/IQoiQyCrcBeDXEzKUdVv/lruJQ46D1IirGcxo\nIgwdb1Tj5ptv58UXn+GnnyZhtVp5+OEnsNvtvPfeO/zww0TMZjPDh19/xGc6duzMY489VD7D+v8b\nbdeuAxs3bqBOnQwA7rrrPl5++Xm+/HIMdrudJ598HoD333/3cNtXX31d0L5fkOMXw1q4HG0W7uQ+\n+Uf1ffpq3RfcPWMUbwx8l6vbXHvS9z8+dzTvr3iHKZdOp0tGtxAk/H+q71WkkPvkP3+OX5QuayFE\nSOwuzAKg3ik8IYPMtBaxQwqyECIk9hTtBqB+YgO/3l+x9ElmWotYIQVZCBESVRlDBtgqT8giRkhB\nFkKExJ7C3aTYUkmyJfv1/vpJDYgzx7E5TwqyiA1SkIUQIbG7aLffT8cAJs1E09RmbM7ddMzGDkJE\nIynIQoigK3QVkleaS71E/wsyQLO0FhS5CtlbsjdIyYQIH1KQhRBBt6ewbEJXAz82Bans/2day8Qu\nEf2kIAshgu5UlzxVkEMmRCyRgiyECLpTXfJUQQ6ZELFECrIQIuiq+oTcTJ6QRQyRgiyECLqs8oJc\nP+nUnpDT49NJsibLIRMiJkhBFkIE3Z7ygtzgFAuypmk0T2vB1rwteH3eYEQTImxIQRZCBN3uot0k\nWZNJtqWc8mebpTaj1FN6eKcvIaKVFGQhRNDtKcw6pU1BKpNxZBErpCALIYKq2FXModJDp7wpSAU5\nZELECinIQoig2lNUMX58apuCVJBDJkSskIIshAiq3eW7dJ3qkqcKh9ciy25dIspJQRZCBNXhNchV\n7LJOi6tBrbhabJFTn0SUk4IshAiq7KI9ANRLrFflNpqltWB7/jZcHlegYgkRdqQgCyGCKqc4G4C6\n1SnIqc3x+DzsLNgeqFhChB0pyEKIoMopzgGgTmLdKrdxeKa1jCOLKCYFWQgRVDlF2Zg0E7Xjale5\njcPHMMo4sohiUpCFEEGVXZxNenwdzCZzldtoJk/IIgZIQRZCBI3P52NvUXa1xo8BmqY2A2BL3pZA\nxBIiLFn8eZOu668CPQEvcLdhGIuP855/Az0NwxgY2IhCiEiV78zD4XGQkZBRrXYSrYnUS6zPFnlC\nFlHspE/Iuq73A1oYhtELuAV48zjvaQP0BXwBTyiEiFjZRWUzrDOqMaGrQrPU5mQV7qLEXVLttoQI\nR/50WQ8GJgEYhrEeSNN1Pemo97wCPBLgbEKICFex5CkjIQAFOa0FPnxsy9ta7baECEf+FOS6wL5K\n/7+//GsA6Lp+AzADkAWCQogj5ATwCbli6dOm3I3VbkuIcOTXGPJRtIo/6LpeA7iJsqfohpVf+zvp\n6clVuGxsknvlH7lP/gn1fSrakAtAq3pNq33tHk07wzzY6dgcku9Dfqb8I/cpcPwpyLup9EQM1Af2\nlP95EFAbmA3EAc10XX/FMIz7/q7BffsKqhA19qSnJ8u98oPcJ/+ouE+b924DIM6VUu1r1zM3AWDJ\nruVB/z7kZ8o/cp/8588/XPzpsp4GXAag63pnIMswjCIAwzC+MwyjXfmEr4uBpScrxkKI2BGIbTMr\n1EusT6o9jfUH1la7LSHC0UkLsmEY84Eluq7PBV4HRum6foOu6xcGPZ0QIqLlFOegoZGeUKfabWma\nRuuabdiStxmH2xGAdEKEF7/GkA3DOHoG9arjvGc7ZV3YQggBlE3qqhVfG4upKtNVjtW65mks3DOf\nTbkbaVe7fUDaFCJcyE5dQoigyQ7ALl2Vta7ZBoB1B9YErE0hwoUUZCFEUBQ6Cyh2F1V7l67K2tQ8\nDYD1B9cFrE0hwoUUZCFEUARyU5AKrWuVPSGvPygTu0T0kYIshAiKnKKyc5AzEgP3hFwzrhYZCXXl\nCVlEJSnIQoigyC4u264gI4BjyFA2jryzYAcFzvyAtiuEalKQhRBBcfgJOYBd1gCta8k4sohOUpCF\nEEHx/2PIgeuyBpnYJaKXFGQhRFBkF5V1WQdy2RNUKsiyY5eIMlKQhRBBsbe4rMu6ToCfkFvVbA3I\nE7KIPlKQhRBBkVOUTc24mtjMtoC2m2hNpGlqM1buX4HX5w1o20KoJAVZCBEUOcU5AZ/QVaFrRnfy\nSnPZcMgISvtCqCAFWQgRcMWuYvKdeWQkBqcg96h3BgB/7VkQlPaFUEEKshAi4IKxS1dl3ev1BOCv\nbCnIInpIQRZCBFxOcXDWIFdoVUMnzZ7Gwj3zg9K+ECpIQRZCBNzeorIn5LpB6rI2aSa61e3B9vxt\n5JRfS4hIJwVZCBFwFWuQgzWGDJXGkaXbWkQJKchCiIDLObwGOXgFuXvd8nFkmdglooQUZCECoaQE\n+3ffkPjUY2j5earTKBesbTMr61inMzaTTcaRRdSwqA4gRCTTDh4g8d/PYf/+W0zlhVhzlFD44iuK\nk6mVXT6uG8wu6zhLHB3SO7Js7xKKXEUkWhODdi0hQkGekIWohqSH7iN+zMf4EhIovus+3C1aEvfZ\nx5hXrVQdTam9xdmk2tOIt8QH9To96p2Bx+dhac7ioF5HiFCQgixEFZnXriHuh4m4Tu/EwaVrKHr0\nSQpf+A+a10vyw/eBN3a3dcwpyg5qd3WFM+r3AmDGzulBv5YQwSYFWYgqSvzPvwEofugRsJSN/rgG\nDKL0vAuxLlqI/ZtxKuMpU+op5VDpITICfMrT8fTLHEiyLYVJG7+Tfa1FxJOCLEQVmFetxD75R1xd\nuuIcPOyI1wqfeQFfQgJJzzwRkxO8KtYFh+IJOc4SxzlNz2NX4U4WZf8V9OsJEUxSkIWogoqn46IH\nHwVNO+I1b2ZDikfdhWn/PuyTJqqIp1Swt8082iUtLwdg4sZvQnI9IYJFCrIQp8iyYhn2qZNxde+J\na8Cg476n9NKyImGbEXtjmzlF5dtmJgb/CRmgb2Z/asen89PmSbi97pBcU4hgkIIsxCmKf/9dAIoe\nGH3M03EFT9PmeBo3wTprJrhcIUynXsUTct2E4I8hA1hMFi5ofhH7S/Yza9fMkFxTiGCQgizEKdAK\n8rFP/hF302a4+g34mzdqOAcNwVSQj3XJopDlCwc5IViDfLRLWl4BwMSNE0J2TSECTQqyEKfA/tMP\naCUllF5x9Qmfjis4Bw0FwPrH76GIFjZCsUvX0brV7U7D5EZM3vITBx0HQnZdIQJJCrIQp8D+9VcA\nOC6/6qTvdfbui89qxRajBblOCJ+QNU3j1g4jKXIV8uril0N2XSECSQqyEH4ybd+Gbf5cnH364W3U\n+OQfSErC1bMX1pXL0fbuDX7AMJFdlE2SNZkka1JIr3tTu1tpnNKET1Z/yJbcTSG9thCBIAVZCD/F\nlW/04bjiar8/U9FtbZsZO7Ot9xZnh2yGdWV2s50nzngGt9fNcwueDvn1haguKchC+MPrJe7rcfgS\nEik970K/P+YcNAQgZrqtXR4X+0v2h2yG9dHOa3YhXTO68/OWH1ggp0CJCCMFWQg/WBfOx7xjG6Xn\nXQBJ/nfFelq3wVOvPraZ08HjCV7AMLGvpKxrXsUTMpSNJT/d+3kA/vn7bTLBS0QUKchC+OHwZK4r\nh5/aByuWPx08iGXl8iAkCy/ZRXsAqBOiXbqOp1vdHtzf9WF2FGzntmkjZLMQETGkIAtxMsXF2H+c\nhCezIa7efU/5466+/QGwLoj+LtSc4vJduhQWZID7uz3MsMZnMWvXDJ6X8WQRIaQgC3ES9l9+wlRY\ngOOKq8B06r8yrs5dAbAsi/4zeys2BakbwiVPx2PSTLw75EOap7XgneVvMGnjd0rzCOEPKchCnERc\neXd16SnMrq7M27gJ3po1sS5dGshYYenwpiCKCzJAij2Vz876ikRrEnfPGMWa/atVRxLib0lBFuJv\nmLJ2YZ01E1e3HniatahaI5qGq1MXzDu2oe3fH9iAYWZ3YRYA9RPrK05SRq/ZmrcHv0+xu5gbpw7n\nkOOg6khCnJAUZCH+hv3br9F8vlOfzHUUd6cuAFiXLwlErLC1q3AXAPWSGihO8v/ObXY+93Z5gO35\n27h35p2q4whxQlKQhTgRn4+4r7/CZ7dTeuHF1WrK3bmsIFuWRndBzirYSe34dOIt8aqjHOGBbo/Q\no94ZTN7yI9O3T1MdR4jjkoIsxAlYli7Gsmkjpeechy81rVptuTqVTeyyLo3eiV0+n4/dhVlkJmWq\njnIMs8nMi31fwayZGT37ARxuh+pIQhxDCrIQJxD3xWdAFdYeH4evVi08jZtgWbYEfL5qtxeODjgO\n4PA4qB+GBRmgbe123NL+drblb+Xd5W+qjiPEMaQgC3Ecpp07iPtmHO4WLXH1HxSQNl2du2A6dAjT\ntq0BaS/cZBXsBCAzOTwLMsAD3UZTJyGD15f8l6yCXarjCHEEKchCHEfCm6+hud0U330/mM0BafPw\nxK5l0TmOXDGhq0FSQ8VJTizFnsro7o/j8Dj4ePUHquMIcQQpyEIcxbQ7i7hxX+Bp0pTSSy4PWLsV\n48iWKC3IkfCEDHBpqyuoHV+bsWs/o8hVpDqOEIdJQRbiKPFvv47mdJY9HVssAWvX3b4DPrMZa5TO\ntM6qWIMcRkuejifOEsf1bUeQW5rLtxu+Vh1HiMOkIAtRiZaTQ/zYMXgaNsJx+VWBbTwhAXebtlhW\nrQCXK7Bth4Gs8i7rzDDusq5wU9tbsJgsfLTyPXxROslORB4pyEJUkvjSc2gOB8V33gtWa8Dbd3fu\niuZwYFm3JuBtq5ZVuBOryUp6Qh3VUU4qI7EuFzS/GOPQev7cNUN1HCEAKchCHGYfN5b4sWNwn9YO\nx1XXBOUa7k6dAbAsi759rbMKs6if1ACTFhl/rdzW4Q4APl71vuIkQpSJjN8cIYLMsnwpyQ/egzc1\njbzPvgS7PSjXcZ3eqex6UXY2stPjJKcomwZhugb5eDpndKV97dOZvuM32eNahAUpyCLmafv3k3LT\nteB0kv/+x3ibNA3atTx6a3x2O5YV0VWQ9xTtxocvogoywIUtLsHtdTNl62TVUYSQgiximM+H7adJ\n1BjaD3PWLooffgzXoKHBvabVirttu7Ix5NLS4F4rhCo22Qj3JU9Hu6D5RQD8sGmi4iRCgF9rOnRd\nfxXoCXiBuw3DWFzptVuBEYAbWGEYxj+DEVSIgPD5MO3ZjWXVSuI/+B+22TPx2WwU3fsgxXfdF5II\n7g4dsS5dgmXdGtwdO4fkmsGWFQGbghxPk9SmnJ7eidlZf3LQcYCacbVURxIx7KQFWdf1fkALwzB6\n6breGvgE6FX+WjxwBdDbMAyvruvTdV3vaRjGgqCmFsIfJSXYpv+GdfFfmHbvwpyVhXnLJkwHDhx+\nS+ngoRQ9/1LVzzquAnfFOPKK5VFYkMN7DfLxnN/8IlbsW8aULZO55rTrVccRMcyfJ+TBwCQAwzDW\n67qeput6kmEYhYZhlABDAXRdTwBSgOygpRXCD5YVy8qefqdMxlRYcPjrPrMZb2ZDSnv2xt2+A66e\nvXCd0Rs0LaT5XB06luWMooldu8q7rBskR9YTMpR1Wz+34El+2DxRCrJQyp+CXBeofGbc/vKvbar4\ngq7rDwF3Aq8bhrEtkAGFOBVxn39K0uj70VwuPA0bUXzTLTiHnomnUWO8GXUDti91dXhat4m6iV1Z\nhWXbZkbiE3KT1KZ0TO/E7F3SbS3UqsqkrmMeJwzDeAloBpyt6/oZ1U4lxKkqLSXpvrtIvv8ufMnJ\n5I39moOLV1H0+NO4evbCW79BWBRjICondu0uzCLFlkqyLUV1lCo5v8XFeHwepm79RXUUEcP8eULe\nTdkTcYX6wB4AXddrAO0Mw5htGEaprutTgN7A/L9rMD09uYpxY4/cKz94vaTfeh1MnQodO2L6/ntS\nmzRRnerv9egOS5eQnrMdunQJ2WWD9fOUVbSLxmmNI/bndXjny3l2/hPMyZnBXf3+Acjvnr/kPgWO\nPwV5GvAU8KGu652BLMMwKo5IsQKf6bre3jCMYqA78PnJGty3r+BkbxGU/aDLvTq59I/ehqlTcQ4c\nTN6nX0JCAoT5fYtr1ZZkoGDmXByNWoXkmsH6ecovzSO/NJ+MuHoR+/Na01efhsmNmLbpN/bkHKJe\nRo2I/V5CSf6O8p8//3A5aZe1YRjzgSW6rs8FXgdG6bp+g67rFxqGsRd4GphZ/vo+wzB+qmZuIfxm\n+WshPP44nnr1yX/3o7JiHAEOT+yKgnHkbflbAWic2kRtkGrQNI1BjYaS78xjcfZfquOIGOXXOmTD\nMB456kurKr32OX48FQsRaFruIVJGjgCfj4L/fYSvVuRMxjk8sSsKZlpvyd0MQLPU5oqTVM/gRkMZ\ns+Zj/tjxO+effqbqOCIGyU5dImIlPXgP5l074YkncPXqozrOqbFacZ/Wtmxil9OpOk21bM3bAkR+\nQe6T2Q+bycb0Hb+pjiJilBRkEZEsSxcTN2kirs5d4LHHVMepEneHTmhOJ5b1a1VHqZYteWVPyE1T\nmylOUj1J1iR61O/Fqv0ryC6U7RRE6ElBFhEp8YVnASh6/JnwWc50itwdy3fsivCjGLfkbcasmWmY\n3Fh1lGob3KhsL/Opm6YqTiJikRRkEXGsc2ZhmzUDZ/+BuHr3VR2nylydypY7WZYtUZykerbmbaFh\nciOsZqvqKNUmBVmoJAVZRBafj8QXngGgaPTjisNUj0dvjTcxCeuSRaqjVFmBM5/9JftolhbZ48cV\nWtXQyUxqyLTN0/B4ParjiBgjBVlEFNvvv2Jd/BelZ5+Hu3NX1XGqx2zG3bET5g0GWkG+6jRVUjGh\nK9LHjytomkb/hgM55DjEqv0rVMcRMUYKsogcPh8JL/8bn6ZR9HBkTuQ6mrtLNzSfL2LHkaNlyVNl\n/TIHADBr10ylOUTskYIsIoZlySKsK5bhPPs8PG1OUx0nIFzlT/mR2m0dbU/IAH0a9Adg1q4/FScR\nsUYKsogY8Z9+BEDJiFsVJwkcd5eygmxZuvgk7wxPFUueoukJOT0hnQ4ZHfhrz3wcbofqOCKGSEEW\nEUE7cAD7DxNxt2iJq29/1XECxptRF0+DTKxLFoPPpzrOKduatyVqljxVNqTpEBweB4uyF6qOImKI\nFGQREeK++gLN6cRx482gHXMCaERzdemGaf8+TDu2q45yyrbkbY6aJU+VDW42GJBxZBFaUpBF+PN4\niB/zCb766V7HAAAgAElEQVT4eBxXDledJuAqZotbI6zbOtqWPFXWr3E/LCYLs3bNUB1FxBApyCLs\n2Wb8jnnHNhyXXoEvNU11nICrmNgVaePI0Tihq0KSLYmuGd1ZsW85uY5DquOIGCEFWYS9uPLJXI4b\nb1acJDjcHU7HZzZjXRxZM62jcclTZX0z++P1eZm7e47qKCJGSEEWYU3buxfb9N9wdeyEu/wM4aiT\nkIC7bXssq1dG1MlP0fyEDNAvcyCAdFuLkJGCLMKa/ceJaF4vpZddqTpKULk7d0ErLcWyZtXJ3xwm\nonHJU2Wd63Qh0ZrEbFmPLEJECrIIa3HfTcBnMlF64SWqowSVq0s3AKyLImeZzfqD67Cb7TRKaaI6\nSlBYzVZ61e/NptyN7C7MUh1HxAApyCJsmbZtxbpkEa4+/fFm1FUdJ6hcPXsBYJ0/T3ES/7i9boyD\n69BrtsFisqiOEzSyjaYIJSnIImzFff8tAI5LL1ecJPi8jRrjyWyIdf4c8HpVxzmprXlbcHgcnFar\nreooQdVXCrIIISnIIjz5fNgnTsBnt+M893zVaYJP03D16oPp4EHM69epTnNSaw+sBoj6gtym5mnU\njk9n1q6Z+CJwJzURWaQgi7BkXrsGi7Ee55Az8aWkqo4TEs7efQGwzputOMnJrTuwBoA2NaO7IGua\nRr/M/uwtzmHDIUN1HBHlpCCLsBQ3cQIAjkuiv7u6gqtXHwBsc8N/3eva8oJ8Wq12ipMEnyx/EqEi\nBVmEH58P+6Tv8CYl4xwyTHWakPE2boKnYaOIGEdee2AN6fF1SE9IVx0l6GRilwgVKcgi7FhWrcC8\ncwfOM8+G+HjVcUIqEsaRC5z57CjYHvXjxxUykxvSNLUZc7Pm4Pa6VccRUUwKsgg7tl9+BqD0nPMU\nJwm9SBhHXneg7B8LbWKkIENZt3Whq4Ble5eojiKimBRkEXbsUybjs9txDRysOkrIRcI4cqzMsK6s\nX2bZGdyya5cIJinIIqyYtm3Fsm4Nzn4D8CUlq44Tct5GjcN+HLmiILeNgQldFXo36IuGJuPIIqik\nIIuwYp86GQDn2bHXXV0h3MeR1x5Yg1kz07KGrjpKyNSMq0WH9I4syl5IkatIdRwRpaQgi7BimzIZ\nn6ZROuxs1VGUqRhHts2eqTbIcfh8PtYdXEuLtJbEWeJUxwmpvpn9cXldLNwzX3UUEaWkIIuwoe3f\nj3XhfNxdu+OrU0d1HGVc/cvWvdr++F1xkmPtKtxJgTOfNrVOUx0l5GT5kwg2KcgibNh+m1p21GIM\nd1cDeOvVx922PdZ5c6AovLpHl+9dBkC72h0UJwm97nV7YjPZpCCLoJGCLMKGfUrZcifnOecqTqJe\n6dAz0UpLsc2ZpTrKEZbkLAKga0Z3xUlCL8GaQPd6PVm9fyUHSg6ojiOikBRkER5KSrD9OQN3Kx1P\nsxaq0yjnHFy2Q5ntt18VJznS4uy/MGkmTq/TSXUUJSq6redkyfInEXhSkEVYsM6fg1ZSgnPoWaqj\nhAV3l65409KwTZ8GYXLKkNPjZOW+5ZxWqx2J1kTVcZToW74eeZasRxZBIAVZhAXb79MAYmrv6r9l\nseAcNARz1q6wWf609sBqHB4HXTK6qY6izOnpnUixpcpBEyIopCAL9Xw+7L/9ijcpGVf3nqrThI1w\n67auGD/uktFVcRJ1LCYLvRv0ZXv+Nrbnb1MdR0QZKchCOfOWTZi3bytb7mO1qo4TNpwDh+DTtLJu\n6zCwKPsvALrVjb0JXZXJNpoiWKQgC+Vs038DpLv6aL7atXF37oL1rwVouYdUx2FJziLS7Gk0S43t\nSXdyPrIIFinIQrnD48eDhihOEn6cQ85E83iwzfxDaY59xfvYnr+NLhnd0DRNaRbVWqS1pG5iPWbv\n+hOvLzz3GxeRSQqyUKuoCOu8Objbtsdbr77qNGHHOaxs1rmtfI9vVZbuXQwQ0xO6KmiaRr/MARxw\nHGDtgTWq44goIgVZKGWbMwvN6ZTu6hNwt+uAp1FjbNN+hdJSZTmWZFdM6JKCDLKNpggOKchCqYoJ\nS87BQxUnCVOaRuk552MqLMA2S92Y5aLshQB0zuiiLEM4qSjIs6UgiwCSgizU8fmwTf8Nb0oqrq6x\nPXP375SedyEAtp9/VHL9EncJi3P+om2t9qTa05RkCDd1E+vRqobO/N1zcXqcquOIKCEFWShj3rwJ\n884dZcudLBbVccKWu2s3PBl1y86KdrtDfv3F2X9R6ik9vEuVKNM3sz/F7mIWly8HE6K6pCALZawz\npwPgHDhYcZIwZzLhPOc8TIcOlZ0AFWIV6237NugX8muHswENy35uZ+ycrjiJiBZSkIUyFUt5nOXn\n/4oTq+i2tv/8Q8ivPTtrJhaThTPq9w75tcNZ7wZ9sZqszNypdkmaiB5SkIUaTifWuXNwN2+Bt2Ej\n1WnCnuuM3nhr1sT2y8/gDd3a1/zSPJbtXUqnOl1IsiWH7LqRIMmaRPe6PVm5bzn7S/arjiOigBRk\noYR1ySJMRYW4BgxSHSUyWCyUnn0e5r05WBaFbsxy/p55eH1e6a4+gYGNBuPDx5/ylCwCQAqyUOLw\n+PEAGT/2l/Pc8wGw//R9yK45p2L8uHyZjzjSQBlHFgEkBVkoYZv5Bz6LBVfvPqqjRAxnv4F409Kw\n//A9eDwhueasXX8SZ46ja4wfKHEibWu3p3Z8OjN3/oEvTM6tFpFLCrIIOe3gASzLl+Hq1gNfkoxL\n+s1mo/S8CzHnZGNdOD/ol9tXvI91B9fQvd4Z2M32oF8vEpk0EwMaDmJvcQ5rDqxWHUdEOCnIIuRs\ns/9E8/lk/LgKSi++DAD7xG+Dfq3ZWTOB/z9uUByfdFuLQPGrIOu6/qqu6/N0XZ+j63rXo14bqOv6\nfF3XZ+u6/lFwYopoYq1Y7iQF+ZS5evXBm14H+8+TwOUK6rWmbZsCwKBGsq3p3+nfsOzneOYOKcii\nek5akHVd7we0MAyjF3AL8OZRb3kPuMQwjL5Aiq7rZwU+pogaPh+2mX/grVEDd4eOqtNEHrMZx4UX\nYzp4EOvsmUG7jMvjYvqO32mQlEnbWu2Cdp1oUCehDu1qd2DhnvkUuYpUxxERzJ8n5MHAJADDMNYD\nabquJ1V6vYthGHvK/7wPqBXYiCKamDdvwpy1C2e/gWA2q44TkUovKuu2jvv+u6Bd46/sBeSV5jKs\nyVkxf/6xPwY2HIzT62T+7tDvpCaihz8FuS5lhbbC/vKvAWAYRiGAruv1gKHAL4EMKKJLxXInGT+u\nOnfXbngyG5ZtEuJwBOUa07ZNBeDMJmcHpf1oM7BR+TiydFuLaqjKpK5j/rms63od4EfgDsMwDlU7\nlYhasl1mAJhMlF50KaaCfGzTfwvKJaZtn0KCJZFe9fsGpf1o071uTxIsiTKxS1SLP0fs7KbSEzFQ\nH6jookbX9WTKnopHG4bh109jerosdfFXVN0rpxPmzgZdp1an0wLadFTdJ3+MuB7efp3UnyfCjcP9\n/pg/92nDgQ1szt3Exa0vpmG99OqkjGin+jM1qNlAft7wM8XWgzROaxykVOEn5n73gsifgjwNeAr4\nUNf1zkCWYRiVZy68CrxqGIbf/1Tft6/glELGqvT05Ki6V9Z5c0grKqK47wCKAvh9Rdt98kuD5tTQ\nW2P+6ScObNyBL63GST/i730at7xsSdWAekNj776Wq8rPVO+M/vy84We+Xf4D17e9KUjJwktM/u5V\nkT//cDlpl7VhGPOBJbquzwVeB0bpun6DrusX6roeD1wL3KLr+gxd1//Qdf2W6gYX0aliuZOMHweA\npuG4/Co0pxP7j5MC2vS0bVPQ0BjS+MyAthvtZD2yqC6/ToU3DOORo760qtKf4wMXR0Qz28zp+KxW\nnL1kXDIQSi+9gsTnnyZuwngc1wfmiWxv8V4W7JlHl4xupCfEbnd1VTRNbU6jlCbM3vUnbq8bi8mv\nv16FOEx26hIhoR04gGXFclzdekBS0sk/IE7K2yATV+++WBfOx7R9W0Da/GnzJLw+Lxe3vDQg7cUS\nTdMYkDmIfGceS3IWq44jIpAUZBESttkzZbvMIHBcfhUAcd9+HZD2ftg0EQ2N85tfFJD2Ys2A8l27\nZu+aqTaIiEhSkEVIWP+cAch2mYHmPO8CfPHx2CeMh2qeNrS7MIsFe+ZxRv3e1E2sF6CEsaV3gz5o\naMzJmqU6iohAUpBF8FVsl1mzJu72p6tOE1V8ySmUnn0uli2bsSytXjfpj5vLzlm+qIV0V1dVjbia\ntE8/ncXZf1HsKlYdR0QYKcgi6MwbN5Rtl9l3gGyXGQSlFd3WX39VrXYmbfwOs2bmvOYXBiJWzOrT\noB9Or5O/sheojiIijBRkEXS2P8qWqDsHDVGcJDo5+w/CU7de2ZGMxVV7KtuWt5Wle5fQN7M/teNr\nBzhhbKk4rnLOLum2FqdGCrIIOtuM8v2rBw5WnCRKWSw4hl+LKT8P+4/fV6mJSZvKDqqQ7urq617v\nDCwmy+HzpIXwlxRkEVwlJVjnz8Xdpi3eujJRKFgcV18HQPyXn5/yZ30+H+PWjyXeEs95zS4IdLSY\nk2RNoktGN1bsW05eaa7qOCKCSEEWQWWdPwfN4ZDu6iDzNm6Cs/9ArAvnY95gnNJnF+6Zz9a8LZzb\n7AJS7KlBShhb+jToh9fnZd7uuaqjiAgiBVkEVUV3tVO6q4Ou5LobAYgbO+aUPvfV+i8AGN7mukBH\niln9MgcAMGfXn2qDiIgiBVkEle2P3/ElJODqcYbqKFHPeeY5eGvVIm7COCgt9eszhc4Cftz0PY1S\nmtCrfp8gJ4wdnTO6Em+Jl/XI4pRIQRZBY9q5A8vGDTh79wW7XXWc6Ge347hiOKYDB7BPnezXR37c\nPIlidzFX6cMxafLXQaDYzXa61+3JuoNr2Vu8V3UcESHkN1AEzeHuahk/DhnHtTcAEPfJh369/6t1\nX6ChcWVr/89UFv7pW95tPVeekoWfpCCLoJHlTqHnadkK54BB2ObPxbJy+d++1zi4nr+yF9A3cwAN\nkxuFKGHs6NugHwCzZRxZ+EkKsggOlwvrrJl4GjfB07S56jQxpXjkKADi33vnb9/32ZqPALih7Yig\nZ4pFHdI7kmJLZXaWFGThHynIIigsSxZjKsgvm12taarjxBTXwCG4W+nYJ32HKXvPcd9T6CrkG2M8\ndRPrcVaTc0KcMDaYTWZ6NejD9vxt7MjfrjqOiABSkEVQ2GZUbJc5VHGSGKRplNz2DzS3+4Rjyd9v\n/JYCZz7XtrkBq9ka4oCxo6LbWmZbC39IQRZBYftjOj6LBVefvqqjxCTH5VfhrVmT+M8/OWZ/a5/P\nx2erP8asmbnutBvVBIwRFRO7ZBxZ+EMKsgg4bd8+rCuW4epxBr6kZNVxYlN8PCU3jMB08CBxE8Yf\n8dLSvYtZtX8FZzY5h3pJ9RUFjA16jdakx9dhdtaf+Kp5XrWIflKQRcDZ/vwDAOdAWe6kkmPEbfhs\nNhLeeh1crsNf/2z1xwDc2O5mVdFihqZp9M3sx97iHDYe2qA6jghzUpBFwMl2meHBm1GXkutvwrxj\nG3HjvwTgkOMgP2yaSLPU5oe3dxTB1adB2XGMcvqTOBkpyCKwvF5sM6bjqZOBp1171WliXsmd9+KL\niyPhtf9AaSnfGONweBxc33aE7MwVIn0OT+yarTiJCHfyGykCyrJmFab9+3ANGCTLncKAt249Sm64\nGfOunfg+/pgxaz7BbrZzpS47c4VK45QmZCY1ZF7WbLw+r+o4IoxJQRYBZf3jd0C2ywwnxf+6B19C\nAn9++iSbcjdyfvOLqBVfS3WsmKFpGn0y+3Go9BBrDqxWHUeEMSnIIqBsf/yOT9Nw9h+kOooo56tT\nh5IRt/Fek/0A3NBWJnOFWu/6Zcv/ZF9r8XekIIuA0QrysS5aiLtjJ3y15AksnGy7eTgT20C7/SZ6\n2FqojhNzKsaR58o4svgbUpBFwFhnTEdzu2V3rjD0VfZkXGYYudBL0ssvqI4TcxokZ9I0tRnzds/F\n7XWrjiPClBRkETD2X6cA4DxL9kYOJx6vhy/WfkaCNYGrCpsRN+YTzKtXqY4Vc/o06EeBM59V+1ao\njiLClBRkERgeD7bp0/DUrYe7Q0fVaUQlM3dOZ0fBdoa3G475yf+geb0kPfogyM5RIdW7Qdk48pzd\n0m0tjk8KsggIy6K/MB08iHPoWbLcKcyMWfMJACO7jsQ1aCilZ52Dbf5c7JO+U5wstvSuWI8s+1qL\nE5CCLALCPq2iu/psxUlEZVkFu5i2fSod0zvRpX4XAAqffgGf3U7i46PRcg8pThg7MhIyaFVDZ+Ge\nBbg8rpN/QMQcKcgiIGy//oIvPh5nn/6qo4hKxq4bg9fnPWKpk7dpM4rvewjz3hwSn3xUYbrY06dB\nP4rdRSzbu1R1FBGGpCCLajNt2Yxl4wac/QdCfLzqOKKcx+th3LqxJFmTuajlpUe8VjzqLlztOhA/\nbizW8r3HRfAd7rbOkm5rcSwpyKLaDndXD5Pu6nAya9dMdhdlcXHLS0m0Jh75otVK4Rvv4DObSb7/\nLigsVBMyxvSq3weQ9cji+KQgi2qzTZsKgHPomYqTiMq+NspOeLqq9TXHfd3d/nSK/3UP5p07SHru\nyVBGi1m14mvRtlZ7FmUvxOF2qI4jwowUZFEtWu4hrAvm4ercBW9GXdVxRLm80lx+2fIzLdJa0jWj\n+wnfV3zvg7j11sR/8qF0XYdInwZ9cXgcLMlZpDqKCDNSkEW12H6dUrY711nnqo4iKpm0aSIOj4Or\nWl+D9nfL0OLiKHj3Q3xWK8l3/QPt0MHQhYxR/z+OLPtaiyNJQRbVYv/5BwBKz79QcRJR2fj1YzFp\nJi5vddVJ3+tufzpFDz6COXsPSQ/eKxuGBNkZ9Xth0kwyjiyOIQVZVJlWkI9txnTcbdriad5SdRxR\nbsNBgyU5ixnQcBD1kur79ZmSf96Nq1sP4n6YiH3ihCAnjG2p9jQ61D6dJTmLKHYVq44jwogUZFFl\ntmlT0ZxOeToOM+PLJ3Nd3fpa/z9kNpP/zgd4E5NIeug+TLt2BimdAOiT2R+X18Vf2QtURxFhRAqy\nqDL7TxXd1RcpTiIquL1uvjHGkWZP48wmp3bIh7dJU4qeexFTfh7Jd94BXm+QUoo+Ffta75JxZPH/\npCCLqiksxPbHb7hb6Xj01qrTiHIzd05nb3EOF7e8jDhL3Cl/3jH8urK9rufMIv6Dd4OQUAD0qNcL\nm8nGHzt/Vx1FhBEpyKJK7NOnoTkclJ4n3dXhZNz6KnRXV6ZpFLzyFt7a6SQ+/zTmdWsDmE5USLQm\n0rN+b1bvX0lOUbbqOCJMSEEWVWKT7uqwc9BxgF+3/kKbmqdxenqnKrfjS0+n4LW30UpLSbnjFigt\nDWBKUWFwo6EA/LFDnpJFGSnI4tQVF2P//VfcTZvhOa2t6jSi3Pcbv8XpdXLlydYe+8F55tmUXHcT\nlrWrSXzuqYDkE0eqKMjTd/ymOIkIF1KQxSmzT52MVlyM84KL5ezjMPLVurGYNTOXtboyIO0VPvMC\n7hYtSXj/HdnFKwha1mhFw+RG/LlrBm6vW3UcEQakIItTZp8wHgDH5SffdEKExoq9y1i1fwVDm5xF\nnYQ6gWk0MZGC9z4u28XrXyPR9u8PTLsCAE3TGNRoKHmluSyWbTQFUpDFKdJycrDNmI6rU2c8rXTV\ncUS5z9d+BsANp90U0HbdHTpSNPoJzHtzSL5nlOziFWCHx5G3S7e1kIIsTlHc9xPQvF4cV1ytOooo\nV+gsYOLGCWQmNWRAw8EBb7/kH//C2bc/9l+nEPfZxwFvP5b1yeyHzWSTcWQBSEEWp8j+zXh8Fgul\nF12mOooo9/2m7yhyFXLNaddjNpkDfwGTiYK338dbowZJTz6C2Vgf+GvEqCRrEj3q92LV/hVkF+1R\nHUcoJgVZ+M28dg3W1StxDhmGr1Yt1XFEuc/XfIpJMzG89XVBu4a3Xn0KXn0bzeEgZeTNshQqgM4u\n31Ft8pYfFScRqklBFn6LOzyZS7qrw8XKfctZsW8Zwxqf5fdBElXlPPd8Sq69AcuaVbIUKoDOa34h\nGho/bp6kOopQTAqy8I/Hg/27b/CmpuEcdpbqNKLcByv/B8D1bQM7metECp99EXfzFiS8/w62X6eE\n5JrRrm5iPXrW78WC3fOk2zrG+VWQdV1/Vdf1ebquz9F1vetRr9l1Xf9M13WZtx/FbH/8hjl7D6UX\nXgJ2u+o4AthdmMXEjRNoVUNnUPls3aBLTCT/o8/xxcWR/K/bMe3cEZrrRrkLml+MDx8/b/5BdRSh\n0EkLsq7r/YAWhmH0Am4B3jzqLf8BlgGyHiKKxX3yIQAlN4xQnERU+HDle7i9bu44/V+YtNB1dnna\ntqPwhf9gys0l5dYbwOkM2bWjVUW39Q+bv1cdRSjkz2/xYGASgGEY64E0XdeTKr0+uuJ1EZ1MW7dg\n++N3XN164GnfQXUcARQ48/l87aekx9fhMj0wO3OdCsc11+O49AqsS5eQ+OyTIb9+tMlIyOCM+r1Z\nuGc+ewp3q44jFPGnINcF9lX6//3lXwPAMIyiQIcS4SV+zCdoPh8lI25VHUWU+2LtGAqc+dzaYSR2\ns4IhBE2j4D+v427Zqmw8+ZefQ58hylzQ4mIAft4i3daxSvOdZOcdXdffB342DOOn8v+fDdxkGMam\nSu9pDEwwDKO7H9eUru1IUlICmZlgNsPOnTJ+HAYcbgct32rJoZJD7LhnBzXja6oLs3o1dO8ONhss\nWwZNm6rLEuFyCnOo/2p9OtXtxOLbFquOIwLvpBv/W/xoZDeVnoiB+kC1pgLu21dQnY/HjPT0ZOX3\nyj5uLCkHD1J09/0U5zuB8BsvDIf7FErvLHuTXfm7+EfHO/EUWtlX6N/3HpT7lNEY+4uvkHLXP3Bd\nehm5P00rK84RTsXPlIkEhjU5m6lbJ/Pr6hl0zuh68g8pFmu/e9WRnp580vf402U9DbgMQNf1zkDW\ncbqpNfyo/iLC+HzEf/IhPpMJx/WhWVYj/t4hx0FeX/pf0uxp3N35PtVxACi96hocV1yNddlSEp96\nVHWciDaiXdmw0CerP1ScRKhw0oJsGMZ8YImu63OB14FRuq7foOv6hQC6rn8DjANa6br+h67rcgRQ\nlLD8tRDrimU4h52NN7Oh6jgCeH3JK+SV5nJ3lwdIi6uhOk4ZTaPgpVdx661J+Oh97OO/VJ0oYvXL\nHEDztBb8sGkiB0oOqI4jQsyfLmsMw3jkqC+tqvTaFQFNJMJGwpuvAGWHCwj1duRv5+NV79MwudHh\nJ6mwkZhI/pivSDtzEMkP3I2nlY67c/h3uYYbk2bipra38Njch/ly3efc2fke1ZFECMlOXeK4zKtW\nYv/tV5w9e+Hq2Ut1nJjn8/l4bO7DOL1ORvd4nDhLnOpIx/A0a0H++5+Ay0XKjddgyslWHSkiXdl6\nOAmWBMas+RiP16M6jgghKcjiuBLefBWA4rvDY5wy1n2/6Vumbp1Mr/p9uKTl5arjnJBr0BCKHnsa\nc/YeUm68Rg6hqIJUexqXtrqCnQU7ZAlUjJGCLI5h3rQR+4/f4+rQEdfAIarjxLy9xXt5ZPYDJFgS\neG3g2yHdlasqSkbdieOSy7EuWUTSg/fASZZWimON6nQXFpOFfy98FpfHpTqOCJHw/s0WSsS/9Rqa\nz0fxXfeBJpPnVRs9+34OOg7ySI8naJraTHWck9M0Cl57G1eHjsSPG0vcx++rThRxmqU259o2N7Al\nbzNfrvtcdRwRIlKQxRFMO7YTN2E87patcJ57vuo4Me+rdV/w0+ZJdK/bk1s6jFQdx3/x8eSP+Qpv\n7XSSHh+NdfafqhNFnPu6PUyCJYH/Ln6RIpdsiBgLpCCLIyS+/AKa203x3feDSX48VFqzfzUPz7qP\nVHsa7wz5IOy7qo/mbZBJ3idjwWQi5ZbrMW3dojpSRMlIyGDk6aPYW5zDByveVR1HhEBk/YaLoDKv\nXYN9wnjcbdpSekn4ThyKBQXOfG7+9TocHgdvDXqPxilNVEeqEnfPMyh88RVMhw6Rev1VaAX5qiNF\nlFGd7qJWXC3eWPoKW/PkHzTRTgqyOCzx38+g+XwUPfZk2d7VQgmvz8u/pt/BlrzNjOp4F2c1PUd1\npGpxXHcjxbeOxGKsJ/n2EeCRpTz+Sral8Hzflyl2F3PXH//A6/OqjiSCSAqyAMCyYD72X6fg7NkL\n55AzVceJaS8seIZftv5E7/p9eaTHE6rjBETR0y/gHDgY++/TSHwmOr6nULm4xWWc0/R8FuyZx0cr\n31MdRwSRFGQBPh9Jz5WdaVv0+NMys1qhcevG8uayV2mW2pxPzvoCq9mqOlJgWCzkf/Ap7hYtSfjf\nW9jHjVWdKGJomsbL/V+jZlxNnl/4NJtzN6qOJIJECrLANmUy1r8WUHrWubi79VAdJ2bNy5rD/X/e\nRZo9ja/OnUCNOIXHKgaBLzWN/LFf401LI/n+u7AsmK86UsSok1CHl/u9Rom7hFun3YTD7VAdSQSB\nFORYV1pK0lOP4rNYyp6OhRJbcjdx09Rr8OHj07O+pFlaC9WRgsLTrAX5H30OXi+pI67BtGO76kgR\n44IWF3NtmxtYvX8lT847+ngBEQ2kIMe4+I/ex7xtKyUjbsXTspXqODHpkOMg1/xyBYdKD/Hf/m/Q\nu0Ff1ZGCytVvAIXPv4xp/35Sr7sKzc/znAU81+cl2tQ8jU9Xf8SPm75XHUcEmBTkGKbt20fCqy/j\nrVGD4vseUh0nJpW4S7hp6rVszt3EPzvdzfA216mOFBKOEbdSctMtWNatIfkft4JXZg/7I8GawIfD\nxpBgSeDuGf+UpVBRRgpyDEt88TlMBfkUPfgovhrRNV4ZCVweF7dNu5F5u+dwXrMLeaznU6ojhVTh\ncy/h7DsA+9RfSPz3s6rjRIxWNXVe6vcqha4Cbp12I6UeOcAjWkhBjlHmVSuJ+3IMbr01jhtGqI4T\nc/Sc1O0AABy8SURBVLw+L3fPGMWv26bQL3Mg/xv6UcTtxFVtViv5H32Gu2kzEt54BfuE8aoTRYwr\nWw/n6tbXsnLfcp6e95jqOCJAYuxvAAGA10vy6PvRvF4Kn30RLBbViWKK1+flgT/vZsKG8XTJ6Mpn\nZ3+J3WxXHUsJX42a5I/9Bm9KKsn3/gvL4r9UR4oYL/T9D3qN1ny06n0mb/lJdRwRAFKQY5D9m3Fl\ny5zOvwjXgEGq48QUj9fD3TNG8cXaz2hf+3S+OvdbkqxJqmMp5WnZivwPPwOXi9QbhmPK2qU6UkRI\ntCby4ZljiDPHcf/MO9lbvFd1JFFNUpBjjJaXS9Izj+NLSKDwmRdUx4kpLo+Lf/0xkvHrv6Rjeie+\nu+DHqFtrXFWugYMpevbfmPbtJeX6q6FITjfyR+uabXi055MccBzg/j/vwidnT0c0KcgxJvHF5zDt\n30/RvQ/ibZCpOk7MKHDmM3zyZXy74Wu6ZHRjwgU/kBZXQ3WssFJyy0hKrrsR66oVpPzzdtnz2k+3\ndriD3vX7MnXrZL42vlIdR1SDFOQYYl61krhPP8LdoiUlI/+pOk7MyC7aw4WTzuHPXTMY1vgsvr3g\nR1LtaapjhR9No/Df/8XZuy/2yT+SPOo2cLtVpwp7Js3EG4PeJcmazKNzHmJ3YZbqSKKKpCDHCq+X\n5IfvK5vI9cJ/wGZTnSgmGAfXc853Q1i9fyXXnXYTn539FYnWRNWxwpfNRv7n43B160HcxAkkj7pV\nirIfGqU05unez1PgzOfBP++RrusIJQU5Rti/GYd10UKZyBVC83fP5bzvh7GrcCeP9HiC//Z/HYtJ\nZrSfjC85hbyvJ+LqcQZx339Hym03QUmJ6lhh79o2N9CnQT+mbZ/KpE3fqY4jqkAKcgzQcg/JRK4Q\n+2XLz1zx00UUuQp5a9B73N3lfjQ5RctvvqRkcsd9h7NXH+w//0DauUMxbduqOlZY0zSNVwa8Sbwl\nnkdmP8CBkgOqI4lTJAU5Bvz/RK6HZCJXCIxbN5YRv16LWbPw5TkTuLL1cNWRIlNSEnnjJ1Jy3U1Y\nV6+kxrD+2H7/VXWqsNY0tRkPd3+cA44DPDZHtsONNFKQo5xl5XLiPvu4fCLXKNVxot67y9/irhn/\nINWWysQLf2Jgo8GqI0W2uDgKX3mDgtffQSspIXX45SSPvBnTnt2qk4Wt2zrcQec6Xfhu4zf8tm2q\n6jjiFEhBjmYuF0l3/7NsIteLr8hEriDy+Xw8N/8pnpr3KPUS6/Pjxb/SOaOr6lhRwzH8OnJ/+R1X\np87ETZxAzTO6EP/GK1BYqDpa2DGbzLw28B2sJisP/HkPBc581ZGEn6QgR7H4/72FdfVKSq6+lv9r\n777jo6rSBo7/ZiaTTHoHxdCFQxeCivQqiIIoC6JrWRdE7Kyia3lFZRdcRV/Lim0RXBUFxcXXXZQm\nhN4ERPpBgSU0KSmkTzIz9/3jTjAghAAhdzJ5vp9PPlPuzZ0nh8t97j1z7nNKuvWwOpyg5fV5eXzJ\naP7+w2s0im3M7MHzUQnNrA4r6HhaX0H2nEXkvj4JIyKcqAnjSGzfkohXX8KWlWl1eAGleWILRqeO\n4WD+Af666nmrwxEVJAk5SDl2/UTkK3/Dl1yL/HETrA4naLm9bu5d8McTpTD/c/N86kbXszqs4GW3\nU3T7XWSu2kD+n58BIHLiiySktiJy3Fhshw9bHGDgGN1+DM0SmvPPrVNYsi/N6nBEBUhCDkY+H1GP\nPYLN7Sb3pVcx4qQi1MWQV5LH7d/cwn92/R8d63Tmq0GzSY5ItjqsGsGIjaPg8afIWL+VvHEvYkRF\nEfH2myRe2YqoJx/Dnr7X6hAtF+YI4++93iXEHsKDC+/lWOExq0MSZyEJOQi5PpxM6KoVuPsPoHjA\nIKvDCUqZRRkM+XogS/encV2D65kxYBYxYbFWh1XzREVReP9DZH6/idxX3sBX+1LCP/yAhA5tiX5o\nFI6d2uoILdW2VirPdHieIwWHGb3ofikYEuAkIQcZx47tRL3wLL6EBPImvgZy72ulO5h3gBu/uo4N\nR9Zzi7qNqddNIzwk3OqwajaXi6I/DCdz9QZy3pmMt0lTXF9MJ75bByLHPl2jJ6t4oO3DdE/pyYK9\n8/jHpnesDkeUQxJyMCkqIua+EWZX9etv46t9idURBZ2dmZoBs/qyM0szqs0DJ7oERYAICcE9ZBhZ\ni1dx/J+f4W3QkIj33yahe0ecSxdbHZ0l7DY7k3q/T1J4Mi+sfFZuhQpgkpCDSOSEcYRs20LhXcMp\n7n+D1eEEnbT0hVw/qw/78/bx9NVj+Uvnv2G3yX+hgGS3U3z9ALLSVlLw0J+w708nbsiNRI5/oUbW\nxq4deQkf959OqCOUkfPvZuORDVaHJE5DjiZBIvS7eUS8/zaey5tIecxKZhgGH2x6j99/MwS3t4h3\n+kzm0SufkFKY1UF4OPnP/YXsuYvMq+W/v0bssMHYjtW8AU5XXnI17107lSJvEb//Zig/Ze20OiRx\nCknIQcDx006iR43AcLnIfX8qRERYHVLQOFxwmDu+vYVnlv+ZeFc8swbNZkjTYVaHJc6Rp20qWQuW\n4O7Xn9Bli4nv05WQTRutDqvK9W94Ay92fYVjhUcZMOta1h5aY3VIogxJyNWcLTuLmDuHYc/NIff1\nSXhaX2F1SEHB6/MyY8en9JhxDQv2zqN7Sk8WDl3OVZd0sDo0cZ6M2DhyPppO/tNjsR86SNyN1xE6\n91urw6pyw1uN5I2eb5NTnMOQfw9k9q5/Wx2S8JOEXJ15PMSMGk7I7l0UPPwo7t/dYnVE1Z5hGKSl\nL6TPzG48suh+CjwFTOjyMp8P/IpLo+pYHZ64UHY7BY8+Qc7UaWAYxPzhNsLfnQQ17Hag3ze/k2nX\nf47d5mD4vDt4etnjFHpkikurSUKurnw+oh4fTWjaQtzX9iP/meesjqha8/q8fP3zLPp+2YNhs29m\nW8YWblG3ser3GxjZ5n4ZvBVkim8YSPa/5+KrVZuo558h6olHoaTE6rCqVO/6fflm8AJUfDOmbP4H\n/b7sweZjm6wOq0aTo0x1ZBhEPTmG8M8+oaRtO3Lf/QAcDqujqpYKPYV8uOUDrvmsHSPn382moxsZ\n2Pgmvhu6lEm936dO1GVWhyguEs8V7ciel4anZWvCP55K7O1DseUctzqsKtUyqRXzhy5heKuR7Mjc\nTr8vezBx7YsUe4utDq1GsllQucU4ejS3qj+zWkpOjuY3bWUYRD77JBGT36OkVRuO/+vfGPEJ1gQY\nIE7bTmdR5Cnio61TeHPDaxwrPEqYI4xh6nYeaPsQjeIuv0iRWut82qkmsOXlEj1qOGEL5uFRzcj5\n6DMSOrSrcW2Vlr6QxxY/zIG8/bRIbMVbvd6ldXL5Y1Jkn6q45OTos96WIVfI1UlxMVFjHiFi8nt4\nmrfg+Myva3wyPlc+w8f07dPo8Glbxq54miJPEaNTx7Duzi282uONoE3G4syMqGhyPp5Bwb33E6J3\nENe7G3z6qdVhVbme9XqzZNgq7mxxN9syttD3yx68tHa8XC1XIblCDmBlzz5tWZnEjLiL0OVLKWnT\nluOffYlRq5bFEQaGip6lbz62iSeXPMa6w2sJDwlnROtRPNRuNAmuxCqI0npyNXN2YbNmEjVmNPb8\nPApvu4P8v/4NI6bm1ShPS1/ImMWPsD9vH+1qpTKl3yekRNf9zXqyT1WcXCEHCcdOTdz1fQhdvhR3\n/wFkfz1HkvE5yHEf55llT3DtzG6sO7yWgY1vYuVt63mu419qTDIWFeMePJSshcsgNZXw6dNIuCYV\n17SPwOu1OrQq1bNeb5bcuopb1G38cGQDfWZ2JS19odVhBT1JyIHMMHBNed8sYrDrZwoe+hM5H06D\nyEirI6sWDMNgpp5Bx8/a88Hm92kQ05DPB3zFlH4fc1l0itXhiQDla9QYVq4k/+mx2AoKiH7sYeL6\n9iDs61lQXHO6b6NDY3ir13u80v0N8orzuHX2YF5bNxGf4bM6tKAlXdYByn7wAIlPPQpz5+JLSCD3\nlTcpHihTKZ7O6brNdmRu56mlY1h5cDkuh4tH2z/BA+0eIcwRZlGU1pPuxYorbSv7L4eIHP8Cri+m\nA+BLrkXhHXfhvnEw3hYta8xsahsOr2PEvLs4kLefvvWvY1Lv94lzxcs+dQ4q0mUtCTnQuN2EvzeJ\nyNdfwVZQQHGvPuS++Y7M3FSOsgeFfbnpvLH+VabvmIbH5+G6BtczvsvL1Iupb3GU1pODZ8Wd2laO\nn3/C9dEUXDM+w348GwDvZSkU9+5LcfcelHTqipEY3F9/ZBRmcN+C4SzZn0b9mAZ8eN2n9GzeSfap\nCpKEXJ34fIR+8x8ixz9PyJ7d+JKSsU98maM3/K7GnIWfr6SkKOZsWcin2z5m5s4ZlPhKaBTbmHGd\nX6Rfg/5WhxcwJCFX3BnbqqCAsDmzCV0wl9BF32HPzj6xyNO8JcVdulLSqSslnToH5R0QXp+Xid9P\n4PX1rxIeEs7kgZPpe+mNVodVLUhCrg4Mg9B5c4h8eQIhWzdjOBwU3jOKgsefIunyunIAPYP8knzW\nHFrFsv1L+G7fXHSGBqBhbCPGXPkkg5sMlXmKTyEJueIq1FYeDyHr1xG6YinOFctwfr8GW1ERAIbN\nhqdla0o6d/X/dMGIjqmCyKvGnD3f8NDCUeQW53BbszuY0OVlokKjrQ4roElCDmTFxYTNmknEu5MI\n2b4Vw2bDPXgoBY8/ibdxE0AOoABur5udmTvYnrkNnbmDnVk72JG5nfScvRiY+26YI4zrGw7g1mZ3\n0C2lBw67VC07HdmfKu682srtxrlhHc7lS3GuXI5z3VpsbjcARkgIJVd1oKRnb4p79cHTqg3Yq/eY\n2l3ZP/Fg2kg2HNpAvZgGvNXrXTrW6Wx1WAFLEnIAsu9LxzV9Gq5P/onj8C8YDgfuQTdT8Oif8apm\nJ61b0w6gJd4SNh3byI9HN7L56I9sOvojOzK3UeI7ucZwUngSKr45qbWvpMtl3bih9bUUHJeRn2dT\n0/anC1EpbVVUhHP99ziXLSZ08SJCftiAzX+89SUlUdy9FyVdulFy9TV4L29SLb+aik0I48/fPsNb\nP7yOz/AxqPFgxnYcJ2M2TkMScoCw5RwndP5cXDNn4Fy8CJth4IuKpujOuykceR++lN/ecA/BfwA1\nDINd2T+zZP8iFu9bxIoDy8kr+fXvdTlctExqRaukK2ie2IJm8c1pmtCMpPCkk7YT7O1UWaSdKu5i\ntJUtM4PQJWmEpi3EmbYQx+FfTizzJSSYV9BXXUNJh454WrepFvOal7bTul/W8uzyJ9lwZD1hjjCG\nNB3G8FYjz1p6syaptISslHoNuAbwAX/SWq8rs6wPMAHwAHO01uPPsrngT8iGgWPPLpxLlxD63TxC\nFy/C5r9/seSqDhTe8QfcA2+CqKhyNxOMB9B9uemsOLCMlQeXs3z/Uvbn7TuxrFFsY7ql9KB97ato\nk9yWJvFNK/Q9cDC208Ug7VRxF72tDAPH9m0416zCuXY1zrWrcexL/3Wx3Y63UWM8LVrhbdEST8vW\neFq0NE/eA+hKumw7+QwfX/30JS+tHc/enP8C0K5WKv0bDqBvg/40T2iBLYBir2qVkpCVUt2Ax7XW\nNyqlmgFTtdadyizfClwLHAKWAPdqrXeUs8ngSsiGgS0jg5DtWwn5cSMhm37A+f1aHAf2n1jF07I1\n7oGDcA+8CW+TphXedHU/gGYXZbEjawfbMrbw45EfWHFgGem5e08sjw+Lp2tKD3rU7UX3uj2pG13v\nvD6nurdTVZF2qjgr2sp+6CDOtasJWbuakC2bCdm6Bfsps0/5YmLxtGhpJummzfA2bIS3YSMzUYdU\n/SDG07WT1+dlUfoCpmz5B0v2peE1zCpnCa4E2te+ina12qMSmqPim9EwthFOh7PK47ZCZSXkccBe\nrfVU/+ttwNVa6zylVEPgI611N/+yp4BcrfXb5Wyy+iRktxt7Zga2jAzsmf6fI4exHziA/dABHOl7\ncezadeK+xFK+hARKOnejuGt3irv3xNew0Xl9fKAcQA3DoMBTwHF3NllFWWS7s8h2Z5Nd5H90Z5FV\nlGUud2dxtOAI+/P2kVucc9J24sLi6FinC10u60qnOl1pntiiUuYZDpR2CnTSThUXEG1lGNgP7Cdk\n6xZCtm3BsW0rIVs349i9C5vv5DEThtOJt159MznXScGXlIiRkIgvMenEjxEbixEeAeEu87ESpmw9\nWztlFWWyMH0B3+2dz7pf1p50Qg7gtDtpFNuYJvGK+jENqB/TgHox9akfU5+U6HpBVcinIgm5IqdU\nlwDryrw+5n/vZ//j0TLLjgDnl31Ox+3GlpMDPh82DPD5zB/DOOnRZpQ+N6C4GFux2xzd6HZjcxf5\nH8u8l5+PLT8XW24utrw87Lm52PL8r/PzzMfsbOz5eeWGZzideBs2oqRjZ7xNmlJyRVs8bdriq9/A\nkm4lt9dNtjsbw/Dh9Xnx4X80vPgMA4/hochTSKGnkEJPAQUlhRR48slxHz+RWEsTbZY760QCPu7O\npthX8ZKBUc5o6kbXJSW6Lk3iFc0TWtAqqU2lJWAhagSbDV9KXYpT6lLcr8z99AUFhOjtOHb9jGP3\nLhx7duP4724ce3YTsuvnCm/eCA3FCI/ACA8Hl5mkjYjwMu+FY4T7X7vCIDQMw+mE0FCM0DAIdUJi\nLC63D8PpxAgLA2cohDoxQsMwnKEkhzoZ5mzOsDotIcXOYU8Wm/J2srPgv+j8Pei83ejc3eis33aq\n2rBxacSl1IttQJ2oy0hwJZDgSiTelUCiK5GYsFhcDhdhIWGEOVy4HC6cDicOmwO7zY7dZsdmsxMZ\nElFtbsk6nz6O8jJN5WWhoiISU1tgP3as0jZ5NkZICEZ0NEZ0DL4GDfEkJuFLTDDPLhMS8SUk4ktO\nxndpHXyXpeCrVbtSzjIrg8/w0fHT1JO+k70Qdpud+LB4YsPiqBdTj9iwOOLC4ol3me+VLot3JRAX\nFk9cWBxxLvMxmM5qhQg4ERF42rXH0679bxbZsrOw//KLv2fvGPaMDOwZx8znublQWIitsABbURG2\nggJshYVQaD7as7OwFRaeuFWros4l1SUAzU95zwAORcOeONgTbz7ujoc98QZ74g+ypuDQiVscz4fT\n7mTukDRaJ7U5721UlYok5IOYV8Kl6mB+X1y67NIyyy7zv1ceW3JyRf4Jo+Ho0bOvVolsVOYZReWo\nWFuZ9o1JP/tKQepc2qkmk3aquGrZVsnR0OT8xmJYxYaZVOoANf0u5or0H84HhgAopVKBA1rrfACt\n9V4gWilVTykVAgzwry+EEEKIc1DR255eBLoDXuBBIBXI1lp/rZTqAkzE7Hn4Umv9+kWMVwghhAhK\nVhQGEUIIIcQpZMirEEIIEQAkIQshhBABQBKyEEIIEQAsmTBWKfU4cDtQDDygtV5vRRzVgVKqNrAd\nuElrvdTqeAKRUsoBTAEaAw7MUq8rrY0qsJRXj16cTCk1EeiCuS+9pLX+yuKQApZSygVsAf6itf7Y\n6ngCkVLqduAJoAR4Tms950zrVvkVslKqBXAL5kjtUZi3SokzmwjssjqIAHcnkKe17grcA8hI/zL8\n9egv99egvwf4u8UhBSylVA+ghb+t+gNvWBtRwBsLZFgdRKBSSiUAzwGdMHPdoPLWt+IKeQDwhdba\nADb6f8RpKKV6AjnAZqtjCXCfAJ/5nx/FLAgkftUb+D8ArfUOpVScUipKa11+bdiaaQmwxv88G4hQ\nStn8xytRhlJKAc2Ab6yOJYD1ARZorQuAAuC+8la2IiE3ALxKqTn+zx+jtd5kQRwBTSnlxDyzGgS8\naXE4AU1r7cW8Rx7gT/yanIWpvHr0ogx/4i30v7wH+FaS8Rn9L2ZdirstjiOQNQAilVJfA3HAOK31\nojOtfFETslJqBOZOXbpD24BawFytdX+lVGfgA+DqixlHoDulnWz+x7nAZK11jnkiGnBVPS1xhrZ6\nXmu9QCn1INAOGGhhiNWB7EtnoZQaBPwR6Gt1LIFIKXUnsFJrvVeOT+WyYfbY3QQ0BNKA+mdcuaoL\ngyilngd2aK0/978+rLWuXaVBVANKqeWY3/HbMAcrHQGGaq23WxpYgPIn6t8Bg7TWJVbHE0j8/+cO\naq0n+1/vAtqUlsAVJ1NK9QPGAf201sfPtn5NpJSagZlgfEAKUASMKu/qryZSSt0N1NZav+x/vQXo\nobU+7axJVnRZz8XsR/9cKdUMqJzpiYKM1rpL6XOl1IfAh5KMT08p1QhzgGA3ScanNR94AZh8aj16\ncTKlVAzmQMrekozPTGt9a+lz/wnfHknGpzUf+NA/cj8BiDxTMgYLErLWeo1Sqr9SaiVmd+ODVR1D\nNSTfYZVvBObO/q1SqrQbu6/W2mNtWIFBa71KKbVeKbWCX+vRi9MbBiQCX5TZl+7SWu+3NixRHWmt\nDyqlvgRWY+5LD5W3vtSyFkIIIQKAVOoSQgghAoAkZCGEECIASEIWQgghAoAkZCGEECIASEIWQggh\nAoAkZCGEECIASEIWopIppT5RSt11jr/zB6XUH893+flQSjVWSu1USk2qxG02V0q19T9/UinVv7K2\nLUSws2Q+ZCHEybTWH13I8vPUCVivtS63WME5uhk4DGwsLRcohKgYKQwixAXyV3SaCrQE0oFIYDrm\nrEEP+1c7Ctyjtc5SSg3AnMmrENiJWUr2WcCBWUN5CtAEs7LPD1rrh/3lCR1a6+eUUjdgzkObjzml\n271a60NKqT2YM4P1x5xl5j6tddoZYm4MzMacgeZf/vhCtNZj/cv3YE7b2BVzCjkHoID/aq1/51/n\nWeBGzOpf04D1wFeY0xaOA/oBy7TWU5VSwzHLm+ZjJuyRWus8pVQ2MN4f8yXALVrrref2LyBEcJAu\nayEuXB+gqdb6auBO4AqgHvA/mDWRu2HOs/uMUiocmAxcp7XujjkVYqcy22oNXK217uyvZ75RKRVd\nurDM79+ste6NWRt+fJnfL9Ba9wMmAI+cKWCt9S7gJcy5WkuvkMuenZd93hG4W2vdHrhCKXWFUqoL\ncL3/b+4KXAts88fzitZ6RpmY62LW0u6pte4F7Ace9S+OATb5/5bPMWfyEqJGki5rIS5ca2AlgNa6\nUCm1BnADlwLz/FfQocAeoAWQrrXO9K//NIBSqpd/W9uAo0qp2ZhXsF9orXP9U9wBNAV+0Vof8r9e\njHnlSZnXAHsx63ufr7LT6a3VWhf7n+/zbzcVWOb/GzyY08tRJs6yUoF1/knazxZz4wuIWYhqTRKy\nEBfOhjkNXSkHZkJeo7W+seyK/tmWHGfakD/xdfcPjBoIfK+UKnsFXToPdNnPLns16zllWUWd+t1V\n6Bm2WfYzK9rDdrFiFiKoSEIW4sJtw/wuFX/3cgdgFXC1Uqq21vqwUmoIZpJeCNRRStXxzwTzOnBi\n2jqlVHugpdb6Y8zu6laYV8WldgLJSqkU/wxEfTBnkrlQOZhd7SilWgLJZ1l/JfCOUsqBmZjnA7di\nnpg4T1l3PfCWUirSP+1jH8z2EUKUId8hC3Hh5gHpSqnVwAeYyeoAMBqYrZRaDAwHVvu7bUcAs5RS\nSzAHVX1TZls/A0OUUsuVUgsxB0itKF2otS7y//4XSqlFQC/MAWFwYdN0zgRS/TGNAM40sMrwx7Ea\nczDYcmAp8C+t9WHMk4vnlVL3lVn3AOYgtIX+tkjCHHx2oTELEVRklLUQQggRAKTLWoggppR6AejO\nb69EN2qtH6v6iIQQZyJXyEIIIUQAkO+QhRBCiAAgCVkIIYQIAJKQhRBCiAAgCVkIIYQIAJKQhRBC\niAAgCVkIIYQIAP8PSX8xrmYI9bYAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x7f6f6c345828>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Ignore numpy warning caused by seaborn\n",
+    "warnings.filterwarnings('ignore', 'using a non-integer number instead of an integer')\n",
+    "\n",
+    "ax = sns.distplot(predict_df.query(\"status == 0\").decision_function, hist=False, label='Negatives', color = 'red')\n",
+    "ax = sns.distplot(predict_df.query(\"status == 1\").decision_function, hist=False, label='Positives', color = 'green')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Pos</th>\n",
+       "      <th>Neg</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Label / Predict</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>Pos</th>\n",
+       "      <td>234</td>\n",
+       "      <td>39</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Neg</th>\n",
+       "      <td>102</td>\n",
+       "      <td>396</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                 Pos  Neg\n",
+       "Label / Predict          \n",
+       "Pos              234   39\n",
+       "Neg              102  396"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from sklearn.metrics import confusion_matrix\n",
+    "conf_mat = confusion_matrix(predict_df.query(\"testing == 1\").status, \n",
+    "                            predict_df.query(\"testing == 1\").probability, \n",
+    "                            labels = [1, 0])\n",
+    "cols = {'Pos': conf_mat[:,0].tolist(), 'Neg': conf_mat[:,1].tolist()}\n",
+    "df_conf = pd.DataFrame(cols, index = ['Pos', 'Neg'])[['Pos', 'Neg']]\n",
+    "df_conf.index.name = 'Label / Predict'\n",
+    "df_conf"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'The F1 score is 0.768'"
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from sklearn.metrics import f1_score\n",
+    "f1 = f1_score(predict_df.query(\"testing == 1\").status, predict_df.query(\"testing == 1\").probability)\n",
+    "'The F1 score is {:.3}'.format(f1)"
+   ]
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/algorithms/scripts/LinearSVC-htcai.py
+++ b/algorithms/scripts/LinearSVC-htcai.py
@@ -1,0 +1,323 @@
+
+# coding: utf-8
+
+# # Create a logistic regression model to predict TP53 mutation from gene expression data in TCGA
+
+# In[1]:
+
+import os
+import urllib
+import random
+import warnings
+
+import pandas as pd
+import numpy as np
+import matplotlib.pyplot as plt
+import seaborn as sns
+from sklearn import preprocessing, grid_search
+from sklearn.linear_model import SGDClassifier
+from sklearn.svm import LinearSVC
+from sklearn.cross_validation import train_test_split
+from sklearn.metrics import roc_auc_score, roc_curve
+from sklearn.pipeline import make_pipeline
+from sklearn.preprocessing import StandardScaler
+from sklearn.feature_selection import SelectKBest
+from statsmodels.robust.scale import mad
+
+
+# In[2]:
+
+get_ipython().magic('matplotlib inline')
+plt.style.use('seaborn-notebook')
+
+
+# ## Specify model configuration
+
+# In[3]:
+
+# We're going to be building a 'TP53' classifier 
+GENE = 'TP53'
+
+
+# In[4]:
+
+# Parameter Sweep for Hyperparameters
+n_feature_kept = 500
+param_fixed = {
+    'loss': 'hinge',
+    'penalty': 'l2'
+}
+param_grid = {
+    'C': [10 ** x for x in range(-5, 2)],
+    'intercept_scaling': [10 ** x for x in range(-5, 2)],
+}
+
+
+# *Here is some [documentation](http://scikit-learn.org/stable/modules/generated/sklearn.linear_model.SGDClassifier.html) regarding the classifier and hyperparameters*
+# 
+# *Here is some [information](https://ghr.nlm.nih.gov/gene/TP53) about TP53*
+
+# ## Load Data
+
+# In[5]:
+
+if not os.path.exists('data'):
+    os.makedirs('data')
+
+
+# In[6]:
+
+url_to_path = {
+    # X matrix
+    'https://ndownloader.figshare.com/files/5514386':
+        os.path.join('data', 'expression.tsv.bz2'),
+    # Y Matrix
+    'https://ndownloader.figshare.com/files/5514389':
+        os.path.join('data', 'mutation-matrix.tsv.bz2'),
+}
+
+for url, path in url_to_path.items():
+    if not os.path.exists(path):
+        urllib.request.urlretrieve(url, path)
+
+
+# In[7]:
+
+get_ipython().run_cell_magic('time', '', "path = os.path.join('data', 'expression.tsv.bz2')\nX = pd.read_table(path, index_col=0)")
+
+
+# In[8]:
+
+get_ipython().run_cell_magic('time', '', "path = os.path.join('data', 'mutation-matrix.tsv.bz2')\nY = pd.read_table(path, index_col=0)")
+
+
+# In[9]:
+
+y = Y[GENE]
+
+
+# In[10]:
+
+# The Series now holds TP53 Mutation Status for each Sample
+y.head(6)
+
+
+# In[11]:
+
+# Here are the percentage of tumors with NF1
+y.value_counts(True)
+
+
+# ## Set aside 10% of the data for testing
+
+# In[12]:
+
+# Typically, this can only be done where the number of mutations is large enough
+X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=0)
+'Size: {:,} features, {:,} training samples, {:,} testing samples'.format(len(X.columns), len(X_train), len(X_test))
+
+
+# ## Median absolute deviation feature selection
+
+# In[13]:
+
+def fs_mad(x, y):
+    """    
+    Get the median absolute deviation (MAD) for each column of x
+    """
+    scores = mad(x) 
+    return scores, np.array([np.NaN]*len(scores))
+
+# select the top features with the highest MAD
+feature_select = SelectKBest(fs_mad, k=n_feature_kept)
+
+
+# ## Define pipeline and Cross validation model fitting
+
+# In[14]:
+
+# Include loss='log' in param_grid doesn't work with pipeline somehow
+clf = LinearSVC(random_state=0, class_weight='balanced',
+                    loss=param_fixed['loss'], penalty=param_fixed['penalty'])
+
+# joblib is used to cross-validate in parallel by setting `n_jobs=-1` in GridSearchCV
+# Supress joblib warning. See https://github.com/scikit-learn/scikit-learn/issues/6370
+warnings.filterwarnings('ignore', message='Changing the shape of non-C contiguous array')
+clf_grid = grid_search.GridSearchCV(estimator=clf, param_grid=param_grid, n_jobs=-1, scoring='roc_auc')
+pipeline = make_pipeline(
+    feature_select,  # Feature selection
+    StandardScaler(),  # Feature scaling
+    clf_grid)
+
+
+# In[15]:
+
+get_ipython().run_cell_magic('time', '', '# Fit the model (the computationally intensive part)\npipeline.fit(X=X_train, y=y_train)\nbest_clf = clf_grid.best_estimator_\nfeature_mask = feature_select.get_support()  # Get a boolean array indicating the selected features')
+
+
+# In[16]:
+
+clf_grid.best_params_
+
+
+# In[17]:
+
+best_clf
+
+
+# ## Visualize hyperparameters performance
+
+# In[18]:
+
+def grid_scores_to_df(grid_scores):
+    """
+    Convert a sklearn.grid_search.GridSearchCV.grid_scores_ attribute to 
+    a tidy pandas DataFrame where each row is a hyperparameter-fold combinatination.
+    """
+    rows = list()
+    for grid_score in grid_scores:
+        for fold, score in enumerate(grid_score.cv_validation_scores):
+            row = grid_score.parameters.copy()
+            row['fold'] = fold
+            row['score'] = score
+            rows.append(row)
+    df = pd.DataFrame(rows)
+    return df
+
+
+# ## Process Mutation Matrix
+
+# In[19]:
+
+cv_score_df = grid_scores_to_df(clf_grid.grid_scores_)
+cv_score_df.head(2)
+
+
+# In[20]:
+
+# Cross-validated performance distribution
+facet_grid = sns.factorplot(x='C', y='score', col='intercept_scaling',
+    data=cv_score_df, kind='violin', size=4, aspect=1)
+facet_grid.set_ylabels('AUROC');
+
+
+# In[21]:
+
+# Cross-validated performance heatmap
+cv_score_mat = pd.pivot_table(cv_score_df, values='score', index='C', columns='intercept_scaling')
+ax = sns.heatmap(cv_score_mat, annot=True, fmt='.1%')
+ax.set_xlabel('Scaling of intercept (intercept_scaling)')
+ax.set_ylabel('Penalty parameter of the error term (C)');
+
+
+# ## Use Optimal Hyperparameters to Output ROC Curve
+
+# In[22]:
+
+y_pred_train = pipeline.decision_function(X_train)
+y_pred_test = pipeline.decision_function(X_test)
+
+def get_threshold_metrics(y_true, y_pred):
+    roc_columns = ['fpr', 'tpr', 'threshold']
+    roc_items = zip(roc_columns, roc_curve(y_true, y_pred))
+    roc_df = pd.DataFrame.from_items(roc_items)
+    auroc = roc_auc_score(y_true, y_pred)
+    return {'auroc': auroc, 'roc_df': roc_df}
+
+metrics_train = get_threshold_metrics(y_train, y_pred_train)
+metrics_test = get_threshold_metrics(y_test, y_pred_test)
+
+
+# In[23]:
+
+# Plot ROC
+plt.figure()
+for label, metrics in ('Training', metrics_train), ('Testing', metrics_test):
+    roc_df = metrics['roc_df']
+    plt.plot(roc_df.fpr, roc_df.tpr,
+        label='{} (AUROC = {:.1%})'.format(label, metrics['auroc']))
+plt.xlim([0.0, 1.0])
+plt.ylim([0.0, 1.05])
+plt.xlabel('False Positive Rate')
+plt.ylabel('True Positive Rate')
+plt.title('Predicting TP53 mutation from gene expression (ROC curves)')
+plt.legend(loc='lower right');
+
+
+# ## What are the classifier coefficients?
+
+# In[24]:
+
+coef_df = pd.DataFrame(best_clf.coef_.transpose(), index=X.columns[feature_mask], columns=['weight'])
+coef_df['abs'] = coef_df['weight'].abs()
+coef_df = coef_df.sort_values('abs', ascending=False)
+
+
+# In[25]:
+
+'{:.1%} zero coefficients; {:,} negative and {:,} positive coefficients'.format(
+    (coef_df.weight == 0).mean(),
+    (coef_df.weight < 0).sum(),
+    (coef_df.weight > 0).sum()
+)
+
+
+# In[26]:
+
+coef_df.head(10)
+
+
+# The results are not surprising. TP53 is a transcription modulator and when it mutated in a tumor, the cell goes haywire. This makes finding a transcriptional signature fairly easy. Also, the genes that the classifier uses is interesting, but not necessarily novel.
+# 
+# 1. TP53 is a [transcription factor](https://en.wikipedia.org/wiki/Transcription_factor "TF wiki") that regulates many genes including EDA2R. Studies have linked EDA2R (or XEDAR) to [increased survival in colon cancer patients](http://www.ncbi.nlm.nih.gov/pubmed/19543321) and [losing hair as a result of chemotherapy](http://onlinelibrary.wiley.com/doi/10.1016/j.febslet.2010.04.058/full)
+# 2. SPATA18 is a gene associated with spermatogenesis and is a transcription factor for TP53. It's association with TP53 was [recently discovered](http://www.ncbi.nlm.nih.gov/pubmed/21300779) in 2011.
+# 3. C6orf138 (or [PTCHD4](http://www.genecards.org/cgi-bin/carddisp.pl?gene=PTCHD4)) is also a transcriptional target for TP53 and was only recently discovered in [2014 to repress hedgehog signalling](http://www.ncbi.nlm.nih.gov/pmc/articles/PMC4239647/).
+# 4. The list goes on and includes several other TP53 targets...
+
+# ## Investigate the predictions
+
+# In[27]:
+
+predict_df = pd.DataFrame.from_items([
+    ('sample_id', X.index),
+    ('testing', X.index.isin(X_test.index).astype(int)),
+    ('status', y),
+    ('decision_function', pipeline.decision_function(X)),
+    ('probability', pipeline.predict(X)),
+])
+predict_df['probability_str'] = predict_df['probability'].apply('{:.1%}'.format)
+
+
+# In[28]:
+
+# Top predictions amongst negatives (potential hidden responders)
+predict_df.sort_values('decision_function', ascending=False).query("status == 0").head(10)
+
+
+# In[29]:
+
+# Ignore numpy warning caused by seaborn
+warnings.filterwarnings('ignore', 'using a non-integer number instead of an integer')
+
+ax = sns.distplot(predict_df.query("status == 0").decision_function, hist=False, label='Negatives', color = 'red')
+ax = sns.distplot(predict_df.query("status == 1").decision_function, hist=False, label='Positives', color = 'green')
+
+
+# In[30]:
+
+from sklearn.metrics import confusion_matrix
+conf_mat = confusion_matrix(predict_df.query("testing == 1").status, 
+                            predict_df.query("testing == 1").probability, 
+                            labels = [1, 0])
+cols = {'Pos': conf_mat[:,0].tolist(), 'Neg': conf_mat[:,1].tolist()}
+df_conf = pd.DataFrame(cols, index = ['Pos', 'Neg'])[['Pos', 'Neg']]
+df_conf.index.name = 'Label / Predict'
+df_conf
+
+
+# In[31]:
+
+from sklearn.metrics import f1_score
+f1 = f1_score(predict_df.query("testing == 1").status, predict_df.query("testing == 1").probability)
+'The F1 score is {:.3}'.format(f1)
+


### PR DESCRIPTION
Sorry that it took me a couple of days before I re-sent the pull request. I spent some time getting familiar with some mathematical details about the optimization of SVMs.

I mainly was manipulating two hyper-parameters: the penalty parameter `C` and the scaling of intercept `intercept_scaling`. Both ranges from 1e-5 to 10. The former reaches the optimal results at 0.01 whereas the latter does not seem to have much effect.

The testing AUROC appears to be fine (89.2%), comparing with the training AUROC (92.0%).

Since the prediction of SVMs is always in {0, 1}, it might not be as informative as those models providing probabilistic predictions, especially when cognoma users are querying a single case. For the same reason, I removed the last cell which plots the probabilistic distribution of predictions. However, I added a confusion matrix for the testing data and calculated the F1 score. I think F1 score may also serve as an indication of the confidence of predicting.

I would like to explore other kernel methods if you guys think it is worth a try.
