### PR TITLE
SVC with rbf kernel

### DIFF
--- a/algorithms/SVC-htcai.ipynb
+++ b/algorithms/SVC-htcai.ipynb
@@ -1,0 +1,959 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Create a Support Vector Machine with rbf kernel to predict TP53 mutation from gene expression data in TCGA"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/haitao/anaconda3/envs/cognoma-machine-learning/lib/python3.5/site-packages/matplotlib/font_manager.py:273: UserWarning: Matplotlib is building the font cache using fc-list. This may take a moment.\n",
+      "  warnings.warn('Matplotlib is building the font cache using fc-list. This may take a moment.')\n",
+      "/home/haitao/anaconda3/envs/cognoma-machine-learning/lib/python3.5/site-packages/matplotlib/font_manager.py:273: UserWarning: Matplotlib is building the font cache using fc-list. This may take a moment.\n",
+      "  warnings.warn('Matplotlib is building the font cache using fc-list. This may take a moment.')\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "import urllib\n",
+    "import random\n",
+    "import warnings\n",
+    "\n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "import seaborn as sns\n",
+    "from sklearn import preprocessing, grid_search\n",
+    "from sklearn.svm import SVC\n",
+    "from sklearn.cross_validation import train_test_split\n",
+    "from sklearn.metrics import roc_auc_score, roc_curve\n",
+    "from sklearn.pipeline import make_pipeline\n",
+    "from sklearn.preprocessing import StandardScaler\n",
+    "from sklearn.feature_selection import SelectKBest\n",
+    "from statsmodels.robust.scale import mad\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "plt.style.use('seaborn-notebook')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Specify model configuration"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# We're going to be building a 'TP53' classifier \n",
+    "GENE = 'TP53'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Parameter Sweep for Hyperparameters\n",
+    "n_feature_kept = 2000\n",
+    "param_fixed = {\n",
+    "    'kernel': 'rbf'\n",
+    "}\n",
+    "param_grid = {\n",
+    "    'C': [10 ** x for x in range(-1, 4)],\n",
+    "    'gamma': [10 ** x for x in range(-5, 0)],\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "*Here is some [documentation](http://scikit-learn.org/stable/modules/generated/sklearn.linear_model.SGDClassifier.html) regarding the classifier and hyperparameters*\n",
+    "\n",
+    "*Here is some [information](https://ghr.nlm.nih.gov/gene/TP53) about TP53*"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "if not os.path.exists('data'):\n",
+    "    os.makedirs('data')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "url_to_path = {\n",
+    "    # X matrix\n",
+    "    'https://ndownloader.figshare.com/files/5514386':\n",
+    "        os.path.join('data', 'expression.tsv.bz2'),\n",
+    "    # Y Matrix\n",
+    "    'https://ndownloader.figshare.com/files/5514389':\n",
+    "        os.path.join('data', 'mutation-matrix.tsv.bz2'),\n",
+    "}\n",
+    "\n",
+    "for url, path in url_to_path.items():\n",
+    "    if not os.path.exists(path):\n",
+    "        urllib.request.urlretrieve(url, path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 1min 22s, sys: 1.2 s, total: 1min 23s\n",
+      "Wall time: 1min 23s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "path = os.path.join('data', 'expression.tsv.bz2')\n",
+    "X = pd.read_table(path, index_col=0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 1min 2s, sys: 1.29 s, total: 1min 3s\n",
+      "Wall time: 1min 4s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "path = os.path.join('data', 'mutation-matrix.tsv.bz2')\n",
+    "Y = pd.read_table(path, index_col=0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "y = Y[GENE]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "sample_id\n",
+       "TCGA-02-0047-01    0\n",
+       "TCGA-02-0055-01    1\n",
+       "TCGA-02-2483-01    1\n",
+       "TCGA-02-2485-01    1\n",
+       "TCGA-02-2486-01    0\n",
+       "TCGA-04-1348-01    1\n",
+       "Name: TP53, dtype: int64"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# The Series now holds TP53 Mutation Status for each Sample\n",
+    "y.head(6)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0    0.655334\n",
+       "1    0.344666\n",
+       "Name: TP53, dtype: float64"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Here are the percentage of tumors with NF1\n",
+    "y.value_counts(True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Set aside 10% of the data for testing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Size: 20,501 features, 6,935 training samples, 771 testing samples'"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Typically, this can only be done where the number of mutations is large enough\n",
+    "X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=0)\n",
+    "'Size: {:,} features, {:,} training samples, {:,} testing samples'.format(len(X.columns), len(X_train), len(X_test))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Median absolute deviation feature selection"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def fs_mad(x, y):\n",
+    "    \"\"\"    \n",
+    "    Get the median absolute deviation (MAD) for each column of x\n",
+    "    \"\"\"\n",
+    "    scores = mad(x) \n",
+    "    return scores, np.array([np.NaN]*len(scores))\n",
+    "\n",
+    "# select the top features with the highest MAD\n",
+    "feature_select = SelectKBest(fs_mad, k=n_feature_kept)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Define pipeline and Cross validation model fitting"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Include loss='log' in param_grid doesn't work with pipeline somehow\n",
+    "clf = SVC(random_state=0, class_weight='balanced',\n",
+    "                    kernel=param_fixed['kernel'])\n",
+    "\n",
+    "# joblib is used to cross-validate in parallel by setting `n_jobs=-1` in GridSearchCV\n",
+    "# Supress joblib warning. See https://github.com/scikit-learn/scikit-learn/issues/6370\n",
+    "warnings.filterwarnings('ignore', message='Changing the shape of non-C contiguous array')\n",
+    "clf_grid = grid_search.GridSearchCV(estimator=clf, param_grid=param_grid, n_jobs=-1, scoring='roc_auc')\n",
+    "pipeline = make_pipeline(\n",
+    "    feature_select,  # Feature selection\n",
+    "    StandardScaler(),  # Feature scaling\n",
+    "    clf_grid)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 1min 25s, sys: 7.84 s, total: 1min 33s\n",
+      "Wall time: 29min 21s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "# Fit the model (the computationally intensive part)\n",
+    "pipeline.fit(X=X_train, y=y_train)\n",
+    "best_clf = clf_grid.best_estimator_\n",
+    "feature_mask = feature_select.get_support()  # Get a boolean array indicating the selected features"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'C': 10, 'gamma': 0.0001}"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "clf_grid.best_params_"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "SVC(C=10, cache_size=200, class_weight='balanced', coef0=0.0,\n",
+       "  decision_function_shape=None, degree=3, gamma=0.0001, kernel='rbf',\n",
+       "  max_iter=-1, probability=False, random_state=0, shrinking=True,\n",
+       "  tol=0.001, verbose=False)"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "best_clf"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Visualize hyperparameters performance"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def grid_scores_to_df(grid_scores):\n",
+    "    \"\"\"\n",
+    "    Convert a sklearn.grid_search.GridSearchCV.grid_scores_ attribute to \n",
+    "    a tidy pandas DataFrame where each row is a hyperparameter-fold combinatination.\n",
+    "    \"\"\"\n",
+    "    rows = list()\n",
+    "    for grid_score in grid_scores:\n",
+    "        for fold, score in enumerate(grid_score.cv_validation_scores):\n",
+    "            row = grid_score.parameters.copy()\n",
+    "            row['fold'] = fold\n",
+    "            row['score'] = score\n",
+    "            rows.append(row)\n",
+    "    df = pd.DataFrame(rows)\n",
+    "    return df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Process Mutation Matrix"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>C</th>\n",
+       "      <th>fold</th>\n",
+       "      <th>gamma</th>\n",
+       "      <th>score</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0.1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0.00001</td>\n",
+       "      <td>0.758369</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>0.1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0.00001</td>\n",
+       "      <td>0.760082</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "     C  fold    gamma     score\n",
+       "0  0.1     0  0.00001  0.758369\n",
+       "1  0.1     1  0.00001  0.760082"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cv_score_df = grid_scores_to_df(clf_grid.grid_scores_)\n",
+    "cv_score_df.head(2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABZgAAAEYCAYAAADRUpMPAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAIABJREFUeJzs3Xl4VOXZ+PHvmX0y2fcNkhCSE/YdRBEUBBUVl7q2trW1\nrdpNa+2v+/rWtm9t+/btqr5trdZd6lJQFBBB3EB2AuGEkJAFsu+TTGY75/fHhIGQABEyJMj9ua5c\nMGeb55nJ3Dlzn+fcj2IYBkIIIYQQQgghhBBCCCHER2Ua7gYIIYQQQgghhBBCCCGEODdJglkIIYQQ\nQgghhBBCCCHEaZEEsxBCCCGEEEIIIYQQQojTIglmIYQQQgghhBBCCCGEEKdFEsxCCCGEEEIIIYQQ\nQgghToskmIUQQgghhBBCCCGEEEKcFstwN0CIs01V1e8APwOKNE0r/4j7Xg38APACtcBnNU3zqqpa\nAVQACmAAyzVN+8vQtlwIMZKoqjoH+B3gB7qAz2ia1nzcNvnA3whd0NWBOzVNK1dVNRl4AnABZuCb\nmqZtUlXVAfwTyARswM81TVvZe6wC4Hlgt6ZpnzkLXRRCDLNIxJnefWYDzwJPapr2o7PVHyHEyHIm\nMaZ33ZWE4sy3NU37x9lsuxDi3DCYONO73R3An4BlmqatO6uNFENCRjCL84qqqt8llAQ+dBr72oFH\ngBs1TVsA1APf6F1taJq2UNO0S3v/leSyEB9/jwFf1zTtEmAt8IsBtvkj8KfemPEH4K+9y38GrOtd\n/nVCSWV6/9+kadp84Ebgr6qqOlRVjep9vlcj1BchxMg05HFGVdUxwH8Br0e05UKIc8FpxxhVVecD\nnwXWn5WWCiHOVaeMM6qq3g5MB3ac3aaJoSQjmMWgqar6Z2AOoZG7NUCjpmk/UlX1buAzhEb19gC3\naJrW0Tuq96/AFUAG8ABwFzAO+Jmmaf9SVfUxoKl32Xjgu8A1wGTgHU3TvtybWHkCSABiCI0O/vVx\nbbsN+BKh0cMQSiLXapr2yeO68UdN09yqqn7puP1HAX8BnEA08H1N0948bt8LAE3TtJrex88DvwR+\n1ft8QohBOtfjiaqqOYBD07StvYueBz447jgWYH5vGwBeAZ5QVdUGXAksANA0bZuqqubeEUJXAj/u\nXV6jqmoJcCGhL2+XAbcAowf9QgtxHpM4M2CcGQMc7u3jjwiNbBZCnIbzPMZYgW2apt3a22YhRASc\nD3Gm18uapj2pqupbp/taieEnI5jFoKiqugiYqWnaTEIJjkXHrHYAizVNuxSoBG4/Zl2DpmkLCQWR\nezVNWwZ8gaMjfwFSNU27GvgpoVsi7gFmA3eoqhoLpAIvaZq2CJgHfE9V1ehj26dp2jPHjB4+MpL4\n+OQymqa5T9DFvwK/0TTtMuBa4G+qqh7/+cgE6o55XNe77Mhr9HdVVderqvqCqqp5J3geIc57H5N4\nMlA8SD9umxSgQ9O0YO9xdaAVSDvB/pkDLK8HMjVN0zVN60EIMSgSZwaMM0fiSY+maQZCiNMmMYa0\nk3yvEkIMgfMozpwsTyPOITKCWQzWVGAjgKZp3aqqHntbZQuwSlVVHcghNDLmiPd6/60Bqo/5f9wx\n27x7zPISTdM6AVRVberdrgGYr6rqlwEfYAcSgaEMQpcC0aqqHvnC5SUUVOtOvEu43jKE6jKv1jSt\nUVXVe4DHCV3tF0L093GMJ8fGg8Fsd/y2phMsH+xxhRB9SZyReCJEJJ3PMebIOYsQIrLO5zgjzkGS\nYBaDdWRShyOCAKqqZgG/AcZpmtasqupDx+0XOMH/lUFsc2S7+wCbpmkX9T5n4/GN+wglMk6kB7he\n07TW4477PJAMaMBTQNYxqzMJBWQ0TXvqmOVPAf89yOcV4nz0cYgn1fSPB8fXdm8gdOHKomlaoPc2\n0zhCF65qevc5eMz+1ccsLz1meQ1CiI9K4szAcUbiiRBD43yOMbGE7ogQQkTW+RJnxMeEJJjFYO2j\nt/ZWbz2ey4HlhEb5NvYGtkRgCbByiJ7zSABMA/b2PvcyQnWS7cduqGnaM8AzZ/Bc7wC3EppQK5lQ\nDeZvaJp285ENemuN5aqqmqdpWgWh21D+o6pqPPAf4KreK3+Lge1n0BYhPu7O+Xiiheojt6iqOlfT\ntPfpjQfHbRNUVfVN4GbgaUK3tr3V+wVtBfBJ4Beqql4EdGqaVqmq6krgNmB9b03mfOD9E/RFCHFi\nEmdOEGdO0GYhxEdz3seYIeiPEOLkzos4Iz4+JMEsBus14DZVVT8EqgjdUhEgNMtnmaqqHwAHCE0Y\n81dVVV/jzG99OLL/P4BnVFW9nNDEEk/1/sz+qAfsLZI/nlDAfEpVVbemaYuBe4FHe6/C2YCfH7+v\npml+VVXv7G2Ln1B//9S7/Elgg6qq7YRelzs/atuEOI98LOIJcAfw595b01oIzaSOqqqfBUyapj1G\nKLY8poYm4vACn+/d96eEJsnZ2Nu2z/Qu/wuhGvDvEBq18DlN03yqqs4Cfk0odiWoqroO+Ptxd08I\nIY6SONM/zny6d99rgPsJ3VKr9CafH9T6T24shDix8z7GqKr6RUIXsVTgAlVVbwe+pmnantPrnhDi\nOOdNnFFV9YfAQmAK8FtVVVuBmzRNaz6TzoizSzGMyJY/UVV1IvAy8DtN0/5y3LrLgAcJfUhWaZrW\nL6knRgY1VOj9Ok3Tnuh9/ArwtKZpzw1vy4QQ5xqJJ0KISJM4I4SIJIkxQohIkzgjzjURHcHcO4z/\nD8DaE2zyv4TKCdQSGv25XNO0fZFskzhtncBFqqreC3gI1SR+YXibJIQ4R0k8EUJEmsQZIUQkSYwR\nQkSaxBlxTonoCGZVVU2AFfgOoRoxfzlmXR7wuKZp83sff4dQbbg/R6xBQgghhBBCCCGEEEIIIYaM\nKZIH1zRN1zTNe4LV6cCxM1E2ABmRbI8QQgghhBBCCCGEEEKIoTOSJvk75SzWgUDQsFjMZ6MtQohz\n3yljyhESW4QQgyRxRQgRCRJbhBBDTeKKECISThhbhjPBfJi+I5azepedUGtrd0QbJIT4+EhJiRn0\nthJbhBCDIXFFCBEJEluEEENN4ooQIhJOFlsiWiLjOH2y3JqmVQIxqqqOVlXVAlwNrD6L7RFCCCGE\nEEIIIYQQQghxBiI6gllV1enAb4EcwK+q6ieA/wAVmqa9AtwDPAsYwDOappVFsj1CCCGEEEIIIYQQ\nQgghhk5EE8yapm0DLj3J+neACyPZBiGEEEIIIYQQQgghhBCRcTZLZAghhBBCCCGEEEIIIYT4GJEE\nsxBCCCGEEEIIIYQQQojTIglmIYQQQgghhBBCCCGEEKdFEsxCCCGEEEIIIYQQQgghToskmIUQQggh\nhBBCCCGEEEKcFkkwCyGEEEIIIYQQQgghhDgtkmAWQgghhBBCCCGEEEIIcVokwSyEEEIIIYQQQggh\nhBDitEiCWQghhBBCCCGEEEIIIcRpkQSzEEIIIYQQQgghhBBCiNMiCWYhhBBCCCGEEEIIIYQQp0US\nzEIIIYQQQgghhBBCCCFOiySYhRBCCCGEEEIIIYQQQpwWSTALIYQQQgghhBBCCCGEOC2W4W6AEEII\nMVK0tDTzz3/+H9VVlQCkpWfwuc99kbS0jGFumRBCCCGEEEIIMTJJglmIEaaxsYGWlmYAoqNjyMrK\nHuYWCfHx19rayrp1b7B2zRt4fV6cioIJhdKOdn74w29z6aWLWbz4CpKTU4a7qUKIc5Cu62zfvoXO\nzk5cLhfTps3EYjn3T8NbW1vYs2c3hmFQUKCSnn7uX4wzDIM9e3bT2tqC0+lk6tQZH4v3SgghhBAi\nkuRsSYgRoqOjg9dfX8Hq1avQdT28/IILLuS6624iNTVtGFsnxMdPIBBg167tvPvu2+zcuR1d13Ga\nTFwaFY1qs+PDoMbv5z1PF2vWrGLt2teZMGEy8+bNZ9q0GVittuHughDiHOD3+/jnP//G+++/E142\nY8ZsvvCFu7HbHcPYsjNTWXmQ//mf/6ajox0Am83G1772TSZMmDTMLTt9uq7zwgvP8MYbr4aXTZo0\nhbvv/jpOp3MYWyaEEEIIMbIphmEMdxsGrbGx89xprBCDoOs6JSV7ePfdt9myZROBQAC71UVSfC6G\nYdDurqW7pxVFUZg0aSrz5s1nypRpktgahJSUGGWw20psOb+0tDSzdu0bvPPOetxuNwDJZjMT7E4K\nbXba9SBrfV4ciQn0tLSy0GqjJRhkj7eH+mAAgChnFBdedDGXXXaFXPw5j0hcER+FYRjs3LmN559/\nmrq6WhJNZiY5nOzxemgKBklJTuGmmz/F9OkzMZnOnWlRuru7WLVqBa+//irBYJC0pELMJhu1TXsB\ngwULFrJs2Q3ExycMd1M/ktLSfTz33FNUVBwgNtrGzMlplJQ1U9vQTVJSMjfddBszZ86JyHslsUUI\nMdQkrgghIuFksUUSzEIMg6qqSt55ZwObN78fHvnjsMWSnqwSHZVCZd0HxMQ66OzwkODKo6WjCren\nKbSdw8mMGbOYN28BhYVFKMqgzx3OK3JSJQayevUqli9/hkAggEMxUWizodocJB9z+/Nzni5u/9IX\nWbx4MWvWrOGpR/+Pm50uAFqDATSvF83vpVvXMZlMLFt2A9dcc718Fs8DElfEYPj9PjZv/oDVq1+j\nuroKBZhgd3CB04VVUQgaBps93ez0ejCAzMwslixZypw5F2K324e7+SfU1NTIunWrWb9+HT09HmzW\nKMZkzSUhNguAzu5GDlS/h8fbjsVi4aKL5nPZZVeM6FJfuq6zc+c2Vq9ehaaVADBubAKXzRuNw24h\nGDR4b+thNu+sR9cNMjIyWbJkKRdccNGQvlcSW4QQQ03iihAiEiTBLMQIUVdXy5NPPsbevcUAWMx2\nkuJySE7IIyYqFUVRKC5fyec+f3s4ufXYP55k4pir6fK00tRWTnPbQbz+LgBGjcrh9tvvoKBAHc5u\njUhyUiWOV1FRzn/91w+IMpmY7Yii0GbHfFxSuFvXWeNy8Mgjj4SX3XXXXSzu6iHqmFFrQcOg3O9j\nk6eLTl3n/vu/w8SJk89aX05HXV0tDQ31xMfHM3p07nA355wkcUWcTHNzE2+9tZa3316H2+1GAfKt\nNmY4o0g0hy5ieQ0duxKKJW3BIFt7uinzedGBqKgo5s27hIULF4+YOyMMw2Dfvr2sXfs6O3ZswzAM\nrBYHGcnjSU8uwmwK9SsQ9GEx29ANncaWMg41FuP1he4QGTduAgsXLmHatBkjZqS22+1m48a3eOut\nNTQ1hS7g52bHcuGMDLLSowHweoPY7WYAWtu9vL+tlpKyFnTdICrKxcUXX8KiRUuGpDa/xBYhxFCT\nuCKEiISTxRapwSzEWeL1evnVr35GR0c7cdHppCcVER+ThclkDm/j83uIiXWwePFiABYvXszy5cvx\n+T24nAm4nDMYnT6djq566ptLqa4+yK9//SA///mvSUtLH66uCXFOCPaWt3AoCtkWa7/kMkDAMGhq\namLNmjXhizxNTU0EHK4+25kVhSyLFadiohOdQCBwVvpwumpqqvn5z3+Iz+dDURTuu+//MWnSlOFu\n1pCor6/D7/eTmZk1YpJX4vS0tDTzzjsb2LFjW3guArPZxNSpM5k3bz4JCYnD3MKBNTTU88or/2bT\npvfQdR2HYmKq3clEu4MYc+hvfHMwwCud7XgNgziTmcujY0gyW1jkimGOM4o93h5KenpYvfo11qxZ\nxcyZc7juuk+QkZE1LH0yDIMdO7byyisvUlV1EACXM4n0pCKS43PD5y7dPa0UH3iDYNCHwxaLmruA\ntKRCUhPH0tJRQ13TPkpK9lBSsofU1DSuvvo6Lrzw4mH7rHZ2dvDaaytYv34tXq8Xq8XE5KJkpk9K\nJSUxVGO5scXDs69o9PiCJMTZuXZJPimJTpZemsvFszPZubeRnSVNvPHGq6xe/RqzZ8/luus+QVra\nuT/BoRBCCCHE6ZIRzEKcJa2trXzzm1/BanEyIf9ynPbYftv0+NzsKV/J3XffHU5uPfzww0wYczUO\nW3Sfbf2BHkrK19LV08IDD3yP8eMnnq2unBPkqr04nmEYPP30E7z55hvYFROLXNHkHFfPvCMY5KmO\nVmw2G8nJyTQ1NeHz+fhUbAKx5qMXgw77/azu7sSj68ydO48777x7xCY3d+/eyaOP/pmuLjcxrjQ6\nuxqwWi3cfvvnmDdvwTlb2sMwDJ5//unwZFzjxk3gvvu+FdEa9RJXho5hGLS0NFNRcYCyslJKSvZS\nXV0ZWqmAYg59noygDr2vZE5OLkVFExg7toC8vHwSEhKH9ffXMAzWrHmd5S88QyAYINFsZordyVib\nHctx7Xq6vZV2PRh+HG8yc1tc3xrFQcPggM/Lzt4azSaTieuuu5Grrrr2rPbT7e7kb3/7K7t27QAU\nkuJGk5E8nuio5H7t2L7vZXp8HeHHDnss09Tr+mzT3dNGbdNeGlvLMQydvLx87rnn60My8vej2Lr1\nQx577BG6u7uJdlmZMSmVyUXJOOx9x9v87dliWtu94ceJ8XbuvKXvOVYgqKMdaOXDnfU0tngwm81c\nd91NLF16zWm9VxJbhBBDTeKKECISpESG+FjRdZ26uloqKg70GTVoMpnIyckjO3vUiE30/Pvfz/Hq\nq69gMlnIzZhFauLYPl9Eenxutu97sV9ya1rRDX0SzG2dhyirfg9/wMOMGbO45557R2yfj9i27UPW\nrn2DoqLxLFt2Q8SfT06qxEAMw+Dtt9/i6acexx/wc2lUNEV2R3h9t67zeHtLv/0+G5cYLpFR4fOy\nuqsTTCZuuuk2lixZOiKTtI2NDfz738+yefMHKIqJvKw5pCUW0NZ5iNKqjQSDPoqKxnPrrbefcyUz\nOjo6ePrpx9m8+X3sNjNRTgut7V7y8sbw+c/fHbGarxJXTk8wGKSurpaqqoNUV1dSVRX6cbs7j25k\nUrAmO7BlubBnR2MAJqsJ3a/jq3bjO9SFv7kH9KMva0xMDKNH5zJqVA6jR+cwalQOGRmZZ+3v4fr1\nb/LEE38nymTiQqeLsVbbgLHgSFw5/m/7sXHlWIZhUOH38a6nC7euc/PNn+KKK646G10iGAzy4IM/\n5uDBcuKiM8jNnEWUI37AbX1+D1tLXujXrxnjbsJmdfbb3uvrorJuK81tB0lKSuanP/0VUVFRke4S\nAMXFO/mf//k1FrPCRbMymTYhBYu5/2vv7vbz13/t6tenez49megoa7/tDcOgtKKNde9V4+7y84lP\n3MJVV137kdsnsUUIMdQkrgghIkFKZIhzjmEYdHZ20NTUSFNTIw0N9TQ01FNbe5hDh6rp6ek54b42\nm42srGzS0zNJS0snNTWN5OQUkpNTiI2NG9ZE7Cc+cQujRo3miSf+Qfmh9/F428jJmBn+QmpSQiMk\nfT4fhw8fDu93ZDlAfXMp5Yc+wGy2cNNNt3H55VeN+OQywEsvvcChQzVoWgmXXnoZMTH9R3CLkc8w\nDNra2qiuPkhlZSXBYAC/34/VasVstpCTk8vo0TnExcWPyKSroigsWLCQ0aNz+d1vf8n6bjcuk4lR\nvaNeo0wm4kzmfiMNjySB6gJ+1nS7sdrs3HvftygqGj8s/TiZzs4OVqx4ibfeWkswGCTamcyY7Atw\nORMJBH3Ex2QxpeBqyg9tYt++vfz0p99nzpy5XH/9zaSkpA5380/K4+lm7drVvP76CjweDxmpLq5b\nko/DYWb121XsKS3nxz/+DvPnX8pVV11LUlLycDf5vBQIBNi3by979xZTVlZKZeVB/H5fn21MURZs\nmS4sCXYsiaEfxWwi0O6ja10dSXGJtHS3Y5+RgGNMLI4xsRgBnUCrl0BLD4FWL11tHvbs2c2ePbvD\nx7XZbOTk5DF2bCHjx09EVcdhsUTmdPfNN9/AoijcEBNHzDHlrvq9HoaBzWbrd3dS4ASDPBRFYYzN\nTrrFyrMdrbz55htnLcFcUlLMwYPlJMXlUjD64pPGcd0IDtgv3QgOuL3d5qJw9HwqrS4ON+5h8+b3\nueSSRZHqSh+rVq3EMAxuuUYlI9V1wu2CQX3APgWD+oDbK4qCOiaB7PRoHl9ewmuv/YelS5eNyL9/\nQgghhBCRJAlmMay8Xi+VlRVUV1dRV1dLY2M9jY0NNDU14vf7+22vEEr2jLbZiTaZ2KcHiU9Oxt3c\nTKFiwq3rNAYDVFaUU1FR3m9/i8VCUlIKycnJpKamk56eTnb2aHJzx+B09h9tEwmzZ89lzJix/P73\nv+bw4RIsZjvZaaHJwWxWJw5bbL/bTY+MBGpuO0j5oQ+IiYnlvvv+H3l5Y85Km89UWVkphw7VAKEE\n5caN61m6dNkwt0oczzAMPJ5u2traaG9vo62tldbWFlpbW2lpaaK5uYmGhvqTXuA5wuFwkpqaSlJS\nMomJySQkJJCQkEh8fAJxcfHEx8fjdEYN25fwvLwx3Hvft/j1r3/OG12dXO6KCSeZL4+OCddKjTeZ\nWRIdA0BtwM8qdyc68OWv3DfiksuGYfDOOxt49tkn8Xi6cdiiycucSnJ8Hh5vG5v3PNunTuq4vEW0\ndR6mqnYbH3zwHlu2bGbZshtYunTZiLto5fF4WLv2dd544zW6u7twOiwsvHAU0yakYDIpeL1Bll6a\nS2FePOs/qGH9+jfZuHE98+Yt4JprricxMWm4u3DeKC7exd///jDt7W2hBQqYY23Y46Mxx9uxxNkw\nx9ow2QZOyHq3tnLXnV8KJ/cefeLvWBaGJrxTLCasKU6sKUf/Xuu+IMF2H4F2H8E2L4E2H/vLNPbv\n11i1agXx8Ql88YtfZty4CUPeV7PZgmGAmVPHseTk5H7zK+D2nPz4gA5YzGfvdP3IuZfDHjOo+Dxg\nv07BYQtdYPb5fKfYcuj4fD5MJoX4WPsptz2dPkU5LdjtJjrcfgzDkASzEEIIIc47kmAWw+btt9/i\n8cf/xvFlWuyKQpzJRIzVRozJRIzJTJzZTKzJRKzJHJ6Y6zlPF184ZoTJU4/+Hze7Qokg3TDo0HXa\n9SCdwSAduk6nHqRT12lvqKe+vrbPiCeAm266jSuvvOas9D05OYUHHvgeDz74Y6rrd6DrAUalT0VR\nTKi5C45OmGOPRc1ZgGEYNLSUUXF4E3a7nfvv/w45Oblnpa1nyjAMli9/FoDrL8/ntbcOsmrVCubP\nv5To3sSdOLuOlJiprT1MU1MjLS3NtLa20NbWOuCFnSMUs4LJZcGWGIU51kbPwU6sujl8G3HAFMSe\nG0Oww4ff7af6UBVVVZUnPJ7VaiM+IZ6E+ESSkpJJSkomIyOTvLx80tMjP1nS2LGF3HPPvfz1L7/n\nVXcH0x1OZjiiSDJb+Hx8El5Dx66Y0A2D7T3dbPZ0g8nEnZ+/e0ROkLd8+bOsWrUCs8lKbsZM0pLU\n8ERc2sENmM2QlpZJU1MTWuUGpqnXER+TSVx0Bk1tFVTVbeXFF5+nsvIg99zz9RGTZP7gg3d55pl/\n0dnZgcNuYd6sTKZPTMVuMw84Gdfnb57A3v0tfLC9lg0b1vHuu29z1VXXctVV10ZsJKs4asWKl0LJ\nZZNCzOxUrKlOFMvgfpf0ngCJUXH9knuengAmx8DvnclmxnRc0tkI6PjqPbg31dPW1srKlS9HJMG8\nYMFC/vWvf7Cmq4Ol0XFYT5JUHGjyUBwnHkkbMAzWdnXiNwzmL7h0yNt+IkVFE3C5oqlt2ktCTBYx\nrpPf1TBQv9JOcoOSx9tBdf12zGYL06fPHOLWn9js2XM5cGA/q946yLVLxmAeoDzGEQO+V5x4gknD\nMHjnw8O0tHmZO3feiImdQgghhBBnk3zTEsNmz57dfZLLoyxWxtkd5Fpt4STyiXTrOo7EhH5fQru7\neogymTApCvFmM/FmMxxXMi9oGNQE/Oz19nDwmFt2d+3acdYSzADx8Ql861vf57e//SWHGotp76pj\nbPZFRDkSmD3hVgJBHxazDZ/fQ2nlBlo6qoiKcvH1r3/znEkuA2zcuJ7S0n2MzY1jbG48c6dnsP6D\nGp599km+8IV7hrt5553nnnsqPCnasUwOM4rLjNURhclh7v2xYHL2/htlQbGZwqOy9J4AwfLufrcR\nO8bEhhNBhmFg+HT07gB6TwDdEwz92xPs/QnQ3NFMY0NDv/ZcccVV3HzzpyL7YgDTps3g29/5MQ8/\n/L9sbW6myu9nsSuGOLMZu2LCrQdZ29VJbSBAXGwcX7rrqxFJVJ2piopyVq1agdMex7i8RdiPqdnu\n83vQ6en3Xvn8HmxWJ4qikJIwhoSYLLTK9WzdupnNmz/gggsuHMYehbz44vOsXPkyVouJi2ZmMHNS\nGrZjRr6+svoAOmYyM9NoamriP2sOcOctE5moJjG+IJG9+1vY+OEhXnnl3xw4sJ+vf/0BSTJH2GWX\nXU7FwXICfj/urY3YsqNxjInBEnfqkaNG0BgwuRcVTBv08wfavPSUd+Cr6QJCJTMWLVpy2v05mQUL\nFrJ3bzFbt27mpc42LnPFkDjAaGOLouDz+Xj44YdZvnx5uK6vxRk9wFGhLRjkza5OGoIBJk2awpIl\nSyPS/oE4nU7uvPNu/vSn37G3Yg05GTNJSywccESuSTEP2K9jy3odYRgGLR1VlNe8TyDo49Of/vxZ\nneRv4cLF7Ny5jb17i3l2RSlLL80lIc7Rbzuz2TRgn06UkPb0BHjz3WpKylpISUnllltuj3BPhBBC\nCCFGJvNPfvKT4W7DoHV3+34y3G0QQ2f8+Ak4HA58Pi/t7e20B4Mc8PvY5e2hPRjEaTLhUkwDfqnx\nGwabO9pITEwkPz+fNWvW8PbbbzPJajvhCKKmQICtPd2s63azz+elTQ+iKAqjR+dy8cWXcPPNn8Th\n6P9lI5JcrmguvHAezc1NVBwspaGlDIvZhsuZhNlkobWjhpKDa+nytFBQoHL//d9m9Oics9rGM9HS\n0swf/vBbTIrBDVeOxW4zk5HqoryqnX3aAXJzx0RspKrLZf/pYLc9n2LL1q2bqays6LPMmh6FPTsa\nZ34cjoI47JkurClOLAl2zDE2TE4LiqXvZ1H3BolzO7n33nsByM/PZ926dfhTlPCt74qioFhMmJwW\nzDE2LAnlhlGpAAAgAElEQVR2rClObBkubNkurAkOTA4zmBR0d9+R09nZo5kyZXqEX42QxMRE5s27\nhPb2NvZVVlDq85FpseAzDF52d9AaDDJjxizu+8b/Iytr1Flp00e1e/cOduzYxuj0acTF9P1M+YNe\nDHNLv/fKZc/CYraFtzOZLNht0TS2HiA1NY0JEyad1T4cr6ammkce+RMJcXZuu7aIwryEPkked7ef\nTTuauPvuu7n33ntJTEzkvfe3MFFNxGY1oygKqclRTC5KpqG5m9KyKpKSksnJyTvtNklcObWsrGzm\nzbsEm81GQ10dXXXteCs6CbT0hOPJCekGXfta2L59O+vWrePtt9/G5/PhVONPOQra39JD19ZGuotb\nCLb5SIhPYMniK/niF79MXl7+EPcyRFEUpk+fSWdnByUVByjx9uA1dFLMlj7nIlZFYb/PS3cgQGdn\nJ8FgkHiTmenOvhPceXWdLZ5u1nncuHWduXPn8aUvfQWLpf/kcpGUnp5Bbm4eO3Zso7HlIK2dh7Db\norHbovv8HTCbrTS1VuD1dYf75bDHkp3aN3a4u5s4UPMehxuLMVtMfPazX2DBgoVntU8mk4mZM+fQ\n2NjAPq2cnXub6PEFSUt2YrUeTYjbrGZKylro6vaF+5QYb+eCacfF1YDO9uIGVqytoLahizFj8rn/\n/u8QHz/whIinIrFFCDHUJK4IISLhZLFFOb48wVBTVfV3wAWEysjdp2nalmPWXQt8H+gBntM07c8n\nO5bMbvrx5fF4KCsrZc+eXWzZspmWlmYAYk0mcqw2sixW0i1WnMfcdvh0eysey9Hb86MCQW6LSwiv\n9+o6dcEAh/x+qvw+Wnsn7YqLjWP6jNlMnDiZwkIVl2vgEURn29atH/L443/D7e4kNbEAhy2Gqrpt\nWK1WbrzxNhYtWnLO3Xb5xz/+ju3bt3D5/Bxa2kJ1ey+Zm01js4cnXiwhPj6BBx/8DXb70Cf2Zebk\ngem6zv79Gvv27aWi4gAHD1bQ0dEeXm9ymLGmRWFNdWJJsoeSywNctNF7AnStres3KtZ1WfqAt7Ib\nhoHeHSDQ4sXf0I2/zoPuPToRVGxsHLm5Y8jLG0NR0XgKCtRh+X3fuHE9jz/+N3T96IROt956O4sX\nXzmia2oePFjOz372A2Jd6Ywfs7hPW3t8bvaUr+z3Xk0YczUOW9/4d6DmfRpa9nP33V9j9uy5Z7sb\nfWze/D4PP/xHLpmbzazJ/Uewtnd6Wbm+hUceeSS87K677uLqSxKJi+k7WvZQnZunX9G47LIr+OQn\nP3PabZK48tEEg0F27drB6tWvoWklANgyXTgK47AmDhz3W1dX97ngZIq2krBk4As7hmEQaPHiKW3D\nX9sNwLhxE1iyZCmTJk05qzFkx46tPP3U4zQ1N2FVFCbYHExxOMMThDYHA6x2d9KmB8O13ZN6Rzt7\ndJ3dXg+7vT34DIOEhERuvfV2Zs264Ky1fyCtra08//xTbNr0HgDRUclkpU4iISY7HGO6e1rRKjfQ\n4+0Il/WKcoTOxTrc9Rxq3E1bZ2jS4gkTJvHJT36WjIzM4ekQod+ZLVs28dxzT9HS0ozVYmLyuGRm\nTUkjxhW64NbY4uE/aw7Q0uYlMd7OssX5pCSGSrB4fUF27G1k664Gujx+HA4ny5Zdz+LFV2I2n3ii\nx1OR2CKEGGoSV4QQkXCy2BLRBLOqqvOBBzRNW6aqahHwD03TLuxdpwCVwFSgFXgNuFPTtMMnOp4E\nvvODruvs3VvMO+9sYOfObXi93vC6eJOZDIuFLKuNGEXhre6u8Je1ha5ounSdmoCf2oCfluDR5JXV\namXSpKlcdNHFTJ487Yy+BERSS0szv/nNL6mrC30MXK5oHnjge+dUSYwjNK2E//7v/yI7PZpblxXy\n6NPFGIbB3beHJjTcuPkQH2yv4/rrb+Kaa64f8ueXk6rBMQyDlpZm9u/X2LNnN7t27aCz8+gkk4rN\nHJqUq/fnyARdikmhdXU1Fp9ytAazzSBhySgM3SDY0TvpVu9PoN2H4Tv6mYyJiWXy5KlMmDCJggKV\nxMSkEZPAffvtt3jyycfQdZ0bb7yNK664aribNCi///1D7Nq1ndHp08lKnRhe7vN72FryAjabLfxe\n+Xw+Zoy7KTyBKEBzexWllevJzMzmJz/5xbCXkmhoqOe7372fxHg7n75hHNbjRrC2d3r55/LSfonz\nO24s7JNgNgyDV9cdpKSshbvu+ipz5px+6Q+JK6evpGQPy5c/S0XFAQDMcTbso6KxZbkwu46O0A20\n++h4+zCGX8cUbSVmThqWOFufYwXdfnyHuvBWdxLsCCWj8/MLuPHGW1HVcWevU8fx+/1s2LCO1159\nhbb2NsyKwkSbnWmOqPAF8iO13SF0IXy710Oxtwe/YRATHcOVS69h4cIl2Gy2kz3VWXXwYDkrVrzE\n9u1bAYhyJJCdNoXE2FHhuH2krBdAu7uO6voddHaFyh+p6jiWLbthRJUX8vt9bNjwFqtWraC1tQWT\nSWGSmsTcGRnhRLPXG8RuD50v+nxBtuyuZ8vuBrzeIA6Hg4ULl3D55UuJiTlJ0elBktgihBhqEleE\nEJEwnAnmnwKVmqb9o/fxXmC2pmluVVVTgLWapk3pXfctoF7TtCdOdDwJfOefQCDAgQP70bQS9u/X\nKCsrDSecTUCO1YZDUfAZBpUBP4He32er1Up+fgFjxxaiquMoKFBH1Je1k2lpaWbVqpX4/T4WLlzM\n6NG5w92k0/Lb3/6SPXt286nrirBaTTyxfC+6QXgirrhoG48+U4xisvPb3/5xyEcxy0nV6dF1ncrK\ng2jaXg4cKKOysoKmpsa+G5kULPGhhLO/rhvdE8TkNGNNjwolk9t8oPd9SVNSUsnJyWXMmAJUdRw5\nObkjekT+kb+NIyXpPRhtba389Kffp729jbzM2aQnF4XXbd/3Mj2+oxcOHPZYpqnXhR+3dtRQWrkB\ni9XM97730xFTiufJJx9j3bo1jBkdyzWXjcF2zK3s7m4/f/3Xrn6J83s+PZnoqFDC0jAMNm4+zKYd\ndeTl5fO97/1ERhkOI8Mw2Lu3mHXr1rBz57bwnQLmeBv2rGhso6IxR4UubOh+HZP1aIwIdvvxVbvx\n1nQRbA/Nn2A2m5k6dQYLFy6mqGj8iPm8+v0+3nlnA6+ufIWW1hZsisJcp4txNjuKomAYBqU+L+95\nuukxdOLi4lm69Brmz1+I3X7qWtXDpaammtdee4VNm97HMAxiXGnkZ8/FaQ8lWH1+DxWHNtHSUQXA\n5MnTuPrqaxk7tnA4m31SgUCA999/h1dffYWGhnosFhMXzshg1uQ0TKbQ75NW3sqb71bT1e0n2hXN\n4iVLWbRoMVFRJ56k8aOS2CKEGGoSV4QQkTCcCeZHgJWapq3offw28HlN08p6H5cDi4Eq4BXgLU3T\nHjrR8STwiWAwSFVVJcXFO9m06T0OHz4UXpeSksqcORcyefJUcnPHDPvou/NZbe1hvv/9BxiVGc2t\n16j87dliWtuPjkRPjLdz5y0TeefDw7y/rZY77vgi8+dfOqRtkJOqoePxdFNTU01NTRVVVZUcPFhO\ndXVVnzISR5hMJkaNGk1eXj6jRo1m1KgcsrKycR5Xa1RERk1NFQ899As6OztITRhLbuYszGYr3T2t\nFB94g2DQ1+c2dsPQqanfRU3DLqxWG1/72v1MnDh5uLsR5vf7+eMff0tx8S6SEhwsvTSX9JSjSZ0T\nxRaAzi4fq9+upLyqg5SUVL7znR+RkJB4Ru2RuDJ03O5Otm3bwocffkBJyZ5wPLGmRxFVFI+lt4SG\nv7kHz75W/PUeIJRUHjduIrNmzWHatJlER4+MMlcD8fv9rF+/lpdfXo7H46HQZmeu08WHnm72+nqw\n2+xcs+x6LrvsinPmIjiE/sa/8MIz7NixFbPZSn72hVjMNsqq38Xn76agQOXWW2+PWO3rSAgGg7z7\n7tv8+9/P0dnZQW52LJfNG8224ga2FTdgtVq58spruPzyq3A6nac+4EcksUUIMdQkrgghImEkJZg3\nAp87JsF8MfAg0EYoyVyladqvT3S8QCBoWCwjs7SBOPsMw+DQoUMEg0FMJhOZmZkjtvTF+ebxxx9n\n+fLlXL0oj1GZMfz1X7v6bXPPpyej6waPPLWboqIiHnrohNeWTtegT6oktnx03d3dbN26lQMHDoSX\n5efnM2PGDKKiJJk8nOrq6vjlL39JeXk5DlsM+aMuJNYVqmF87G3s3T1tlFW/S5enmeTkFL73ve9S\nUFAwnE0fkN/v5x//+AcrV64EYMr4ZObNzCLKaRmwVmpCnJ2tuxv4YFsdPn+QqVOn8sADDxAXFzcU\nzZG4EgGdnZ289957rF69mtLSUiBUexnDQO8KAFBUVMTixYu58MILR3RSeSBNTU384he/YP/+/eFl\nOTk5/OAHPyA9PX0YW3Zm1q1bxx/+8AeCx5Qku+OOO7j++utH9B0qJ9PR0cFDDz3Ejh07wssyMzP5\n4Q9/SHZ2diSfWmKLEGKoSVwRQkTCsCWYfwwc1jTt/3ofHwAma5rWNcC2vwB2aJr2/ImOJ1fWhBj5\nDMPg29++l472Vr78mcl0e/w8+nRxv9vYv/TJicTF2HluZSlVhzp56KE/kJSUPGTtkKv24nzm9/t5\n+eXlvP76SgzDICt1MqPSpoRLCNQ3l3Kw9kN0PcjcufP41Kc+O6S3e0dCSckennzyMWprD2O3m5k/\nO4sp45JRFCVcK/VgTQdr36mitd1LtCuaG2+6jYsvvmTISidIXIm8ffv28txzT9HUFKrfm5qazi23\nfIrCwqJT7Dmyud1uXn75Bdrb24iJieW6624kNnZILnoMqz17dvPeexsxDIOpU6cP++SgQ8Hn87Fi\nxYs0NzfjdEZx9dXXnvHdD6cisUUIMdQkrgghImE4RzDPBX6iadrlqqpOB36vadr8Y9a/BnwW6Abe\nBy7RNK3lRMeTwCfEyFdfX8d3v3s/6pgEli0ec8qJuLYVN/Dmu9V87nNf4uKLLxmydshJlRBQVlbK\no4/+maamRpLicikYPY/q+p0catiNy+Xijju+xIwZs4a7mYMWCARYt24NL7+8nJ4eD3mjYrlm0Rhs\nNhMbPjjEh7vqURSFRYuWcO21n8DlGtqRrhJXhBCRILFFCDHUJK4IISLhZLElokVqNU17X1XVraqq\nvgsEga+oqvpZoE3TtFeA/wNWAzrwi5Mll4UQ54a6uloAUpOP1ihMTk5m8eLFACxevJjly5eH16Um\nR/XZTwgxdMaOLeTHP36Q//3f31BWVkpLcRWGoZOams4DD3yX5OSU4W7iR2KxWFiy5EpmzbqAxx57\nhOLiXTzxYgkx0VaqD7tJT8/grru+Sk5O3nA3VQghhBBCCCHOGxGfBU3TtO8dt2j3MeteAl6KdBuE\nEGfPkYmKfL7QhE1ms4mmpibWrFkTHsHc1NSE2Rwqh+H3hWo3Wq3W4WmwEB9zLlc09977AD/60Xdo\nbW3BZrPzjW9865xLLh8rISGB++77fzz88B/ZsmUTbR1eMjOz+e53fzTko5aFEEIIIYQQQpxcxBPM\nQojzS25uHlarlZKyFubOyCA6yorLqfDwww+zfPlympqaiI5SiI4KJZR3aU0AqOq44Wy2EB9rLlc0\nP//5r2lrayMmJobo6JjhbtIZM5lM3HXXV7ngggvx+XxMnjxNJpgUQgghhBBCiGFwbk7xLIQYsZzO\nKBYtWkKH28db71cDcO2SfExKkMOHDxMdpbBscT4Ae/e3UFrexpgx+RQVjR/OZgvxsed0RpGRkfmx\nSC4fYTabmT59FhdccJEkl4UQQgghhBBimMgIZiHEkLv22hspLt7Nzr1VxMfamT0lna/dMRWvN4jd\nbgag+nAnr2+oxOFwcOed96Aog56HQgghhBBCCCGEEEKMEJJgFkIMObvdzr33PsAvHvwxGz44RJTT\nysTCpHByuaG5m5feOAAofOUr3yAjI3N4GyyEEOeYlpZmNm5cz6FDNeFleXljuOiiBcTGxg5jy4QQ\nQgghhBDnG8UwjOFuw6A1NnaeO40VQnDoUA2//OVP6OnxcMvVhWRnRNPl8fOvf++js8vHXXd9lTlz\nLozIc6ekxAx6SLTEFiHEYAxnXOns7ODAgTL279coKdnDwYPlA26nKAr5+QWMGzeBggKVMWPGSvkQ\nIUY4OWcRQgw1iStCiEg4WWyREcxCiIjJysrmq1+9n9/85he8uq6Cz908ntVvV9HZ5eOGG26OWHJZ\nCCHOZYFAgOrqSsrKSikvP0B5eRmNjQ1HN1AUzFGpWGJHY4nOxNCDKCYTgc4a/B1VlJXtp6ysNLx5\nRkYmeXn55OePJT+/kOzsUZhMMg2HEEIIIYQQYmhIglkIEVFFReNZunQZK1e+zMurD1BZ00lhYRFL\nly4b7qYJIcSI0dTUyPbtW9m9eyelpfvw+bzhdYrZhtmVjtmZhNmZjDkqGcVkJdjTRlf566D7UGwx\nOLMuwpaoYgR9BLsbCXqaCHqaqatvpLb2MO+9txEITfhYVDSOSZOmMm3aDOLi4oer20IIIYQQQoiP\nASmRIYSIOI/Hwze/+VV6ejwAfPe7P6agQI3oc8ptYUKIoTbUcaWhoZ5t27awZcsHlJcfCC832WIx\nR6VijgollBVr9IAToboPvIrh6zxmvxhc+Vf1284wDHRfB7qnmWB3I4HuBgx/FxAqqVFYWMTMmXOY\nNm0GiYlJg+2iEGKIjJRzlsrKgzz77L9oaKjvszwnJ5dbb/00qalpkXrqiNB1nb17d/Paayuprj7Y\nb31eXj5XXnkNRUXjz6nJpt3uTjZseIuNG9/C5/P1WWezWrlo3gIWLFh0TtXjNwyDsrJSXn99JRUV\n/UtAZWZmccUVVzF+/KRz6g4cj6ebjRs3sGHDm3g8nj7rLBYLc+bMZeHCy0lISBjy5x4pcUUI8fFy\nstgiCWYhxFnx4ovP88Ybr5KfX8C3vvX9iJ/Iy0mVEGKoDUVcOXz4EO+//w7bt2/h8OFDvUsVzK5U\nLDGjsERnYrKeumayHvDQtf8VbDYbycnJNDU14fP5cBVci8niPPX+vk4C7sMEOqoJeprCy3Nycpk+\nfRZz584jOTllcJ0VQpyR4TxnMQyD/fs11q59na1bP8QwDBSLE5TeJJ4ewAh6MZvNzJ17MYsWLSEn\nJ3comzCkAoEAZWWl7Ny5nQ8//ICWlmYATC4Livnoy2wEDfSuAADJySnMmnUBU6ZMY8yYsVgsI+8m\n3/b2doqLd7Jt24fs3rWTQDCARVFwHXc+3WUYBAwDs9nMpElTmDZtJpMmTSE+fugTmGdK13UqKsrZ\nuXMbW7Zsoq6uFgCrxYnZdPQ90A0dX+9F0cTEJGbNuoCpU6eTn18wIt8rt7uT4uLdbN++hR07tuH3\n+zCbFGKibX226/b48fl1TCYT48ZNYMaM2UyaNIWkpOQhaYd8FxJCRIIkmIUQ5x05qRJCDLUzjSsr\nVrzESy+9EHqgmDG70rBEZ2GJycJkcXyktug+N/7q1dx9990sXryYNWvW8PDDD2MdtQSTLfqjHcvf\nTaCzhoD7EMHuBug9N7zjji8yf/6lH+lYQoiP7myfsxiGQVXVQbZu/ZBNm94L13g3ORKwp07B4krv\ns22gsxpf42703jsmsrNHM3v2BcyYMYuMjKwzbc4Z8fv9VFZWUFq6j337Sijdvw+fN1RiSLGasGW6\ncIyJxZJg779vcw89FR34D3djBHQAHA4HhYXjUNUiCguLyMnJG5YkZltbK2VlpWjaPjRtLzU11eF1\niSYzRXYHRXY7dqXvaF6fobPP62Wfr4fmYDC8PDMzm6KicRQWjqOgQI3IiNlTCQaDVFVVsn+/hqaV\noGkldHeHEscmxUxC7CjSkgqJdaX1G4ji7m6irlmjpb2KoO4HwG53UFiooqrjwu+V1Wo96/3q6Oig\nrEyjtFRD0/ZSVVXJkRxLQpydiYVJTB6XQpSz7++R36+zZ38zxVoTtQ3d4eVpaenhiXoLC4tOO+Es\n34WEEJEgCWYhxHlHTqqEEEPtTOPKr371M0pL9wFgjkrB7EzGZIvFZItBsUWjmO2DvrtDD3iI6/qQ\nRx55JLzsrrvuot01a1AjmCGUODICPej+TnRfJ7q3g2B3I3pPCwCzZ8/l7ru/NqhjCSFO39k4Z/F6\nvezbt5ddu7azY8d2WltDI3sVkwVzdBbW+HzMUSknjEGGoRN01+JvKyfQVQtGKCGblpbBlCnTmDJl\nGgUFasSTsW63m/37NcrKStm/X+PgwXICgUB4vTnGijXViTUtCmuKs8+oZQDdr2Oy9k3KGkEdf4MH\nX50Hf4MHvcsfXme1WsnLy2fs2EIKClQKCgqJinINaZ90Xae29jClpfsoKyulrKy0z8SuZkUhw2wh\n22ol12ojwdz/NfYaer9kc1swSKXfR7XfR20wQOCY7/3JScmM7e1PQYFKZmb2kJee8Hg8HDhQSmmp\n1jtpbVmfkh52WzRx0enEx2QRH52J2dw3ORwI+rCY+4761fUg7e5aWjsP0e6upcfbEV5nsVjIzR1D\nQYEafr+ioz/aBddTMQyD+vq68Hu1f79GfX1deL3ZpJCZ5iI3O5YxOXGkJDr7faa83iB2u7nPsvZO\nLwcq26mo7qCm1o3Pf/TiQEJCImPHFjJ2bCGFhUWMGjV6UO+VfBcSQkSCJJiFEOcdOakSQgy1M40r\nzc1NvPbaCoqLd/ZJHhyhmKwoVhcmqwvFFo3JGo3JFh1KQFujUI4fqVb9Bnd9/tPhEcyP/uNfWEdd\n3mcbw9Ax/F2hBLLPHfrxu0PL/G7QgxwvPSOTqVOmccUV15xTNTyFOFdF6pylo6Oj9zb9rezdW4zf\nH0qchiYOzcASk40lOgPF1D9haQR9KMcl945dF+g8FLrroasOQw8leB0OJxMnTmbatBlMnTodp/PU\n5X5ORdd1yspK2bFjG3v27Kampio8OhQFzHE2rIkOLMkOrEkOTM6BE9yBdh+dm+rR3X5M0VZi5qRh\niRu4f0FPgEBTD/7mHgLNPQQ7fHDkKRWF0aNzmTBhElOnTmfMmLGnlZjt7Oxgx45tFBfvoqSkGLfb\nHV5nVxTSzBYyLFYyrFZSzRbMJ0j8NwcDvOHupF0PEmcyc3l0DEkDJKCDhkFjMEBtwE9twE9dIID3\nmDyAy+Vi3LgJTJw4halTpxMbG/eR+2QYBhUVB8LvVWVlBbquh9c77fHEuFKIdaUS60rDfoK7bbp7\nWtEObqDH14HDFouau4Aox8Ajrn3+bjq6Gujsqqezq5GunlbCbxYwatRoJkyYxJQp0ykoUE/rveru\n7mLnzu3s3r2TkpJi2tvbw+tsVjOZaS6y0qPJTo8mI82F1TLwczS2eHhl9QFa270kxNm5dkk+KYn9\nLwjrukF9Uzc1tW4O1bk5VO+m23P0IorT6URVxzNp0mSmTp15wtHo8l1ICBEJkmA+zwQCARob6zl8\n+DA1NVUcOLAfTduH3x+6Ymy1WiksLCI/v4BRo0aTkZFFamraiKxhJcTpkpMqIcRQG8q44nZ3cuhQ\nDbW1h6mrq6WxsZ7GxgYaGhrw+bz9d1BModHOjnjMjkTMUakYGBiNm0mMddLS4UFJmY1i6AS7Gwn2\ntKD3tIWSyIbe73AOh5PU1FRSUlJJTU0nLS2djIxMsrJGERV15kkhIcTgDWVsMQyDXbt28NZbaygu\n3hVO8JlssVhiMjFHZ4YmD1UGToIFe9oINm4iKdZJc4cHc8oczI74Ez+fHiTY3RCq6e4+HJ5A1GKx\nMG3aTBYtWkJhYdFguxem6zrr1q3h9ddXhusoY1KwJNqxJvcmlBMdKCdI5h2vdXU1Fp8SrlkfsBkk\nLBk1uLb4dQItPaGkc1MPgVYv6KG3ITkllaVXXsOCBQsHdQdKfX0t//7382zb9mH4vXGZTGRZrGRY\nrKRbLCSYzIO+m+Xp9lY8FnO4X1GBILfFnbr8hWEYtOlBagOhpPPhgB/3kd8Vk4mpU2fwiU/cPKgS\nKIZhsHHjel599ZXwxVNFUYh2JhPrSiPGlUpMVAoWS/8yJQPZvu9ldHrCfTIpDqap1w1q32DQT2d3\nI51dDXR0NeDubkQ3QhdS4+MTWLJkKYsXX4HZbD7FkaClpZkXX3yezZvfD4+SdzmtjMqMJjsjmqz0\naJITnJhMg3uv/vZsMV0eI9yv6CiFO2+ZeMr9DMOgrcPLobouauo6qTrspr2jtwyMojBx4mRu+P/t\n3XmcnXV99//XWWbPTCaTTPaFbFxAwl4EQUCBgCiouBS8va1Lua0t7V2ttf3VLne1t9pWsRbbitpS\n71rrggurIkGgKKIYIBAg+UL2kMk2yez7WX5/zCQkk8zkzMk5mTPJ6/l4zIM517nOdb7fuSZvrvlc\n3/P9vv3Gw+ZG928hScVggfkE1d7exrZtW2lq2s6uXTvYtWsnu3fvorl5D8PPa7w6SaYnNXhDN8bB\nN3aBwf85TZ06jRkzZjJ9+kxmzpzF7NlzmDt3PpMnj/0OtjTexvuiKpVKsWvXTrZtG5xr7uWXw4GL\n0/Lyck499XSWLDmV+fMX0Ng4PacLXUnj63jkSjabpaOjnd279xecd7Fr1w527GiiqanpwM1igFhZ\nNfGySWSzGWKxOJn+drKp3gPPV1RUMnv2HGbNms2MGbOYPn0606fPoLFxOjU1k4q+2Kqk3BQqW1pa\n9vHlL9/G+vUvARCvbKCsbv7gPO/ltTkdP5dPRowkm82S6WsbnNO9fSuZ/sHpC84553xuvvl3x3Tz\n6s47v8WPf3wvsWSc8jk1lM+poWxa7gXlg2V6U3Q9tPOwOetrrppJvHLsA2yyqQwDe3ro395F//Yu\nsuksN9zwLq6//oZRX9fe3sYnPvExuru7mZpIsLS8glPKyqkfQ0H5YN2ZDN/q6TysX++umkT1GEfq\nZrNZ2jIZNg/08XJ/H83pNJWVlXz6059nypSGUV9733138YMffJd4PEFD3XymTl7A5EmzDpvyIhf9\nA/QuUUUAACAASURBVD2s2XD3YX06c/FbKS/Lbfqng6UzKdq7drGvbSt7WzeTzgzwhjdcxXvf+8FR\nX9fb28snPvFHtLa20lBfyRlLG1iyoJ5pDZV5navO7gH+7TvrDuvXb994GpOqx/5zam3vY+PWNtau\n30fTri6SySSf/ORnD7khMN5/C0k6MY2WLQ5ZnSD6+vrYtm0LGzduYP36l9iw4WVaWvYdtl+8IkGi\noZzEpDISteUk6spJ1lfQ9lgT5WWvrjSfKstQc/Y00u39pDsGSHcOsK9jH83Ne3jhhTWHHHPKlAYW\nL17CkiWnsmjREubNm09FxdgWI5JORJlMhr17mw+6wbOb3bt3Hvg+c/BHz+MJiCWJxWJk0wNs3bqF\nhx56AIBEIsmMGTOYMWMmjY0zmDFjxoEbPVOmNBR8TjxJpSsWi1FXN5m6usksWXLqIc9lMhl27tzB\nxo3refHF51m9+il6u1+daqOmZhLnXvR6zjhjGQsXLqaxcbr5IZ1E7rjjK6xf/xLJ2rmUT1tGYoRp\nBUaSSfUwta6KFStWALBixQq+973v0ZbqyWlu91gsRqKynkRlPeXTlpHu2UP/nsGsuvPO/+J977s5\n57Zs3boZgIpFdVSfPuWwuZTHIpseHDU6vF/d6fxqarFknPJZNZRNr4JknL6N7WzZsvmor9uzZzfd\n3d1UxWJcWXPkqSzGIpU9cr9SnT1jPlYsFqM+keCcRDULysq5t6Odrt5edu/eddQC8+bNmwBonLKE\nU2b9BvF4/oMmMtn0Efu0fxTyWCXiSabUzqF+0iwqyyexdeczB9o7mra2VlpbWykvT/CmN5zCrOnH\nNu92Op05Yr/S6cM/YZSL+roKzls+nUXzJ/P9H7/MvtY+tm/fPu6Lbko6uVlgLlFNTdt59tmn2bx5\nE9u2bWHXrp2HjEqOVyQom1lNcvJgETkxqYzEpDJiZYf/IZnpTZHsjx12xzRZX075zENHEmQHMqS7\nBgaLzu39pNr6aWtpY9WqJ1m16klg8AJk+vQZzJu3gIULF3HWWecyZ87c4v5ApHGWTqeHppxZz+bN\nG9m6dQs7dmw/MJ/hwWKJcmIV9STL60hU1hOLV5BpWcO0hsnsbe8hPu0yyKbI9Owj3ddKpq+dHTt3\n09S0/bBjlZeXM2fOXObNW8Appyxi8eKlzJlT+IVYJJW+eDzO7NlzmD17Dq973eWDi/QddG0Qi8Uc\nlSydxFpbWyAWo2zK0jEXlwHIpGlubmblypUH/mZobm6mrGrsxb1YLEayejrZ+kWku3fT0tIypte/\n/e2/yZYtm+h8qZX+bZ1ULqmj8pS6I/6tk4sj9auaGXkdK9Ofpm9TB70b2sj0pqmrm8xb3/qOo75u\n0aIlXHLJZTz++GN8t72VRWXlnF1Zxczk2Eew7nekflGZXzF0d2qA1b09bBzoJwtcdNHFLF0aHfV1\nb3nL21m//iV27Q20tG1l5rTTmTH11MMW6MvVkfo0I8/lANKZFHv2raep+UX6+juprKziXe9691Ff\nN2PGTK655s385Cf3858/XMfCeXW85uyZzJud/6d/jniuGL14P5I9e3v49XO7WLt+H5lMljPPPIdz\nzjkvr2NJUqE4RUYJ2rGjib/4i48fNs1FsqGCspnVlM+uIVFblvtK870pqlanDltpvuecZE4fC8tm\ns6Q7BhjY0UX/jm5S+w6dGzIWi/GpT/2dRWaVlGP9WNjAQD/r1q3lpZfWsn79y2zatOGQla+JJQbn\nQ62oI15ee2Ahrnj5JGKJQ+eYy20hrizZdB/Z/k4yA/sX4+og09c++BHTg+ZQraysZNGiwU8VRNHp\nx2XVdkl+3FRScRQqW1avfop/+qd/IJPJUFa/hIrGM4nlOO8tQKa/k64N91Fe/uqnHvv7+6lZfB3x\nERZkG/FYA1307X6WVPtWKioq+PjH/5xFi5aM6RgdHe3cf//dPProT+nv7ydWFqdycR2VS+uJj6HQ\nnO4aoPUn2w7rV/0180jU5F7czfSn6Xmpjb6N7WRTGSoqKrjiiqt505uup6Ymt5/P/jmy7777ewdG\n0s5KJrmgspo5ZWMryLan03yzveWwfr2nbgp1Y5h6rWlggFW93WxPDQ6amDdvAW972zs455zzc/57\ns6urkx/96F4efnglfX29JOJlzJh6KrMbl1M2ht/B3v5Onln3g8P6dO5pb6dyDL+D6fQAO/auY2fz\niwyk+kgmk1x66eu57robRlwU70jWrn2Bu+76Hi+/HACY2VjNxefPZtH8ujEVmts6+vjqfz1/WL8+\n9D+WM7k295/Pzj1dPL5qBxu3Di40OGvWbK6//gYuvPDiw9rjNYukYnAO5gmms7OTW2/9LFu2jPzx\nnVgyTqw8TrwiQawiQXzoK1aZIF6VIF6VJFGdJFYxOKdX18O7+NBv/farBa7/+Deq3zCdbF+adHeK\nTE+KTG+abE+aTN/gV3b/f/szZFMjf3xn/vwFfOxjf0ZtrSvNq3Qcy0VVc/Me/uZv/pKOjvYD2+IV\nk0lUTSVRNY141VTi5bUjLpBzsEyqh8ldvz7sBk9bzQU5fdwUIJvNkOlrI92zl3TPXjI9zWT6Ow48\n3zB1Gv/nr/6v/walIvOPNUnFUMhsWb/+Je6446vs3NlELFFOeeNZlNUvzqkYtr/APNxYCszZbJr+\nvesY2LuWbCbFokVL+OAHf4fZs/P/6H5nZwePPPIQKx96gM6ODuIVCarPmkrFvNzalOlN0fKjrYdt\nn/Km+TkPtunb2kn3mn1k+wdHLF9zzZu4/PIrqK7Ob7RwNptl3boX+fGP7+P5558FYGFZOZdWT6Im\nx0+pdWcy/L+2w6dMfN/khpzmYO7OZPh5dycbhub2X7bsTN74xus444zleY/S7e7u4tFHf8qDD/6Y\n9vY2kolyFsw6n8YpS3I6Zv9AD0+tvfOw7eef/q6c52De17aVTU1P0j/QTVVVNVdeeTVXXnnNMa0r\ntGHDyzzwwH089dSvAVgwt5ZrLluQc3G4s3uAL3/jucO2/+57z8ppDubevhSPPvEKa8LggpdLlpzK\nm950PWedde6In2r0mkVSMVhgnqA6OzvYuXMHzc17aG1toa2tjfb2wa+OjnbaO9rp6OggPbRw2JHE\nkvHB0c4VceLtGabWT2Vv615SyQyZ7vSoheNEMkntpFpqa+uoq6ujrm4ytbV11NfXU18/halTpzFz\n5iyLWipJx3JRtXXrFj71qT8/sLo3DE17kawa+qoknqwklhj8fv9XPFkF8UM/XZBJ9TCw5ceHTVFT\ntuDawwrM2WwWMgNkUj1kUz1kU71kU71kUr2Dj9O9ZAeGnsu8OjVHMpnks5/9AlOnThv7D0pSzvxj\nTVIxFDpbUqkUDz30E+6+5/v09faSqJ5O5ZzXHvXGdibVQ9fLdx+2vWbpW3O6KZ7pa6dn+y/I9LVS\nW1vHO995E5dcclnBpvXq6+vlwQcf4L77fsjAwADl8ycx6ZxpOS381/LgNjKdr147xSeVMeXqeUd9\nXWYgQ9fTe+jf3kVFRQVvecvbufLKaygvz2/6hyPZtGkD3/72f/Lyy4HKeJwrqiexIMfRzP/V1kLb\nQWt+1McTvHvy0UfovjLQz0PdnfRkMixevJSbbvqfLF68NO8+DNff38/DD6/knnu+T29vLw1181k8\n97UkcxjN/My6u+jtf3WQR2VFHedGbzvq69KZFJubfs3ufS+TTCZ54xuv49prr6OqKvfFJY/mlVe2\n8d3vfpPnn3+OivIEV182n9MW5zbNxb9++3la2l79JHBDfQW/fePyo76uaVcn9z60ifbOfubNm89N\nN72X009fdtTXec0iqRgsMJ/AstksPT3dtLe3097eRltbKy0tLbS07KO5eTe7du2kqWn7IYUyGJzH\ncdas2cycOYupUxtpaJhKff0U6uvrhxYXqqOqqtq5HDVhHetF1e7du3jhhefYvv0Vdu/ezb59zbS0\ntNDT0z36weIJ4slqYmU1xMsmEa+opX9voCyeOvCRuIFsOZWzfoNMb+vgNBj9nWQGusimeuAoi5hU\nV9fQ0NBAQ8M0pk+fzty581m+/CwaGqbm2l1JefKPNUnFUKxsaWlp4Rvf+DdWr36aeFk1lfMuJ1Ex\n+ijOzg33kz3oU1Lx8lpqFr/5qO+V6t5N7ys/I5se4HWvez033fSevEf3Hs3u3bu4/StfYvOmjSRq\nyqg5d9rggnujta+tn7aHX4HsYHG59sIZJCePXsTt39lN1+pmMt0pli6N+F//6/eYNq2xkF05IJPJ\n8PDDK/nud/6TVDrNsopKLqyspuIoxfm96RTfa28lw2Bx+epJoy8e2J/N8GRPN2v6ekkkErzjHTdx\n9dXXFm1tj3379vLVr/4zL720joqyGhbOuZApdaNPq9jd28JzL91HliyVFXVECy6n+ihzird37WLj\nK7+kp6+NefPm8zu/8wfHNGp+NNlslscff4xvfvPr9PX1ccbSBl7/2rnUVI0+EnnPvh7+43svkskO\nFpffsmIxjQ0j/94ODGT45TM7+NXqXQBcf/0NXHfd23KeFs9rFknFYIH5JDcw0H/Ywhr19VMKeudd\nKjXFuqjq6+ujra31wA2d9vY2WltbD6w23dq6j71799LV1Tmm9tbW1tHQ0MCUKQ1Mnlx/0NfkQ74v\nG+P8fJIKxz/WJBVDMbMlm83yox/dy/e//21iiXKq5l1Oomrkm9Lp3la6N/0EyBIvr6VyziUkKutH\nfY9Ux3Z6t/+CWCzLBz7wIS655LKxNDEvqVSKH/7wTh544D6y2SxlM6qoOn0KZQ2VI76ma81esuks\nk84Z+RNf2WyW1N5eeta1MrC7h3g8znXXvY3rr7+BxBjmNc7Xli2b+dpX/5mmHdupiMU5p7KSZRWV\nVIwyLdsvurtIZ7NcOso80P3ZDC/29fJMby+92QwzZszkQx+6hYULFxejG4dIp9Pcf//d3HPPD8hk\nMtRNmsnc6WdRVzNjxMFMm5tWkcmkWTT3wlGP3dndzCu719DSvg2Aq666hne9693H5Xp5x44mvva1\nf2Hz5o2UlyU4/8zpnLd8OtVVIxeAH33iFVLpDFe9bv6I+wwMZFgTmvnV6p10dg3Q0DCVm2/+XU47\n7Ywxtc9rFknFYIFZ0klnvC+qent72b17Fzt2bGfTpg00NW0nlUqRSCSIxeLMmzefU05ZyKxZc2hs\nnE5FRe4LfEgaH+OdK5JOTMcjW372s0f5+te/BrE4FTPOJzl54YjFvd5dq8lm0lTNOn/UY2azGfr3\nBvr3PEdZWRm33PIRzjrrnHyal7fNmzfyne98kxDWApCcWkHl4smUz64hFs/9k5jZTJb+Vzrp2dBO\numVwGoNly87kxhvfw9y5IxcDi2FgYICVK3/Mj+6/h+6ebspiMU4rr+DMiiomj7HI3Z5O83xfD2v7\n++jPZqmsrOTaa9/CG9/4puM+aGFweon/OjDndE3VVGZNO42pk08hHs+9X9lshn3t29jZvI72rsHR\nvUuWLOXGGws7zUcu0uk0jz76EPfc8wM6OjpIJuOcsbSB85dPZ9ooo5OPpKOrn9Uv7OHZtc309KYo\nKyvj6quv5c1vfhuVlSPfOBmJ1yySisECs6STjhdVkgrNXJFUDMcrW5599hm+8pV/ore3h0TNLCpn\nnke8vDavY6V7W+jduYpMz14mT57C7//+R1m8eEm+TTsm2WyWENbywAP38dxzqwGIVyWpXFxHxcI6\n4mUjj/7N9Kfp3dhO38Z2Mr1pYrEY55xzHtdeez1Llpx6vLpwRN3d3TzyyEP89KEHaG1rBWBBWRnn\nVFQzK5kcdSrDHakBnu3tYdPQAn6T6yZzxZXXcMUVV1Ezykjn42H/gnlPP71qcPR5spIZUyNmTo0o\nS45cSE2nB9i172V2Nq+lb6ALKMzChIXQ19fLY489wsqVP6a5uRmABXNqueDsGZwyt27Utu3a082T\nz+4kbGwlm81SU1PDG96wgquuuoa6uvwXJvSaRVIxWGCWdNLxokpSoZkrkorheGbLnj27+frXv8ba\ntS9ALE7ZlKVUTDuDWCK3T1JlBrrp27OGVNsmAC644CLe8573U1dXGot+79jRxMMPP8jPfv7f9Pf1\nESuLUxXVU7lk8iEjmrPpDD0vt9H7UhvZVIbKyiouu+z1XHHF1UyfPmMce3C4VCrFqlVP8tBDD7Bx\n43oAZieTvLaqhunJQ+f9bU6l+EVPF9tTgwsaLly4iKuueiMXXHBRznP3Hi979uzm4YdX8thjj9DT\n000iXsasaacze/pyEvFX25rJZtjZvI7tu9eQSvdRXl7OxRdfypVXXsOcOaPP53y8ZTIZnnnmKX76\n05+wbt2LAMxsrOb1F81l3uxDb+bsa+3l0V++woYtbQDMnTuPq656IxdeeHFBPtnoNYukYrDALOmk\n40WVpEIzVyQVw/HOlmw2y69//UvuvPNb7N3bTCxRTvnUMyhrWEosduSpCrKZAfqb19K/L0A2zZw5\n87jppv/JsmVnHmtziqK7u4uHH17JT35yP11dXSQml1Nz7jQS1UnSXSm6nt5DumOASbW1vOna67n8\n8iuoqqoe72Yf1fr1L3HffXfx3HOriQHnVFaxvKKSGPBCXy9P9/aQBZYvP4vrrnsbS5dGJb9oe29v\nL4899jA/+tG9tLe3UVley6K5r6Wqoo7+gW42vvJLunr3UVVVzTXXvIkrrriaSZPGdxR2LrZs2cz9\n99/NqlW/AuDcZY285pyZxGMxXly/l58/2UQ6k2Xp0ojrr7+BZcvOLOi58ppFUjFYYJZ00vGiSlKh\nmSuSimG8smVgYICHH36Qe++9i+7uLuIVdVTOuohEVcMh+6U6d9C789dkB7qpr5/CDTe8i0suuYx4\nfOSpJ0pFV1cnd975LR577JHDnrvyymt4+9t/k6qqsc2VWwrWrn2Bf7/jKzTvbT5ke8OUBt7/gQ+x\nfPlZ49Sy/PX29nL33d/nJz+5/7DnLrnkMm688T1MmpTflC7jacOG9dxxx+3s2NF0yPba2jp+67c+\nyHnnXVCUmwBes0gqBgvMkk46XlRJKjRzRVIxjHe2dHZ28IMffJdHH/0pxOJUzryAsvqFZLNZ+ve+\nSP+eNcTjca699nquu+6tVFSMfcGx8fbLX/6C1atXDT2KccEFF3L++a8Z1zYdq46Odu6554d0dLQD\nMGnSJK6//u1Mnpz/vL2lYPXqp/jVr55gf53izDPP5pJLLhvnVh2bnp4e7rnnB7S07AOgqqqKN7/5\nrUyb1li09xzvXJF0YrLALOmk40WVpEIzVyQVQ6lkywsvrOHLt99Gd1cX8coGyKTI9LfTMHUaf/D7\nH2XBgoXFemtJBVYquSLpxDJathR9pv8oir4AXARkgI+EEFYd9NwtwHuAFLAqhPBHxW6PJEmSJOlQ\ny5adyZ98/C/44hf/ntbWwZGWM2fO5o//+M9oaJg6zq2TJEmlrKgF5iiKLgOWhBAujqLoNOAO4OKh\n52qBPwYWhRCyURT9JIqi14QQnixmmyRJkiRJh5s/fwGf//yXyGQyACQSiZJfJE6SJI2/Yq/McCVw\nF0AIYR1QH0XR/iVf+4E+oC6KoiRQBewrcnskSZIkSSOIx+Mkk0mSyaTFZUmSlJNiF5hnAnsOetw8\ntI0QQh/wKWAjsAn4VQhhfZHbI0mSJEmSJEkqkKLPwTzMgVvgQ1NkfAJYAnQAj0RRdGYIYc1IL54y\npZpkMlH8Vko6qZgtkgrNXJFUDGaLpEIzVyQVQrELzE0MjVgeMhvYMfT96cCGEEILQBRFPwPOB0Ys\nMLe0dBepmZJONI2NtTnva7ZIyoW5IqkYzBZJhWauSCqG0bKl2FNkPAi8EyCKovOA7SGErqHnNgOn\nR1FUMfT4N4CXi9weSZIkSZIkSVKBFHUEcwjhiSiKnoqi6HEgDdwSRdH7gNYQwt1RFH0OeDSKogHg\nFyGEx4vZHkmSJEmSJElS4cSy2ex4tyFne/Z0TJzGShpXjY21OS97brZIyoW5IqkYzBZJhWauSCqG\n0bKl2FNkSJIkSZIkSZJOUBaYJUmSJEmSJEl5scAsSZIkSZIkScqLBWZJkiRJkiRJUl4sMEuSJEmS\nJEmS8mKBWZIkSZIkSZKUl+R4N6DUdHd30dzcfOBxY+N0qqqqxrFFkiRJkiRJklSaTvoCc3t7G9u2\nbWXz5k289NJa1q59gVQqdeD5srJyli1bzqmnnsaCBQuZN28+kybVjmOLJUmSJEmSJKk0nBQF5lQq\nxa5dO9m5s4mdO3cMfb+DHTua6OrqPGTfWNkkiPdBZgDiZaSySVavfprVq58+sE9tbR2zZs1mxoyZ\nzJw5ixkzZjJr1mwaG2eQTJ4UP1JJkiRJkiRJOjELzNlslhdeWMOqVb9i48b1NDU1kcmkh+0VI1Y+\nieSkOcQrJhOvnEKiahrdWx+mPBlj2rTZNDc3kyJB9ZLrSffsJdPbQrqvjc7eNl56KfDSS+sOOWIi\nkWD27LksWbKU17zmtUTR6cev05IkSZIkSZJ0nJ2QBeZf//qX3H77lw48jldNpax8MvGKOuLltcTK\na4mX1xCLJQ55XSbVQxl9fPjDH2bFihWsXLmS22+/HWJxyurmQ938A/tmM2kyA51k+jsGv/rayfS1\nsW3bFrZt28IjjzzERz/6p5x55tnHrd+SJEmSJEmSdDzFx7sBxVBXN5lEYqh4HIsRS1SQqGmkbMoS\nkrVzSFTUHVZcBiCTZtq0aaxYsQKAFStWMG3aNDhs9DPE4gkSFZMpq51Lef0SktWNxBLlB55PlpU5\nV7MkSZIkSZKkE9oJOYL5tNPO4DOfuZXHH3+Mp556ku3bXyHd2UQs/jTJyadQVr+IeEU9sVjs0BfG\nEzQ3N7Ny5coDI5ibm5spW3B4MTqbzZLp3cdA60ZS7VvIZgYXBpw//xTOP/81XHLJpTQ0TD0e3ZUk\nSZIkSZKkcRHLZrPj3Yac7dnTkVdjd+7cwRNP/JzHHnuEtrZWAGJlNSRrZpGomUGyejqxZAUAnRvu\np4w+pk2bNjQHcwU1i98MQCbVS7p7N+munaS6dpId6AagoWEql19+BRdddAmNjdML0VVJx6ixsTZ2\n9L0G5Zstkk4u5oqkYjBbJBWauSKpGEbLlpOiwLxfKpXiueee4Ve/eoI1a56lt7fnwHPxiikkJ80i\nXllP/541ZPo7iJXXUjFtOeneFtJdO8j0tR3Yv7q6hrPPPpcLL3wty5efTTx+Qs42Ik1YXlRJKjRz\nRVIxmC2SCs1ckVQMo2XLqFNkRFEUDyFkhm0rCyEMFKpxx1MymeS88y7gvPMuIJVKsWnTBtate5G1\na1/g5Zdfon9vCwDxyikkJs0mO9BNb9MTAJSVlXH6sjM57bRlnHbaGSxcuMiisiRJkiRJkqST2ogj\nmKMoOgV4ALgwhNA2tO01wL8CV4YQ9hyvRu5XzDtrfX29PP/8c/z3fz/M888/d2D7ueeez6WXvp4z\nzjiT8vLyUY4gqZR4115SoZkrkorBbJFUaOaKpGLIdwTzPwCf3F9cBgghPBlF0aeBW4HfKlwTx19F\nRSXnn/8azj//NXR3d5NOp0gmk1RVVY930yRJkiRJkiSpJI02x8PMEMK3hm8MIXwHOKVoLSoB1dXV\n1NbWWVyWJEmSJEmSpFGMVmAebXSzlVdJkiRJkiRJOsmNVmBuHZpz+RBRFF0ONBevSZIkSZIkSZKk\niWC0Ucp/Dnw/iqJvAL8GEsDrgHcClx+HtkmSJEmSJEmSStiII5hDCE8CFwBp4L3AjcA+4OwQwobj\n0zxJkiRJkiRJUqkabQQzIYSdURT9LXA6kAFeDCH0HpeWSZIkSZIkSZJK2ogjmKMoikdR9DfANuDf\ngf8AtkRR9KfHq3GSJEmSJEmSpNI12iJ/fwVEwNIQwpkhhOUMjmQ+M4qi/++4tE6SJEmSJEmSVLJG\nKzC/FXhvCGHv/g0hhH3AB4F3FbthkiRJkiRJkqTSNlqBuTuE0Dd8YwihH3AeZkmSJEmSJEk6yY22\nyF9NFEVlIYSBgzdGUVQB1OT6BlEUfQG4iMFFAj8SQlg1tH028E0gC8SARcCfhhC+PbYuSJIkSZIk\nSZLGw2gjmO8Gvh5F0eT9G6IomspgUfjfczl4FEWXAUtCCBcDNwO37X8uhNAUQnhDCOEK4CpgC3DP\n2LsgSZIkSZIkSRoPoxWYPwVsBTZFUfRsFEVrgACsCSH8Y47HvxK4CyCEsA6oj6Jo0hH2ez/w/RBC\nd84tlyRJkiRJkiSNqxGnyAghpIE/i6LoM8DpQBew/kjzMo9iJrDqoMfNQ9vWD9vvZmDFGI4rSZIk\nSZIkSRpno83BTBRF1wDLgSdCCC8MbYsBfxxC+Fwe7xc7wntcBKwNIXQe7cVTplSTTCbyeFtJGpnZ\nIqnQzBVJxWC2SCo0c0VSIYxYYI6i6K8ZnBv5SeCOKIo+CaxmcP7lbTkev4nBEcv7zQZ2DNvnOuCh\nXA7W0uIMGpJy09hYm/O+ZoukXJgrkorBbJFUaOaKpGIYLVtGm4P5GuDyEMIfAa8DPsfgInyfDSG8\nK8f3fhB4J0AURecB20MIXcP2uQB4NsfjSZIkSZIkSZJKxGgF5t6heZgJITQD24HzQgh353rwEMIT\nwFNRFD0OfBG4JYqi90VR9NaDdpsJ7B570yVJkiRJkiRJ42m0OZizwx53hRA6xvoGIYRPDNu0Ztjz\nZ4/1mJIkSZIkSZKk8TdagbkhiqIrDno85eDHIYSHi9csSZIkSZIkSVKpG63A3Ar85QiPs4AFZkmS\nJEmSJEk6iY1YYA4hvP44tkOSJEmSJEmSNMGMWGCOouivhm3KAm3AXSGErUVtlSRJkiRJkiSp5MVH\nea5s2Fc5sBx4JIqiS49D2yRJkiRJkiRJJWy0KTL+8kjboyhaANwBXFmsRkmSJEmSJEmSSt9oI5iP\nKISwpRgNkSRJkiRJkiRNLGMuMEdRVAZUFaEtkiRJkiRJkqQJZLRF/q44wuYG4P3A94vVIEmSQeNR\nOgAAEtFJREFUJEmSJEnSxDBigRk40hzM7cB3gP8uTnMkSZIkSZIkSRPFaIv8veHgx1EUVQHvAD4A\n/B0wu7hNkyRJkiRJkiSVstFGMAMQRdFFDBaVb2RwzuYP4RQZkiRJkiRJknTSG20O5j9hcL7lGuA/\ngN8A7gwhfPv4NE2SJEmSJEmSVMpGG8H8aeAF4JYQwiMAURRlj0urJEmSJEmSJEklb7QC8zzgfcDt\nURQlgK8D5cejUZIkSZIkSZKk0hcf6YkQws4Qwt+FECLgg8ASYEEURfdGUfSm49ZCSZIkSZIkSVJJ\nGrHAfLAQwmMhhPcDs4H7gL8qZqMkSZIkSZIkSaVvtCkyDhNC6AC+MvQlSZIkSZIkSTqJ5TSCWZIk\nSZIkSZKk4SwwS5IkSZIkSZLyYoFZkiRJkiRJkpQXC8ySJEmSJEmSpLxYYJYkSZIkSZIk5cUCsyRJ\nkiRJkiQpLxaYJUmSJEmSJEl5scAsSZIkSZIkScqLBWZJkiRJkiRJUl4sMEuSJEmSJEmS8pIs9htE\nUfQF4CIgA3wkhLDqoOfmAt8CyoCnQwi/V+z2SJIkSZIkSZIKo6gjmKMougxYEkK4GLgZuG3YLrcC\nnwshXASkhwrOkiRJkiRJkqQJoNhTZFwJ3AUQQlgH1EdRNAkgiqIY8Drg3qHn/yCE8EqR2yNJkiRJ\nkiRJKpBiF5hnAnsOetw8tA2gEegEvhhF0c+iKPpMkdsiSZIkSZIkSSqgos/BPExs2PdzgH8AtgL3\nR1F0bQjhxyO9eMqUapLJRJGbKOlkY7ZIKjRzRVIxmC2SCs1ckVQIxS4wN/HqiGWA2cCOoe+bgc0h\nhM0AURT9FFgGjFhgbmnpLk4rJZ1wGhtrc97XbJGUC3NFUjGYLZIKzVyRVAyjZUuxp8h4EHgnQBRF\n5wHbQwhdACGENLAxiqLFQ/ueD4Qit0eSJEmSJEmSVCBFHcEcQngiiqKnoih6HEgDt0RR9D6gNYRw\nN/BR4OtDC/6tCSHcW8z2SJIkSZIkSZIKp+hzMIcQPjFs05qDntsAXFrsNkiSJEmSJEmSCq/YU2RI\nkiRJkiRJkk5QFpglSZIkSZIkSXmxwCxJkiRJkiRJyosFZkmSJEmSJElSXiwwS5IkSZIkSZLyYoFZ\nkiRJkiRJkpQXC8ySJEmSJEmSpLxYYJYkSZIkSZIk5cUCsyRJkiRJkiQpLxaYJUmSJEmSJEl5scAs\nSZIkSZIkScqLBWZJkiRJkiRJUl4sMEuSJEmSJEmS8mKBWZIkSZIkSZKUFwvMkiRJkiRJkqS8WGCW\nJEmSJEmSJOXFArMkSZIkSZIkKS8WmCVJkiRJkiRJebHALEmSJEmSJEnKiwVmSZIkSZIkSVJeLDBL\nkiRJkiRJkvJigVmSJEmSJEmSlBcLzJIkSZIkSZKkvFhgliRJkiRJkiTlxQKzJEmSJEmSJCkvFpgl\nSZIkSZIkSXmxwCxJkiRJkiRJyosFZkmSJEmSJElSXpLFfoMoir4AXARkgI+EEFYd9NwmYOvQc1ng\nPSGEHcVukyRJkiRJknQsuru7qa6uHu9mFJz9mjhKpU9FLTBHUXQZsCSEcHEURacBdwAXH7RLFnhj\nCKGnmO2QJEmSJEmSCuGVV7bxz//8RXbt2sGMGbO45ZaPMHfuvPFu1jGzXxNHqfWp2FNkXAncBRBC\nWAfUR1E06aDnY0NfkiRJkiRJOgHt3r2L5557mt27d413U8Ysk8kwMNBPT08PnZ2dtLW18aUv3UpL\ny15mz55NS8tevvSlz7Nv317a2tro6uqkp6eHgYF+MpnMeDf/iLLZLKlUir6+Prq7u+noaKelpYXb\nbvv8sH7dSktLCx0d7XR3d9PX10cqlSKbzY53F45o8FwN0NPTQ1fX4Lnat2/vEfvV1tZGZ+fEPFet\nrS3cdtvw38FbaWnZR3v7/nPVe1zPVayYbxRF0VeA+0II9w49fgz4YAhh/dDjTcDPgIXAz0IInxjt\neHv2dJTmb7CkktPYWJvzzSuzRVIuzBVJxWC2SCq0Y82VZ55ZxZe+9IWCtae8vJwPf/jDrFixgpUr\nV3L77bfT399fsON/4hN/zZIlpxbkWL29vXzuc59m06YNo+6Xb59OPfU0Pv7xPyeRSBSkvbl64omf\n87Wv/ctR98u3Xzff/LtcfPGlhWhqzjKZDJ/73KcJYe1R982nXwsXLuLjH/8LKisrC9XknDz77DN8\n+cv/eNT25Xuu3v3u32LFijfm1bbRsqXoczAPM7whfwk8AOwD7o6i6O0hhB+M9OIpU6pJJo/vP0JJ\nJz6zRVKhmSuSisFskVRoR8qVJ598vKDvMW3aNFasWAHAihUr+N73vkdTU1PBjv/ii6t57WvPL8ix\nursTpDMDR90v3z5lMimmTq2hrKzsmNs6FpWVuf2/I99+VVYmaGysPaY2jlUqlSKTSee0bz79SqdT\nNDRUU1NTc8xtHYvq6mROheJ8z1VFRbwo56rYI5j/D9AUQvja0OMNwFkhhK4j7Pu7wPQQwidHOp53\n7CXlytFAkgrNXJFUDGaLpEI71lzp7+/npZfWkk5nDvp4fZZs9tCvTCZDJpMlm311aoH9z+3/HqCj\no50lSxZy8cWv5Re/eIINGzYzaVItsdirzYzFYsMex4nH48TjMWKxOLEYB/67f+xiLBajvLycU089\nrSgjgvdPTZBOp0mn9/938OvWWz/LjTf+5oHRo9/5znf5wz/8OMlkkkQicdBX8sC2g/s3njKZzFC/\nXu3T/n5+4Qt/y0033XhIvz760T8lkUgM69tgv+LxYs+8m5tsNntQPw49V6lUii9+8e8P69fHPvZn\nh52r/f0s5XO1v09HOlcf+cifHHaeDj53x2q0bCl2gfm1wF+HEK6Joug84IshhMuGnqsDvgtcH0IY\niKLo28CdIYTvj3Q8L6gk5co/1iQVmrkiqRjMFkmFVoq5snv3Lnbu3M7MmXOYPn3G8XjLonrllW3c\nfvttQBaI8eEP/+8Jv2gc2K+JZDz6NG4FZoAoij4DXA6kgVuA84DWEMLdURT9AfB+oBt4JoTwv0c7\nlhdUknJVihdVkiY2c0VSMZgtkgrNXDl+uru7qa6uHu9mFJz9mjiOZ5/GtcBcSAafpFx5USWp0MwV\nScVgtkgqNHNFUjGMli2lMVmKJEmSJEmSJGnCscAsSZIkSZIkScqLBWZJkiRJkiRJUl4sMEuSJEmS\nJEmS8mKBWZIkSZIkSZKUFwvMkiRJkiRJkqS8WGCWJEmSJEmSJOXFArMkSZIkSZIkKS8WmCVJkiRJ\nkiRJebHALEmSJEmSJEnKiwVmSZIkSZIkSVJeLDBLkiRJkiRJkvJigVmSJEmSJEmSlBcLzJIkSZIk\nSZKkvFhgliRJkiRJkiTlxQKzJEmSJEmSJCkvFpglSZIkSZIkSXmxwCxJkiRJkiRJyosFZkmSJEmS\nJElSXiwwS5IkSZIkSZLyYoFZkiRJkiRJkpQXC8ySJEmSJEmSpLxYYJYkSZIkSZIk5cUCsyRJkiRJ\nkiQpLxaYJUmSJEmSJEl5scAsSZIkSZIkScqLBWZJkiRJkiRJUl4sMEuSJEmSJEmS8pIs9htEUfQF\n4CIgA3wkhLDqCPt8FrgohPCGYrdHkiRJkiRJklQYRR3BHEXRZcCSEMLFwM3AbUfY53TgUiBbzLZI\nkiRJkiRJkgqr2FNkXAncBRBCWAfUR1E0adg+twKfKHI7JEmSJEmSJEkFVuwC80xgz0GPm4e2ARBF\n0fuAR4AtRW6HJEmSJEmSJKnAij4H8zCx/d9EUTQF+ACDo5znHfzcSBoba4+6jySNldkiqdDMFUnF\nYLZIKjRzRVIhFHsEcxMHjVgGZgM7hr6/ApgG/Az4AXBuFEW3Frk9kiRJkiRJkqQCKXaB+UHgnQBR\nFJ0HbA8hdAGEEL4fQlg+tADgDcDTIYSPFbk9kiRJkiRJkqQCKWqBOYTwBPBUFEWPA18Ebomi6H1R\nFL21mO8rSZIkSZIkSSq+WDabHe82SJIkSZIkSZImoGJPkSFJkiRJkiRJOkFZYJYkSZIkSZIk5cUC\nsyRJkiRJkiQpL8nxbsB4i6LoC8BFQAb4SAhh1UHPVQBfAZaFEC4YpybmJYqi5cBdwBdCCP8y7Lmr\ngE8DKeDHIYT/Ow5NzNnwvkRRNBf4BoM3SHYA7w0hDAx7zYjndTzl2pcoit4D/CGQBr4WQrhj2HGO\n+jMo1X5EUZQEvg4sYPB38AMhhM3Djj9q/ycCs6W0s8VcKb1cGWqD2TIKc6W0cwXMFkowW8yVozNb\nSjtbzJXSy5WhNpgtozBXSjtXwGyhBLNloufKST2COYqiy4AlIYSLgZuB24bt8jngGWBCrYQYRVE1\ng315aIRd/hG4AXgdcHUURacdr7aN1Qh9+RTwpRDC5cAG4IPDXnO08zoucu3L0H5/CVwBvAH4aBRF\n9cMON+rPoJgK0I//AbSEEC4FPgP87RGOf7T+lzSzpbSzxVwpvVwBs+VozJXSzhUwWyjBbDFXjs5s\nKe1sMVdKL1fAbDkac6W0cwXMFkowW06EXDmpC8zAlQzeHSCEsA6oj6Jo0kHP/9n+5yeYXuBaBu9w\nHCKKooXA3hBCUwghC/yIwZ9DqTpSX14P3Dv0/b3AVcNec7TzOl5y6csK4ELgyRBCZwihF/g5cMmw\nYw1/3fCfQTEdSz9ex+D5+eHQvg9xeN9y6X+pM1tKO1vMldLLFTBbjsZcKe1cAbOlFLPFXDk6s6W0\ns8VcKb1cAbPlaMyV0s4VMFtKMVsmfK6c7AXmmcCegx43D20DIITQddxbVAAhhEwIoW+Ep4f3eTcw\nq/itys8Ifak56GMKR2r/qOd1vIyhLzM4tP17OLyP1Uf5GRRNAfpxYPvQ/3wzQx/n2G/4+TtS/0ud\n2VLC2WKuACWWK2C25MBcKeFcAbNlSElli7mSE7OlhLPFXAFKLFfAbMmBuVLCuQJmy5CSypYTIVdO\n9gLzcLHxbsA4mOh9zqX9E6WPI7XzaO0vtf6NtR9Hy6FS618+ToQ+jNVE7rO5Upr9M1sONdHbn4+J\n3mezpfT6Z64c7kTow1hN5D6bK6XZP7PlUBO9/fmY6H02W0qvfyWfKyd7gbmJQ++4zOYIH3c4wTRx\n6F2KOUPbJpKOoYUB4Mjtn0jndXhftpPbOeo8ys/geMu1H/u3zwTYf0cthJA6aL8T4Xd0Iv0OFspE\nP2/mSunlCpgtB5tIv4OFMtHPGZgtUHrZYq4caiL9DhbKRD9v5krp5QqYLQebSL+DhTLRzxmYLVB6\n2TKhcuVkLzA/CLwTIIqi84DtR/i4RozSu3MxFoe0PYSwBaiNomj+0C/ddQz+HCaSh4B3DH3/DuCB\nYc/ncl5LxZH68iTwG1EU1Q3NaXQx8LMcXjeextKPlcC7hvZ9C/DIsGP9aoTXTSRmy8TLFnOl9HIF\nzJaDmSsTL1fAbBnpdePJXDmU2TLxssVcKb1cAbPlYObKxMsVMFtGet14mlC5EstmJ9TCnQUXRdFn\ngMuBNHALcB7QGkK4O4qi7wLzgDOAp4CvhhC+PW6NzdHQP/ZbgQXAAIN3M+4BNg3163XA3zO4auv3\nQgj/MG6NPYoR+vIe4P8BFcAW4AMhhHQURd8C3h9C6Bt+XkMIa8alAwcZY1/eDvwJkAFuCyF8O4qi\ns4G3hRA+GUXRTOA/hr9ugvQjDvwrsJTBiezfH0LYHkXRnwKPhhB+daTXHY++FZLZUrrZYq6UXq4U\nqC8nfLaYK6WbK2C2UILZYq7kxmwp3WwxV0ovVwrUlxM+W8yV0s0VMFsowWw5EXLlpC8wS5IkSZIk\nSZLyc7JPkSFJkiRJkiRJypMFZkmSJEmSJElSXiwwS5IkSZIkSZLyYoFZkiRJkiRJkpQXC8ySJEmS\nJEmSpLxYYJYkSZIkSZIk5SU53g2Q8hVF0Uzgc8ByoBPIAp8MIfx0XBsmacIyVyQVg9kiqdDMFUnF\nYLYoX45g1kR2F/B4COHcEMKlwO8B34iiaOE4t0vSxGWuSCoGs0VSoZkrkorBbFFeYtlsdrzbII1Z\nFEVXAn8TQrh42PbJIYS2cWqWpAnMXJFUDGaLpEIzVyQVg9miY+EIZk1Uy4BfD99o6Ek6BuaKpGIw\nWyQVmrkiqRjMFuXNArMmqjSQGO9GSDqhmCuSisFskVRo5oqkYjBblDcLzJqo1gCXDN8YRdHyKIqq\nxqE9kiY+c0VSMZgtkgrNXJFUDGaL8maBWRNSCOExoD2Koj/Zvy2KomXA3cDccWuYpAnLXJFUDGaL\npEIzVyQVg9miY+Eif5qwoiiaBPwDcCGwF+gF/iKE8NS4NkzShGWuSCoGs0VSoZkrkorBbFG+LDBL\nkiRJkiRJkvLiFBmSJEmSJEmSpLxYYJYkSZIkSZIk5cUCsyRJkiRJkiQpLxaYJUmSJEmSJEl5scAs\nSZIkSZIkScqLBWZJkiRJkiRJUl4sMEuSJEmSJEmS8vL/A15mFhdgwtSgAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x7f04c9d90240>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Cross-validated performance distribution\n",
+    "facet_grid = sns.factorplot(x='C', y='score', col='gamma',\n",
+    "    data=cv_score_df, kind='violin', size=4, aspect=1)\n",
+    "facet_grid.set_ylabels('AUROC');"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAdMAAAFhCAYAAAAr/EDTAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAIABJREFUeJzs3Xd8FEUbwPHfpVFCQiqkUQMMKtKrL9IMTaUoRaSFJtI7\ngnQjIgpIKAKKYKHYBZEoIh3FAqEqMtKlhyS0QHru/eOOkEASzpBLcuT5+rkPud2bvWfWvXtuZmdn\nDUajESGEEEJkn11eByCEEELYOkmmQgghxAOSZCqEEEI8IEmmQgghxAOSZCqEEEI8IEmmQgghxANy\nyOsAsrKizxy5bicTvx47k9ch5GvX42/ldQj5lmuhonkdQr4Vun5yXoeQrzm5ehqste2qZRpn+/v+\n4OntVovLUtIyFUIIIR5Qvm6ZCiGEKBgMhjxvXD4QSaZCCCHynMFg2x2lth29EEIIkQ9Iy1QIIUSe\ns0O6eYUQQogHYuvnTKWbVwghhHhA0jIVQgiR5+xsfACSJFMhhBB5Trp5hRBCiAJOWqZCCCHynEFG\n8wohhBAPxtbPmdp29EIIIUQ+IC1TIYQQec7WByBJMhVCCJHn7Gw8mUo3rxBCCPGApGUqhBAizxls\nvG0nyVQIIUSes/Vzprb9U0AIIYTIB6RlKoQQIs/Z+gAkSaZCCCHynK3PgCTdvEIIIcQDkpapEEKI\nPGfr0wlKMhVCCJHnZDSvEEIIUcDlSctUKdVFa/1ZXrw3wP5LRzgUcRQMBjAauRATSWWvclyMiaSI\nY2EAGvhXpYJ76czL3Izklfq9+eP8IQ5HnqCUqw9Pla0HwJ+Xj3Ez4Rb1/KvmSf0ehFNhJ4IndqOo\nSxHsHRz44eMf+Xu3BuCROpUZPKs/Q5qMuqecbzkfXn6jL1u+2MaOtb8A0KRDI2o1q87xQydZu+Q7\nAGoH1cTV3YUtX27PvUrloEKFnXh5Wh+cXYri4OjAmg++43C45uUpvSkZUILYm7HMf/U9Ym/GppZx\nLOTIy5N7UdzDFQcnB9YuD+PArj9p+UIz6j1VG33gGJ+/+w0ADVrUpbiHKxs+25RXVcy27B47zw1o\nQ2DV8hjs7Ni4chMHfj5E046NqNn04Tp2dofvY8yrE6kQWB6jESpVCKRXj25MmBpCSkoK3l6ezAiZ\niqND+q/lt+fO4+Chv7Czs2Pc6BE89khlVn76OT9u2kKN6lUZNXQwAGEbNhIVHU3Prl3yonoPTEbz\nZk9/IM+SafWSlalesjIAp69d4O+oEyQmJ9KsTF0qeJS2uAzA4cgT9KrajlV/hZGYnITBYODAJc2L\nj7XOncrksPqt63Lp9CXWffA9rp6ujAgdTEiPN3FwtKdlt6e4Fnn9njKOhRzpPPx5dPg/6ZbXbFKN\nOYPnM3TOABydHDEaU2jQuh7vvvJeblUnxz357BNcOHWRL5esxc2zOK++O4qNX2zh+pUbLJ66jCZt\nG6KqV2D/L4dSy9RsWJUTf5/i+1U/4VnSg/ELRnBg15/Ufao2If3fZtz8ETgWcsSYYqTRs08wa+T8\nPKxh9mXn2KlYvQI+ZX2YPWgeRV2K8uqyMRz4+RA1mlR/6I4dgNq1ajLnzempzyeHvEHXzh0JataE\n+YuWsGbdejo/3z51/Z69+zhz5hwrl7/PiVOnmBIyg5XL32fj5q2sWPYe/YcMJy4uHjs7A2u/C2Px\nvDl5UKucYeujea2WTJVSuwFjBqsMQCVrve9/tfPMXp6r1IzNp3//b2VUMwAc7OwBcHYsQnxyAgcj\n/qG272M2ezL95rWb+Jf3BcDZpSg3rsYA0LJ7c7at2cnzA9veUyYpIYl3x75Hi25B6ZcnJQNw40oM\nRYoVpl7LOuxY8zMpySlWroX13LgaQ6lAfwCcXYty4+oNajSsytfvrwNg27qf7ynz++bw1L89fTyI\nunQFgKSERACuR1+nqHMRGj7dgE1fbbPZ/ZOdY+fo/mOcOnwagNiYWJwKOwGQlJgEPFzHDoDRmP4r\ncXf4PqZMGAdA4ycb8vGqT9Ml0993h9OsSSMAypcty42YGG7evImToyMAHu7uxMTEsO77H+jS6Xkc\nHGQYTF6x5jf+X8AqoFMGj8NWfF+Lnb9xmeKFnHF2KgLA7ot/sfLP9azRm4lNjMu6jKOpjNFoJMWY\nQkzCLQDO3riEo70D3x3dzh/n/8ydiuSg8C378CjpwbTVExkxfwjfLPoW7wAv/AP92L/9oKmb+y5G\no5GkxOR7ltsZDNjZ2+Hq6YrRaKR8lXLEx8XTfVwXmnRolBvVyXG/b9qDl48ns796nYmLx/Dpgq/x\n9vOk2v+qMGHRaAaF9KVosSIZlp3y/isMnNaHlXM/B8BgZ4edvR1uXsUxYqRi1UDi4+LpN7EnLTo3\ny81q5YjsHDsAieYfFU88W58/fzV9NTyMxw7AiROnGDZmHMH9B/Lr77uJi4tL7db1cHcnMjIq3esj\no6Jwd3NLfe7u5kZkVDQpRiNJSUmm1xsM7D94iCJFijDl9Rms+uyLXK1TTrEz2GX7kR9YM4qXgUAg\nUmt9Os3jFHDGiu9rsf2XjlC1hAKgqnclmpWpS/cqz1LS2ZPtZ8LvWwagps+jrPhzPZU9y7Hr7H4a\nlarFb+cO0qZiYy7ejORG/M1cqUtOqdO8FtGXopnW9Q3mjXiXLiM60nHIc3z97tr/vK2d63YxPHQw\n+7cfoGX35oR9tIGgLs1Y+dZnlKoUQHFPVyvUwLqeaFmXyItRjOk4mRmD3yF4zIsAXDh1kRmD5nD2\nxAXa9no6w7Ih/d9m7iuLGBjSF4DN32xnwruj2L11L22DW7Pmg+94ulsLPnjjE8qq0rh5Fc+1euWE\nBzl2qjasQoPW9fgi9Gvg4Tx2ypQOYGD/vsyf/RbTp0xi6vQZJCen/RGaUUdeekajEYPBQOfn29N3\n0FCCmjVh2UefMPClPny8cjUhkydw+Mg/RFy+bLV6WIvBYMj2Iz+wWp+A1joeGJbJus7Wet//4vT1\n87QK/B8AZd38UpdX8ijDD8fv7a67uwzAY96BPOYdSHTsNS7djMKnmBcpRlNXlIuTM9fiY3Ap5GzF\nWuSswCrlOPzHEQDOn7hAKRVA1IVoek/uARgo7mE6FxY64t37bit8yz7Ct+zD298L/wr+nD16Djt7\n0++3q5ev4uHjwbWoe8+j5WeVqlbg0G9/AXD2+DncvIpz6exl/t5nOl986Le/eP6lNunKlFWluX7l\nOtERV/n36Fns7e0pVrwYv2/aw++b9lAywJvSFUtx+p8z2Jv3T3TEFbx8PLkaeS13K/gAsnvsPFKn\nMi27BbFgzBLiY+OBh/PYKeHtTcsgU49DqQB/vDw9+evvIyQkJODk5MSliMt4e3vdVcaLyKg7rdWI\ny5fx8vKkVYsgWrUI4t8zZ9FHj/GIUiSbT6uULOnN+QsXKeHtnXuVy+eUUu8A9YEUYITWek+adYOB\nbkASsEdrPUop5Qx8ArgDTkCI1npjVu+RJ+1jpVS7vHjftG4k3MLJ3im1i+CrIz9xJc704Tx97QLe\nzh73LZPWjjPhNC5dG4BkczK9Hh9DMaei1qqCVUSci6TcY2UB8CjpTsSZy0x9cTqzB81j9qBQrkVf\nzzqRZvAr8eleLQlb/gMADg6mc8zuJdy4ZkOJ4rZLZyMIrFIeMJ3/jLsVz/5fDlGtQRUAyj1Shgun\nL6Yro2pUpHXXFgC4erhQqLATMddiUtc/169N6jlXB0fT71vPku5cibxq9frkpOwcO4WLFuK5gW1Y\nNH4pcTfvPbXyMB07YRs28vHK1QBERkYRFR1N+zbPsHHzVgA2bdlGwwb105VpUK8uP20xrT98RFOi\nhDdFi9w5jbB46TIG9+8HQGKS6TzzpUsRlLgrKdsCO4Mh24+sKKUaARW01k8A/YD5ada5AGOA/2mt\nGwGPKaXqAr2AI1rrZphOTc67X/xWP1utlCoG+JifXtBa3wTcsiiSK2ISbuFsvgwGoLbvY6zRm3G0\nc8DJ3pE2FZsA8I3eTNuKTXCws7+nzG3/Xr+IZxG31MT5mFcgHx38Fq8ibrgVdsmV+uSUn9ftosf4\nFxkxbwh2dgY+nfNl+hekGUDRe3IPVsxcjW85XzoMaoeHjzvJSSnUaFyV9yd9SGxMLIGPlyPizGWu\nR98AYM/mvYxZNJwLpy4SbR6IY0u2rNnBS5OCmbhoNHb2diyfuZLjh08yYEpvmrRtSOytON577UMA\nBr/ej/dCPmLLN9vpNzGYSUvG4OjkyEezVqdur1K1Clz89xLXok0/5H7d+AdTlo7j/MnzRF2MzpM6\nZld2jp1azWrg7OpMv9eCMWDAiJGP31jF1cvXHrpjp2mjhoybNI0tO3aSlJTElFdfQVWsyIRpIXy1\n5lv8fH1o+4zpKoBXJk5h+tRJVK/6OI9WrkyPvi9jZ2/HxFfGpG5v7/4DlCldGi8vTwBatwiie5/+\nBJYvh5+vb57U8UFYcTTvU8BaAK31EaWUm1KqmNY6BkgA4gFXpdRNoAgQDUQCj5vLewD37Tc33D26\nLKcopWpj+gXgZg7MAPgB54DBWutDWRQHYEWfOdYJ7iHw67F8cdo537oefyuvQ8i3XAvZVm9Jbgpd\nPzmvQ8jXnFw9rZbx2lTrlu3v++8OrMo0LqXUe8B6rfV35uc7gD5a62Pm512BBcAt4DOt9Vjz8h+A\nCphy2DNa6z+yisGaLdNQc8BH0i5UStUE3gVsd0ieEEKIHJWLA4lS38jczTsBU9KMAbYopR4HqgKn\ntdatlVJVgWVAnaw2as1zpnZ3J1IArfVewN6K7yuEEMLGWOucKXCeO6cawdRDesH89yPAca31Fa11\nIrATqA38D/gRQGt9EPBTSmX5RtZsmf6mlFqHqa/6dn+zD9ARsM35wIQQQtiajcA0YKm5Z/SceewO\nwCngEaVUIfMVKLWBMExdu/WBNUqpMsANrXWW3dDWvDRmlHkU1VNAPfPi88A0rfWv1npfIYQQtsda\nA5C01r8qpcKVUr8AycBgpVQwcFVr/a1SahawTSmVCOzSWv+ilNoPLFdKbcPUk/ry/d7HqqN5tdY7\ngB3WfA8hhBC2z5ozGWmtJ9y16FCadUuBpXe9/ibwwn95j/wxD5MQQghhw2RWZCGEEHkuv0wLmF2S\nTIUQQuQ5W7+fqXTzCiGEEA9IWqZCCCHynNwcXAghhHhA0s0rhBBCFHDSMhVCCJHnZDSvEEII8YCk\nm1cIIYQo4KRlKoQQIs/JaF4hhBDiAUk3rxBCCFHASctUCCFEnpPRvEIIIcQDkm5eIYQQooCTlqkQ\nQog8J6N5hRBCiAck3bxCCCFEAWdRy1QpVRIoY356Wmt9yXohCSGEKGge6tG8SqnOwKuAL3DGvLi0\nUuoc8KbW+ksrxyeEEKIAsPVu3kyTqVLqI/P6XlrrA3etqwaMVUo9o7XuZdUIhRBCiHwuq5bpGq31\ntxmtMCfX7kqpdtYJy2TXsX+tuXmbtv/C0bwOIV9LNibndQj5Vk1fldchCHEPW+/mzWoA0ndKqUlK\nKfvbC5RSlZVSE28/zyzZCiGEEP+F4QH+yw+ySqaTgVpAoTTLzgPVlFLDrBqVEEIIYUOySqZtgC5a\n61u3F2itrwPBwAvWDkwIIUTBYWfI/iM/yCqZxmqt4+9eqLWOBVKsF5IQQoiCxmAwZPuRH2SVTIsp\npZzvXqiUcgdcrBeSEEIIYVuySqYrgDVKqYq3F5gvifkOmGPtwIQQQhQcdgZDth/5QaaXxmit31FK\nxQNblFKumBJvBDBDa70itwIUQgjx8Msv3bXZldWkDe5a63eBd83JNEVrHZPBa65YO0ghhBAiP8uq\nm3e9UioITKN4M0ikzTF1+QohhBAPxA5Dth/5QVYzIHUEliql5gAbuDM3bymgFfCv+TVCCCHEA3lo\nu3m11heAZ5VS1TElz0fMq84AwVrr/bkQnxBCCJHv3fcWbOakKYlTCCGE1eSXUbnZZdH9TIUQQghr\nsvFcmuUAJCGEEEJYQFqmQggh8txD382rlJoAjAVczYsMgFFrbZ95KSGEEMJy+eVWatllSTdvD6A6\n4GR+OJr/FUIIIQSWdfP+BZzVWidbOxghhBAF00N7nWkaHwMHlVLhQNLthVrrPlaLSgghRIHy0J8z\nBeZiuoPMWSvHIoQQooCy8VxqUTI9prV+zeqRCCGEEDbKkmT6u1LqNeAX0nfzbrFaVEIIIQqUgtDN\n2+iufwGMgCRTIYQQAsuS6Wit9V6rRyKEEKLAsvXrTC1JprOBZtnZuFKqMvAU4GtedB7YqLU+lp3t\n5RSnwk70mtidoi5FsHdw4PuPN/D3bg3AI3UqM2TWywxuMjLDsg5ODkz+aDzff/wjv/+4m6YdG1Or\naXWOHTrB2iWm27vWCaqFi7sLW77clltVynHjXh9C+YplSUhI5O0pCzlz6hyderZl6Li+NK/Vmfi4\n+AzLOTk5sur7xSxfuJof1m6hc3A7nmr9JAfC/2LRrA8BaNGmCR6ebnz20drcrFKOGf/6MAIrlSUx\nIZGZk+fz76lzdO7ZjuHjX6JZzQ737Js2HVvQun0QGI1gMFC5SgWaVX+eF4LbE/R0Iw7s+YuFs5YB\n0LJNUzy83Pj0wzV5UbUHcudzVRQHR3vCPvqRv3cfAeDRupUZMmsAgxqPSFemYvUKvBTSm/MnLmAw\nGDh3/BxfzP+GZh0bU6tZDY4dPMGaJesA0+fK1cOFzV9sy+2q5Yjd4fsY8+pEKgSWx2iEShUC6dWj\nGxOmhpCSkoK3lyczQqbi6JD+a/noseMMHzuenl270KVTBwBWffYFG37aTI3qVRk1dDAAYRs2EhUd\nTc+uXXK9bjmhIHTz/quU2gb8BiTcXqi1npJVIaXUJKAF8D1wAtPMSf7AaqXUp1rrudkN+kE1aF2X\ni6cvse6DMFw9XRkROpiQHm/i4GhPy25BXIu8nmnZp3u25Ob1m6nPazauxuzB8xg6ZyCOTo4YjSk0\naF2Pha8syY2qWEWjoAYULVaUl7uMwa+UDyMnvcymsB24e7px+VJUlmV7D36Ra1dvpD5v2vJ/vNxl\nDKEfTqdQISdSjCk806E5o/pOtnY1rKJxUAOcixXlpRdG4VfKh9GTB/JT2HY8stg33321ke++2ghA\njTpVeKq16YzJU62f5KUXRjH/oxnmfWPk2Q4tGNF3Yq7VJyc1aF2PS/9e4tulps/VyNAhvNZjBg6O\nDrTs1jzTz9XRfcdYOvXDdMtqNKnOrEGhDJszyPy5MvLE0/VYMNZ2P1cAtWvVZM6b01OfTw55g66d\nOxLUrAnzFy1hzbr1dH6+fer62Lg4Zs6ZS/26ddJtZ+PmraxY9h79hwwnLi4eOzsDa78LY/G8OblV\nlRxnzVyqlHoHqA+kACO01nvSrBsMdMM0JmiP1nrU/cpkxJIZkE4CW4FYIDnN435aA4211jO11su1\n1su01iHAE+TxTcVjrt3EubgzAM4uRYm5GgNAq+4t2L5mJ8lJSRmWK1mqBD5lSvLnr4dTlyUlmXbF\njSsxFClWmKYdG7N9zU5SklOsXAvrKVXWj78P/APA+TMX8fErwY5Nv/L+3E+yLFe6nD9lAkuxa9sf\nqcuSEk378krUVZxdnOkc3J6vV64n2Ub3T6my/hw+aOrFuL1vtv+0iyVzP7aofN8h3flg4SoAEhMS\nAdO+KebiTJfg9ny1cp3N7puYazE4u2bwuerRnG3f7CApk89VRr17tz+DN67eoEixwjTr1JhtNv65\nAjAajeme7w7fR+NGDQFo/GRDfvtjd7r1hZycWDzvHby9PNMtv9169XB3JyYmhpWffUGXTs/j4CDT\nrd9NKdUIqKC1fgLoB8xPs84FGAP8T2vdCHhMKVU3qzKZuW8yNV8WsxAIM//9uoWXyjhwp3s3LT8y\n/PjknvAt+/As6c5rqycxcv5Qvl70Ld4B3vgH+rFv+4FMfyJ1GNyerxauSTdTh8FgwM7ejuKerhiN\nUL5KOeLjEug+7kWadmiU4Xbyu+P6FPWerInBYKB0OX98A0pSqPD9Z5Ac9upLzJ+xlLT/ew12Buzt\n7fDy9sBoNPJ4jUeIjY1jwozhdOrZ1oq1sI5j/5yi/pO1zfsmAL8AHwoVLmRR2UeqVOTi+QiuRl8D\nwGBnl27fVK35KLGx8Ux6cySde7azZjWsInzLPjx8PAhZPYlRC4bx9aK1lAjwJsD8ucrsnJhvWR8G\nzOjH6AXDULUqAWAw2N3zuUqITaCHDX+uAE6cOMWwMeMI7j+QX3/fTVxcXLrEGBmZvnfDzs4OJ6d7\nP3spRiNJSUmm1xsM7D94iCJFijDl9Rms+uyLXKlLTjMYDNl+3MdTwFoArfURwE0pVcy8LgGIB1yV\nUg5AESD6PmUyZMlE912A181vWAVYoJQK11ovv0/RicBPSqko4LJ5mS/gAgy83/taU53mtYi6dIWF\nr7yHX3lfeozryo0rN/h83leZlqnbojYn/jxJ9KUr6ZbvXPcLI0IHs2fzPlp1DyLsow0893IbFoxZ\nQs9Xu1Lc05VrUZl3G+dHv+0M5/Gaj7Bo1Vsc16c4ffzMfQcHtGrXjEN7D3PxfES65Ws+/YEFK2ay\naf12ggd0ZvnCVQwc05uRfSYz6a2ReJXwIDIi2prVyVG/7dhD1RqP8t7q2RzVJzh1/IzFvwzbdW5N\n2DcbU59/szqMRSveZmPYNoIHdGHpgpUMGduHYb0nMuWt0Ta3b+o2r030xWgWjl2CX3lfeo7vyvUr\nN/g8NPPPVcSZCNYv/4G92/bj5evJyPlDmdwlhB3f/szI0CHs2byXVt2bE/bhBtoPaMOC0YsJntDN\nJj9XZUoHMLB/X1oGNePM2XP0HTiE5OS0nXzGTMverfPz7ek7aCitmwex7KNPGPhSH0IXLua9BaFM\nnDadiMuXKeHtnfOVsE0+QNou2kjzsmNa63ilVAimU5G3gM+01seUUpmWyexNLBrNC1QDwszPxwDb\ngCyTqdZ6E6YmczlzEADntdanLXhPqwqsUp7Df5gGRpw/cYHSKoCoC9H0ntwTA1Dcw5URoUMIHbEw\ntczjDR7D09eDx594DLcSbiQlJHH18lXCt+wjfMs+vP29CKjgx9mj57CzN91Q5+rlq3j4eNjchx5g\n6byVqX9/uekDrphbU8ZMPvBPNKmDXykf/tesHiV8vEiITyDiYhSbv9/B5u93EFDal4qPlOOfwydw\nMO+fiItR+PiVsKmEAfD+vE94f57p7683f3hn3xiz/jKsWa8qs167c0xt+n47m77fTkAZPypWLs8/\nh49jn7pvIvH1L2lT+ybw8XJ3fa5KEXUhmj6TgzEYoLinKyPnDWXu8AWpZa5FXWfvtv0ARF6I4nr0\nddy8iqf7XPlX8OfM0bPY25s60q5E2ObnqoS3Ny2DTGM5SwX44+XpyV9/HyEhIQEnJycuRVzG29vL\nom21ahFEqxZB/HvmLProMR5RimTzKaeSJb05f+GizSXTXByAlPpG5m7eCUAFIAbYrJSqmlWZzFiS\nTK9prW8ppQDQWscqpRLuUyaV1vokpvOuqZRS7bTW31q6jZx2+dxlyj1WhgM7D+JR0p2IM5d5rceM\n1PWvfz4lXSIFWPbanXNiz/RqReSFKPTeo+mWfbPYVCUHB9MXonsJd65FXrNmVawiUJXlheB2zJgw\nj/pP1uLIn3d+jGXWQp0y8q3Uv/sM6cqFsxcJ/+3AnWVDu7HwLdOIVQdH02FX0sfLppIFQAVVji69\n2jP91bnUb1SbI3/eOQay6m7y9Pbg1s1bGZ4P7Te0GwtmfgCAo6MjACV9ve872Cu/iTgXSbnHyrI/\nzedqWvc3UtdP/3xqukQKphG6xT1d2fT5Vlw9XHBxc+Fqms/MM71b880i06hve3N3qHsJN5v8XIVt\n2EhkZCTB3bsSGRlFVHQ07ds8w8bNW3m2dUs2bdlGwwb1My2f0W+1xUuXMXrYEAASzeeZL12KoISF\nSTk/sWIuPc+dBh2YTjVeMP/9CHBca30FQCn1M1ATOJdFmQxZMgApUikVDBRRStVUSr3FnW7b7Cr3\ngOUfyM51u/D08WDkvCH0ntSD1XPuOseQ5qjtM7knDo5Z37o18PHyXDoTwfVo0yjW3Zv3MmbRCJKT\nku/pFrYFx/UpDAYDH3w1lx4vd2L+m0sJHtCZhSvexMPLjbnLQhg4phcAr819BUenrH+TVa31KGdO\nnSM60rQvflq/nfc/n01SUvI93cL53TF9EjCw/Kt5BL/cmdAZ79FrYBcWrXwbDy835i2fzuCxpntA\nvD53PI5OpuToVcKD6Kir92yvWq3H+PfkOaLM++bH9Vv54Iu5JCUl2dy+2fntL3j6eDBq/lB6T+7J\n6tmfp1uftlejz5SeODg6cPCXQ1SsXoHRC4Yx4I1+rJ7zeeogo8DHyxOR5nO1Z1M4YxeNJDk5xSY/\nV00bNWTP3v0E9x/I8FfGM+XVVxg6oD/rwr6nV/9BXL9xg7bPtAbglUlTSUhI4PARTZ8BQ/h2/Q+s\n/vxL+g4cwvUbpv2xd/8BypQujZd5cFLrFkF079MfBwcH/HwzGq6Sv9kZDNl+3MdGzINelVI1gXNa\n69uXZJwCHlFK3R74UBs4CvyURZkMGe7XNaWUcgOmA00xnTf9GZh6O5Nnh1Jqi9b6vteuDmw03PKT\nCAXM/gtH7/+iAizZKHcMzExNX5XXIeRb88Om5nUI+ZqTq6fV2o9vtZ+W7e/7cWunZRmXUmoG0BjT\nlSiDMbU+r2qtv1VKvQT0ARKBXVrr8RmV0Vofyuo9LOnmbaW1HnJXYAOALC/4UkoNymTV7etNhRBC\nCMC6MyBprSfctehQmnVLgaUWlMlSpslUKVUDU/Yeo5QqmmaVIzCF+yRTYBSwiYz7mR3/S5BCCCFE\nfpZVyzQOKAm4AU+mWZ4CjLVg2+0xXeg6XGudbn41pVST/xamEEKIh5kF14vma5kmU63138Df5vOb\nv/3XDWut/1RKPYupH/puo//r9oQQQjy87Gw7l97/nGl2EmmasrcyWS53oRFCCJHK1lumllwaI4QQ\nQogs3DeZmgciCSGEEFZjxbl5c4UlLVPbvaePEEIIm2BnyP4jP7Da/UyFEEKIgsKSZHrP3LpCCCFE\nTsov3bUkLY/sAAAgAElEQVTZZclo3teUUs6AwnSPIJ3ZKF0hhBAiO2w8l1o0AKk9pnu4LcE05dI/\nSqnW1g5MCCGEsBWWdPOOBapqrS8DKKX8gK+AH6wZmBBCiIIjF+9nahWWjOZNuJ1IAbTW5zHdPUYI\nIYTIEYYH+C8/sKRlGqOUGo3p/m4ALYEb1gtJCCGEsC2WJNO+QAjQHdMApF/Ny4QQQogcYeO9vBYl\n01pa6wFWj0QIIUSBVRDOmY5SSlmSdIUQQogCyZIkeRU4rJTaS/oZkHpaLSohhBAFykM/aQOw3vwQ\nQgghrMLGc6lFydRXaz3T6pEIIYQQNsqSc6ZVlFIVrB6JEEKIAsvWb8FmScu0KvC3UioK0zlTA2DU\nWpe2amRCCCEKjPxyK7XssiSZtrF6FEIIIYQNs6Sb9yLwLDBQa30a8AEuWTUqIYQQBYqtd/NakkwX\nAYFAU/PzmsBH1gpICCFEwWMwZP+RH1iSTCtrrUcBtwC01osBP6tGJYQQQtgQS86ZJpn/NQKYbxRe\nxGoRpbH3vM6Nt7FJsYmxeR1CvuZo75jXIQgh/gNbn07QkmT6pVJqM1BeKTUfaA28a92whBBCFCT5\n5dxndt03mWqtFyqlfgeaYLqPaRetdbi1AxNCCCFshUUT2GutdwO7rRyLEEKIAsrGG6aWJVMhhBDC\nmmy9m9eS0bxCCCGEyIJFyVQp9YxSaoj570CllG3/hBBCCJGv2Pp1pvft5lVKvQVUBMoAC4GuQAlg\nqHVDE0IIUVDY+qUxlrRMG2utnweuA2itX8c0C5IQQgghsGwA0u3ZAW5P2mBvYTkhhBDCIjbeMLUo\nKe5SSn0I+CmlRgHPA9usGpUQQogC5aEfzau1ngiEAZuBAOAdrfU4awcmhBBC2ApLu2s3A+GYbgyO\nUqq81vqE1aISQghRoNh4w9Si0bwLgGAg0rzIgOn8aXkrxiWEEKIAsfVuXktapk0Ab611vJVjEUII\nIWySJcn0CJBg7UCEEEIUXDbeMM08mSqlQsx/xgDblVI/c+fepmitp1g5NiGEEAWErU/akFXLNNn8\n7ynzIy2jNYIRQgghbFGmyVRr/RqAUmqE1jo07Tql1GvWDkwIIUTBYeMN0yy7eZsCzYDuSimPNKsc\ngd7AVCvHJoQQooB4mEfzHgF8zX8np1meCHSxWkRCCCGEjcmqm/cCsFoptUtrfSr3QhJCCFHQ2HjD\n9P6XxjxoIlVKFQN8zE8vaK1vPsj2hBBCPHys2c2rlHoHqA+kACO01nvMy/2AVZgG1RowTUY0Tmv9\nmVLqbaAhYA/M1Fqvyeo9rHb3F6VUbWA+4IZp9iQDpsnyzwGDtdaHrPXeQgghBIBSqhFQQWv9hFKq\nMrAceAJAa30eaGp+nT2wFVinlGoCPGou4wHsA7JMpplOdK+UmmD+d1I26xAK9NFaP6q1bqS1flJr\nHQiMAN7N5jaFEEI8hAyG7D/u4ylgLYDW+gjgZu4xvVsv4Gut9S1gO9DJvPwqUFQpleU7ZdUy7auU\ncgG6KKWc7l5pwaQNdubA7y631/wLQAghhACs2s3rA+xJ8zzSvOzYXa/rBzQH0FobuXMv737A9+Zl\nmcoqmXbHlNEh/WheS/2mlFqH6RfBZfMyH6Ajpqyfp8a/PozylcqQmJDIzMkLOHPqHJ17tmPY+H48\nVbMj8XH3TkXcsm1TuvfrSFJSMu+HfsKvO/bwQnA7nnq6EQf2/MW7s5YD0KJNEzy83Pnswyx7BfK1\nyTNGU0GVIzEhkekT38HVzZVRrw4gKSmJ+PgEJox4g2tXr6crU6FSOUKXTmfFB1/y+Yq1AHTt1YGW\nbZqyb/chQme+B8DT7YLw8HJn5bIvc71eOWHC9BEEVipLYkIiMyaHEhcbz9S3x+Lg4EBSYiKTRs3k\nStTVdGWGjXuJ6rWrYG9vx4eLP2XbT7t4sddzBD3dmP3hf7LgrQ8AaNW2GR5e7qxe/nVeVO2BOBV2\notfE7hR1KYqDoz1hH/3I37tNv6cfrVuZIbMGMKjxiHRlKlavwEshvTl/4gIGg4Fzx8/xxfxvaNax\nMbWa1eDYwROsWbIOgDpBtXD1cGHzF9tyu2o5Ynf4Psa8OpEKgeUxGqFShUB69ejGhKkhpKSk4O3l\nyYyQqTg6pP9aPnrsOMPHjqdn1y506dQBgFWffcGGnzZTo3pVRg0dDEDYho1ERUfTs6tcbHEf92Rt\npVR94G+tdcxdy9thuhS0xf02mtVo3l+BX5VSW7XWv/zXaLXWo8x91U8B9cyLzwPTzNvOM42CGuBc\nrCj9XxiNXykfRk0ewKawHbh7unH5UlSGZVyLF6PvkG70aDsYZ+civDS8B7/u2MNTrRvR/4XRzP/o\nDQoVciLFaOTZDi0Y2Te7veN5r2mLhhQr5kxwhyH4l/Jh/LThxMbG8eqI6Vw4d4mXhwXT4cVnWb54\ndWqZwoULMf61Yfz2c3i6bbV4pgnBHYawZMXs1P3TrlNrBgW/ktvVyhFNmj+Bs0tR+nYegV+AD2On\nDubqlWt88+l6Nv+wk07d29K9X8fU5AhQq141ylcsQ59Ow3Et7sLq9UvY9tMugp5uTN/OI3j345mp\n+6ZNx5YM6/1qHtYw+xq0rselfy/x7dIwXD1dGRk6hNd6zMDB0YGW3ZpzLfJ6huWO7jvG0qkfpltW\no0l1Zg0KZdicQTg6OWI0Gnni6XosGLskN6piNbVr1WTOm9NTn08OeYOunTsS1KwJ8xctYc269XR+\nvn3q+ti4OGbOmUv9unXSbWfj5q2sWPYe/YcMJy4uHjs7A2u/C2PxvDm5VZUcZ8XxR+e5MwgWwA+4\ncNdrngU2pV2glGoJvAq01FrfuN+bWDIAKVoptQWojWnE02+YBhDd3US+h9Z6B7Dj7uVKqUJ5eRea\n0mX9+eugBuD8mYv4+JVk+0+7iL0VR6u2TTMsU+d/Nfjjl73Ex8UTHxfPW1MWAJCQYLoHQHTUNZxd\nnHn6uaf4auV3JCen5E5lrKBMuQAOHfgbgHNnLuLrX5KOrfqkri/h48Xe3QfTlYmPT2Bg8Cv0Hdg1\n3fLExEQAoqOuUMy1GG2fb8lnn6whOTk7nR15r1TZAP46YD52zpr2zfghrxMfbzoOrkRdRT1aIV2Z\n8N8P8Od+0/68cT2GwoULAWmPnasUc3Hmmeeb8+WKb2322Im5FoN/edOl6c4uRYm5avqR36pHc7Z9\ns4PnB7XLuGAGX6LJSaZpwG9cvUGRYoWp36ou29bsJMVG981tRmP6nsLd4fuYMmEcAI2fbMjHqz5N\nl0wLOTmxeN47LPt4Rbpyt1uvHu7uxMTEsO77H+jS6XkcHKw2ptTqrNjNuxGYBixVStUEzmVwVUkd\n4NPbT5RSrsDbwFNa62uWvEmmA5DSWADMwTSBgz+wBFhsycaz8NEDln8gx/45Sf0na2EwGChdLgC/\ngJIUMn/BZcbXvyRFihRm1pKpLF79NrXqVwPAzs4Oe3s7vLzdwWikas1HiYuNY+KbI+ncM5Mvj3zu\n6JET/K9RHQwGA2XLl8K/lC/uHsV5olEd1m1ZgYenO2FrfkpXxmg0kpiQeM+2DHZ22Nvb413CE6PR\nSLVajxF7K45pb79C114dcqtKOeaYPkmDJ2tjMBgoUy4AvwAfijgXAUxfBp16tGPDus33lLudbNu/\n8DQ/b/0dADuD+dgp4YERI9VqPkZsbByTZ46mS3D7e7aR34Vv2YeHjwchqycxasEwvl60lhIB3gQE\n+rFv+wEMGWVNwLesDwNm9GP0gmGoWpUAMBjssLO3o7inK0YjlK9SjoTYBHqMe5GmHRrlZrVy1IkT\npxg2ZhzB/Qfy6++7iYuLS5cYIyPT94zZ2dnh5HTPkBVSjEaSkpJMrzcY2H/wEEWKFGHK6zNY9dkX\nuVIXW2HuCQ1XSv2CaWDsYKVUsLkL9zYfICLN8xcAT+ALpdRWpdQWpVRAVu9jyc8Yg9Y6LM3zNUqp\noZZVI2Na6xcfpPyD+m1HOFVrPMqS1bM4pk9y6viZTD7mdxgMBlzdXBg74DX8SvmwaOVbtG8czDer\nw3h3xVv8FLad4AEv8MGCVQwe24fhvScy+a3ReJXwIDIiOlfqlVN+2f4H1WpV4cMv5vPPkeOcOHYa\ng8HArh27adusB8PH9afvoG4sW7Tqvtv6cuW3fPDpXDZ8t4V+g7qxZN7HDB/Xn4E9x/L67PF4l/Dk\nckTGXev50a87dlOt5qMs/ewdjh45wcnj/2IwGDAYDLz+znh279rLnt8OZFi2cdATtO3YksHBppbI\nV6vXs2TVbDau30bvgS/y/vwVDH2lH0N6jWfa22PxKuFJpA3tm7rNaxN9MZqFY5fgV96XnuO7cv3K\nDT4P/SrTMhFnIli//Af2btuPl68nI+cPZXKXEHZ8+zMjQ4ewZ/NeWnVvTtiHG2g/oA0LRi8meEI3\ninu6ci0q427j/KpM6QAG9u9Ly6BmnDl7jr4Dh9zVQ2P5/UM6P9+evoOG0rp5EMs++oSBL/UhdOFi\n3lsQysRp04m4fJkS3t45XwkrsuakDVrrCXctOnTX+mp3PV8KLP0v72FJMnVSStXUWu8FUErVsaSc\nUsoR6AMEcWdawvPABuBjrXWe9vO9P28FzDN1nXy1eTlXok0t+bu7YW6LjrzKwb2HAVPX8K2bsRR3\nd2XT9zvY9P0OAsr4UrFyef45fBx7e1ODP+JiJD7+JW0umQIsemc5i8x/r9++iuq1H2fLjzsB2PTD\nDgaMCLZoOz+u38qP67dSqow/lR4J5MhfR3FwMA3mvnTxMr4BPjaVTAGWhH4MoR8DsGbLR1yJuspr\ns17h9IkzfLAw4x8YDZ6sTe+BLzKk13hu3TQNEvwpbBs/hW0joIwfFSuXRx8+hr2D6di5dDESX/8S\nNpVMAx8vx+E/TAOOzp+4QGlViqgL0fSZHIzBAMU9XRk5byhzhy9ILXMt6jp7t+0HIPJCFNejr+Pm\nVZzwLfsI37IPb38v/Cv4c+bo2dTP1ZWIq3j4eNhcMi3h7U3LoGYAlArwx8vTk7/+PkJCQgJOTk5c\niriMt7eXRdtq1SKIVi2C+PfMWfTRYzyiFMlJpq/UkiW9OX/hos0lU1u/BZsl3bxjME0rGK2UisbU\nRTvSgnIrgNKYuoh7AsHAQqAa8GEW5ayugirHxDdNVajfqBZH/jyaui6zfvvffw6ndoPqALi6uVCk\nSGGuXbnzYe43tLspQQOOjo4AlPT1IjKTAU35WcXK5Zn2tmmA0P8a1+XwoX94eXgwlR4JBODxGo9w\n6sSZzDeQwS4cMKIXi+aa/rff3j8+viW4fCkyZ4O3sgqVyzF55mgAGjSqw5E/j9GqbTMSEhJZumBl\nhmWcixVl2PiXGNFvIjE37p0ArP+wHrxnTs539o13poPh8quIc5GUe6wsAB4l3Yk4c5nJXUKYNWgu\nbw+cy7Wo6+kSKZhG6Aa9YBqn4OrhgoubC1cj75yieqZ3a9Yv/x4Ae3N3qHsJN65FWnQaK18J27CR\nj1eaBu1FRkYRFR1N+zbPsHHzVgA2bdlGwwb1My2f0e/8xUuXMbh/PwASzeeZL12KoISFSTk/seJ1\nprnCkukEfwcqK6WKA0attaU/B3211neP0T4O7FBK5emlMcf0SQzAsq9CiY9PYOqotwge+AL1/lcT\nDy83Qpe/zqF9f7No1oe8Pnc8IePmEBkRzZYNO1n2VShgZPZri1K3V63WY/x78hzRkVcA2Lh+G0u/\neIeTx/7l4vmIjIPIx44eOYHBYGDV2sXExcXz6vDpeHq7M3H6SJIS71waAzBz/mQmj5lJhUplGT1p\nMH7+JUlKTKJ568aMfHkyN67HUKP245w+eYaoy6YW+g/rNvPJN+9y4ugpLpy7lJdV/c+OHTmJwWDg\n428WEBeXwKSRM5i5YDJOhRx5b9VsjEYjJ46d5u1pC3lj3gSmjZ1Fi2eaUNzNlZkLJmMwGDAajUwZ\n8xYRFyOpXrsK/548S5T52Pnxu60s/3IeJ4+dtrljZ+e3v9BzfFdGzR+Kwc6O1bM/T7femKYbs8+U\nnnzy5moO/nKIPlOCqdbwcewd7Fk95/PUQUaBj5cn4kwE16NNAyn3bApn7KKRXDh9kehLV3KvYjmk\naaOGjJs0jS07dpKUlMSUV19BVazIhGkhfLXmW/x8fWj7TGsAXpk0lelTJnLsxElmhy7g/IWLODo4\nsGnrVua+/SauLi7s3X+AMqVL4+XlCUDrFkF079OfwPLl8PP1zSoUYQWGzLo1H5RSaiumwUvfaa0T\nzcsKAR2AXlrr+163U69CK7kJeSZiE2Pv/6ICzNHeMa9DyLfq+D+a1yHkW/PD5M6SWXFy9bRaO3DT\n+CXZ/r4Pmjkgz9un1hxH3QMIAWYrpZzNy25gupbHshNuQgghhA2wZCCRr/l2bP+J1vospgFIGW1z\nC6YbjwshhBD55txndlnSMl1FNhKfUmpQFqv9/+v2hBBCPLwMdradTS1Jpv8opT4BdgEJtxdqrZff\np9woTF26GbVq5YSWEEKIVAWhZVoI00T39dIsM2K6J1xW2mO6n+nwu6cONN8rTgghhHgoWHJpTG+l\nlB1QQmt90dINa63/VEo9C9w7xxyM/g8xCiGEeMhZcW7eXGHJAKRmwDIgHtP1pnOBTXdNMZgh801W\nM1q+978GKoQQQuRXlsyANAOoz51zn28Ak60WkRBCiALH1mdAsiSZxmitU6ep0VpHkmYgkhBCCPGg\nbt8wIjuP/MCSAUixSqnGgEEp5Q50AeKsG5YQQoiCJJ/kxGyzJJkOwnT/0jrAMeBn4CVrBiWEEELY\nEkuSaaDW+tm0C5RS7YHT1glJCCFEgWPjTdNMk6lSqiwQiGlu3VHcubGWI6a7la+1enRCCCGEDciq\nZeoLvACUBaakWZ4CLLFiTEIIIQqY/DKQKLsyTaZa61+BX5VS32utpRUqhBDCamw8l1p0acx+pdRX\n5vuTopTqp5SqaOW4hBBCFCAGO0O2H/mBJcn0feCTNK/9x7xMCCGEEFiWTB211uswnStFa73DuiEJ\nIYQoaArCDEgopdww3SkGpdRjQBFrBiWEEELYEkuuM30N+A3wVUodBLyA7laNSgghRIHy0I7mvU1r\nvU0pVQOogunOMf9orWU6QSGEEDnGxnOpRbdg8wM6AsUxT9yglEJrHWLl2IQQQhQQtt4yteSc6Q9A\nDcAJ0+xHtx9CCCGEwLJzplFa695Wj0QIIUSBZeMNU4uS6RqlVDfgVyDp9kKt9b9Wi0oIIYSwIZYk\n06pANyAqzTIjUNoqEQkhhChwbP2cqSXJtD7grrWOt3YwQgghCiiLZj3IvyxJpruBwpgui8lVcUly\nBU5mihUqltch5GvxSfLbTwhbUhBapgHAKaXU36Q/Z9rIalEJIYQQNsSSZPpGBsuMOR2IEEKIgsvG\nG6b376XWWm8HwoGT5sd5YLaV4xJCCCFshiUzIL0CTAAKATGYJrlfZeW4hBBCFCC2fs7UkvFTHYES\nwG9aa2+gK/CnVaMSQghRoBSEW7Dd0FonYJpOEPO9TdtZNSohhBAFi41nU0sGIF0xz4D0p1LqQ+Aw\n4GfdsIQQQgjbYUky7Ympm3cNMALTpTIvWjMoIYQQBYvBLn+0MLPLkmQ6TGs90/z3DGsGI4QQQtgi\nS86ZVlFKVbB6JEIIIQosGz9lavFE94eVUtFAAqYbhBu11jLRvRBCiBxh65fGWJJM22SwzD2nAxFC\nCFFw2XgutWgGpNOAM1DG/KgEfGrluIQQQgibYckMSPOAFoAPcAwIRKYTFEIIkZNsvGlqyQCkulrr\nR4D9Wus6QHOgqHXDEkIIIWyHJcn09o0hCymlDFrrcOB/VoxJCCFEAWOwM2T7kR9YMgBJK6UGATuA\nn5RSGnCzblhCCCEKEmv28iql3gHqAynACK31njTrAjCNA3IE9mqtB6VZVxjTXPQhWutPsnoPS1qm\nA4DPMN05Zjmm86YZjfAVQgghssdKF5oqpRoBFbTWTwD9gPl3vWQOMEtrXR9INifX2yYDUZaEb0ky\ntQOeAMYA/pjm5j1nycaFEEKIPPYUsBZAa30EcFNKFQNQShmAhsB35vVDtdZnzesUUBkIs+RNLOnm\n/RDTJTG7ME3YMAnTbdleyqqQUsoR6AMEAb7mxeeBDcDHWutkSwIUQgjx8LNiN68PsCfN80juXJ3i\njek+3aFKqZrATq31BPPr5gCDgV6WvIklybSy1rru7SfmTP6bBeVWAMfNAUVgSsT+QAdMCbqnJQEK\nIYQQOchw19/+wFzgXyBMKdUa8AJ2aa1Pmxqo3DfVW5JMzymlCmut48zPCwEnLCjnq7Xuctey48AO\npdR2C8oLIYQoIKw4Kvc8ppbobX7ABfPfkcAprfUpAKXUZqAKUBMor5Rqg+lOaXFKqTNa6y2ZvYkl\nydQAHFdK/YLp/Gk9TPc2/QRAa51ZCzNFKfU88J3WOtEcaCFMLdP4TMoIIYQogKw4N+9GYBqw1NyV\ne05rfRNAa52slDqhlArUWh8HagGrtdazbhdWSk0FTmaVSMGyZLrG/LjtOwsr0AMIAWYrpW5P8hAD\nbEK6eIUQQqRlpVyqtf5VKRVubhAmA4OVUsHAVa31t8BI4CPzKcxDWmtLc1w6BqPRmHNR57BqZZtY\nLbjJM0YRWKkciQmJTJ/4DrGx8YTMGoeDowNJCYlMGPkG0VFXU19fpEhhpr/zKq7FXXB0dGTJvI/4\n7edwuvbuQItnmrB/zyFCZ74PQOu2T+Hp7c7KZV9ZK3ycnZyttm2AV0KGUL5iGRITEnl76kLOnDpP\npx5tGDKuLy1qv0B83L2dC4PG9qZarcews7djxXtfsGPTb3Tu2ZZmrZ/kYPhhFs3+EIDmzzbGw8ud\nzz9aa7X445Os1/kxYfoIAiuVJTEhkRmTQ4mLjWfq22NxcHAgKTGRSaNmciXNsQMwbNxLVK9dBXt7\nOz5c/CnbftrFi72eI+jpxuwP/5MFb30AQKu2zfDwcmf18q+tFn8d/0etsl2nwk70mtidoi5FcXC0\nJ+yjH/l79xEAHq1bmSGzBjCo8Yh0ZSpWr8BLIb05f+ICBoOBc8fP8cX8b2jWsTG1mtXg2METrFmy\nzhR3UC1cPVzY/MU2q8QPMD9sqtW2vTt8H2NenUiFwPIYjVCpQiC9enRjwtQQUlJS8PbyZEbIVBwd\n0rdxjh47zvCx4+nZtQtdOnUAYNVnX7Dhp83UqF6VUUMHAxC2YSNR0dH07Hr32bWc4+TqabXmo/74\ny2x/36vgTnk+c4MlLdMcp5SaqrV+LS/eG6Bpi4Y4F3OmV8eh+Af4MG7aMK5eucZXq79j0w/b6dy9\nHT1f6pyaHAHadmzFyeP/snD2Mry8PVj66VyeCwqmxdNN6NVxKEs+mUWhQk6kGI2069Sawb3G5VX1\nHlijoPo4FyvKgBfH4lfKhxET+7P5+524e7px+VLGl1zVqPs45SqU5uUuY3ApXoyP1y5gx6bfaNq6\nIQNeHEvo8tdxKuSEMSWFZzo0Z3S/Kblcq5zRpPkTOLsUpW/nEfgF+DB26mCuXrnGN5+uZ/MPO+nU\nvS3d+3VMTY4AtepVo3zFMvTpNBzX4i6sXr+EbT/tIujpxvTtPIJ3P56Zeuy06diSYb1fzcMaZl+D\n1vW49O8lvl0ahqunKyNDh/Bajxk4ODrQsltzrkVez7Dc0X3HWDr1w3TLajSpzqxBoQybMwhHJ0eM\nRiNPPF2PBWOX5EZVrKZ2rZrMeXN66vPJIW/QtXNHgpo1Yf6iJaxZt57Oz7dPXR8bF8fMOXOpX7dO\nuu1s3LyVFcveo/+Q4cTFxWNnZ2Dtd2Esnjcnt6qS42z9FmyWXGdqDdZrkligdFl//jzwNwDnzl7E\n178kb0yay6YfTOOirkRfxbW4a7oyV69cw829OADF3VxTWx4JCQkAREddpZhrMbr17sDnK9aSnGy7\nV/4ElPHj8MF/ADh/5iI+fiXYselX3g9dkWmZfX8cYuKwNwGIuX6TQkUKAZCYkAjAlahrFHNxpnNw\nO75ZtZ7k5BQr18I6SpUN4K8DGoDz5mNn5uT5bP5hJwBXoq5S/K5jJ/z3A4wbHALAjesxFC5s2jfp\njh0XZ17s9RxfrvjWZvdNzLUYnF1NPSbOLkWJuRoDQKsezdn2zQ6SkpIyLpjBd2iy+bU3rt6gSLHC\nNOvUmG1rdpJio/vmtrt7AneH76Nxo4YANH6yIb/9sTvd+kJOTiye9w7eXp7plt9uvXq4uxMTE8PK\nz76gS6fncXDIk/aRwIJkqpT6TCkVlJ2NK6XclFLPKKX6mR9PK6VctNYHsrO9nHJUn+SJRnUxGAyU\nKV8K/1K+FHUuAph+Hb3Q8zl+WLcpXZkf12/F178k67au5IPPQnlnxmIA7OzssLe3x6uEB0ajkWq1\nqhB7K5Zpb42la6/nc71uOeH4P6ep17AmBoOB0uX88Q0oSaFCTvctlxBvSg5tO7dk1zbTl4LBYIe9\nvR2eJdwxGo08XvMRYm/F8eobw+nUw/Ym0jqmT9LgydqmY6dcAH4BPhRJc+x06tGODes231Mu3rxv\n2r/wND9v/R0AO/O+8SrhgREj1Wo+RmxsHJNnjqZLcPt7tpHfhW/Zh4ePByGrJzFqwTC+XrSWEgHe\nBAT6sW/7AQyZnBTzLevDgBn9GL1gGKpWJcB03NjZ21Hc0xWjEcpXKUdCbAI9xr1I0w6N/t/efYdH\nVawPHP9uEkCkp0GoIuKLigWBq/BDEQwKFi4WVJSioCiIICqIdJCmdMJVFBGQpuhVURCkC4peKVaU\nV3oLEJJQLIS6vz/OCSQhjSSbZMn7eZ592D1nZ8/MsJv3zJw5M7lZrBy1bdsOur70Mu06duLb/60l\nISEhWWCMjU3e8xMQEEDhwuf/9s54vZw6dcp5v8fDjz//QtGiRen/6jBmvT83V8qS0zweT5Yf+UFm\nWqYfA8+IyEYR6ZdiqqU0iUh7YDVwD1AZZ+KHB4G1IuK7Tv1MWPPV9/z64++8+8F4Hn38frZv2Xn2\nP2aNNjwAACAASURBVGXo2N58/8161n77Y7I0d/07kn17D9C8UWs6PvYCrwx2rv18OOszJs8ew9KF\nq+jQ+THeGj+Ndh0fZuDLI6lR80rCwkNSy0K+9r/V6/nt5z/4z6wRtGzbnJ3bdmf6C3vL7Tdz9/2R\njH3V6Y779P0viHpvOCu/XEPbp1vybtRsHu1wP8P7jOfKa64gNDzYl0XJcd+uWsvGnzYx+f0xPPL4\nfWzfuuvsd+fVMb1Yu2YD675L/VyxYWR9mj94J68PmgjAR7PnM2nWKJYv+ponOrXi7QkzaPPkQ7za\nazQ1rqlOqJ99d/7VpA7x++Pp/+gQxnaL4pHuLXnwufv4cOInaaaJ2R3D/HcXMqn3O0wfNou2vR4l\nIDCAVfO+pvu4Lvyw8ieatm7CgqmLiGzVmBmvzaGyVKJUSMk0PzO/qlK5Ip06dmDCqNcY0r8vA4YM\nS9GDlflLhg/d34IOnZ8jsvFtTJn2Hp2eas/0mbMZ3K83v236g5iDB3M8/z4XkI1HPpBhn4CqzgXm\nikgxnDl554jIn8AYVV2aTtKngLpJ7k8FwJ3GaTHOfL955o2xU2Gsc53msxUziY87zKuje7Fz227e\njjq/O/OGOjVZs+p7ADZv2kZ4WecP3ZfzV/Dl/BVUqlIBuboamzZuITAwEIAD+w4SUbEsB2MyNbVj\nvvLOhJlnZ7Ccu2Qyh+KPAOn/3G9qcCNtnm5J9/b9+OfvYwAs+2I1y75YTYXKEVxRoyp//L6NwCCn\nfg7uj6Vc+XBiY+J9WZQcN2ncdBg3HYBPlk/jUNxhBo3syc5tu3ln4qxU09S7pQ5PdGpFl8d7na2b\nJQtWsmTBSipWKU/1Gpejv20hMMj5y3BgfywRFcKJ9aPvTrVrq/Lb986Ao+ht+6gslYjbF0/7fu3w\neKBUSEm6j3+Osd2izqY5EneUDSudE9fYfXEcjT9K6dBSrF/+A+uX/0BYhVAqXFGB3Zv3EBjo1M2h\nmMMElwvmSFzq12Dzq/CwMO6MbAxApYoVCA0JYePvmzhx4gSFCxfmQMxBwsJCM/VZTe+IpOkdkeza\nvQfdvIWrRDh9ygnMZcuGEb1vP+FhYT4riy/klxZmVmUqpru3tjyAM0lwAM7tMV1FZEg6yQJJPVjn\n+blE9RqXM/C1HgDUb/gvNm38g2bNb+fE8ZO8NSH1hQF279jLdbWcUZARFcryt/sHMdEz3drxxthp\nABQqVAiAcuXD0hywk59Vk8t4ZWg3AG66pTabNm45uy+tr/ulxYrSuecT9Hh6EH//9c95+zs89yjv\nTHACTVAh52sRHhHqV8EC4IoaVek34kUA6t1al02/bqFp88acOHGSyVEzU01TrPildO31FM8/2Ye/\n/vz7vP0du7bhLTc4n/3uRPjfdydmbyxVr7kMgOCyZYjZfZB+jwxmZOexvN5pLEfijiYLpOCM0I18\nuBEAJYNLUKJ0CQ7HHjm7/+4nmjH/3S8ACHS7Q8uEl+ZIkvf4iwWLFjN95mwAYmPjiIuPp8W9d7N4\n2QoAli5fSYN6N6eZPrUbL96cPIVnOz4JwEn3OvOBAzGEZzIom5yTYctURKbiLAg+D3gx8XqniEzC\nme+wbxpJxwPrROR7ILHPIQKoA/TKZr6zZfOmbXg8HmZ++gYJCSfo3W0Ir/9nAIULF+adOWPxer1s\n27yT4QPGM2JCP/q9NIKPZn/OoJE9eef9cQQGBDCkz5izn1erzrXs3L6buINOC2vhZ8uY/t+JbNu8\nk317D+RVMbNsq+7A44HJH47heMJxBr40irbPPETd+rUIDi3NmHcG8euPm3hz1DQGjenJkJfHEHn3\nrZQqXZIh43o5k2x6vQzuOZqDB+K4rvbV7Nq+l/jYQwAsnb+Kt94fxfatu9gf7V/dUVs2bcfj8TD9\n4ygSEk7Qt/swRkT1o3CRQrw1a5Tz3dmyk9cHTmTo+N4M7DGSO+6+jVKlSzIiqh8ejwev10v/l14j\nZn8sN9Spya7te4hz6+bLz1fw7ofj2b5lJ/ujY/K4tBdm9bxvaNvrUV6Y8ByegABmj/og2X5vkn6N\n9v3b8t7w2fz8zS+079+O6xtcS2BQILNHf3B2kFG1ay8nZncMR+P/BGDd0vX0eKM7+3buJ/7Aodwr\nWA5pdGsDXu47kOWrVnPq1Cn6v9ITqV6d3gMH89En8ygfUY7mdzcDoGffAQzp34ct27YzalwU0fv2\nUygoiKUrVjD29eGULFGCDT/+RJXKlQl1Byc1uyOS1u07Uu3yqpSPiEgvK/mSv7dMM7zPVES6AlMS\nZ4xwt92sqt+JSC1V/SGdtJfizJhU1t0UDXyfsus3Lb68z9Tf+fo+U3/ny/tM/Z2v7jO9GPjyPtOL\ngS/vM90655Ms/72v1uq+PI/EabZMRaQ0EAK0Aj53Z4cAZwHV94ArMwikhXBmQWrCuVVj9gKLRMRW\njTHGGHNOnofD7Emvm7cezjRLNwBJ5yQ8A3yZic9OXDVmFLZqjDHGmHT4cKL7XJFmMFXVhcBCEXlG\nVbMy7YitGmOMMSZz/PyaaXrdvINTe55IVTOaD85WjTHGGFMgpNfNm941zcxcKE66akziaJk/cVaN\naZe57BljjCkI/Lxhmm43b5oT0YvIyLT2JUm/B2ifRvrlQOPMZNAYY4zJ7zJzn2kTYBjOyF6AIkA8\n0CODdJ3T2V0hsxk0xhhz8fP3+0wzs8TAEOA5YBzQAXgYZ87djLyA06W7L5V9hTKbQWOMMQXAxTqa\nN4mj7gQNJ1R1I9BfRBYCSzJI1wJndtduqppswJGI3Jal3BpjjLkoFYSWaSERaQAcEpF2wG9A1YwS\nqeqvInIPcDKV3S9eWDaNMcaY/CszwfRpoBzONdKJOFMDDsvMh6vq+TOeO9s3ZDaDxhhjCgD/bphm\nagk2BdR9eYdvs2OMMcb4n8yM5m0FvAyUIcm5g6pW9mG+jDHGFCAF4ZrpIJx1THf6OC/GGGMKqIt2\nbt4kNqvqKp/nxBhjTMFVAFqma0RkGLASOJW4UVWXp5nCGGOMuQAFoZs30v23XpJtXpIvy2aMMcYU\nWJkZzdsIQEQ8qprlldCNMcaYi1VmRvNeD0wBigM1RKQfsFhV/+frzBljjCkg/LuXl4BMvGcizuov\niXPsfgCM8VmOjDHGFDieAE+WH/lBZoLpSVX9OfGFqv5BkoFIxhhjTLZ5PFl/5AOZGYB0SkSq4i4I\nLiLN8PsGuTHGmPykIIzmfQmYB4iIHAF2AG19mSljjDHGn2RmNO/PwHUiEgYcV9Wjvs+WMcYY4z/S\nDKYiUhLoC9QAVgHjVNWulRpjjMl5+WQgUValNwDpDffft4GrgQG+z44xxpiCyOPxZPmRH6TXzXuZ\nqrYGEJGFwLLcyZIxxpgCJ3/ExCxLL5ieTHyiqqdFJNdnPypbPCy3D+k3/jl5LK+zYIwxOSa/tDCz\nKr1u3pTB06YSNMYYY1KRXsu0vojsSvI63H3tAby2OLgxxhjjSC+YSq7lwhhjTMHm56N50wymqroz\nNzNijDGm4PL3a6aZmQHJGGOM8S0LpsYYY0z2+HvLNDOrxhhjjDEmHRZMjTHGmGyybl5jjDF572Id\nzWuMMcbkFn+/ZmrB1BhjTN6zYGqMMcZkj8e6eY0xxpj8S0TGADcDZ4DnVXVdkn3bgV3uPi/wmKru\nE5HHgB44i770V9WF6R3DgqkxxpiLlojcClyhqvVFpAbwLlA/yVu8QFNVPZYkTTDQH6gFlAAGARZM\njTHG5HO+u2Z6O/ApgKpuEpHSIlJcVf9KPDLnr6YaCSxR1X+Af4BnMjqI3WdqjDEmz3k8niw/MlAO\nOJjkday7LalJIrJaRIa5ry8DionIPBH5SkQaZ3QQn7ZMRaQ08H9AhLspGlitqn/68rjGGGP8TO6N\n5k15oH7AIiAe+FREHnDfEwy0AKoCK4Aq6X2oz1qmItIeWA3cA1R2M/IgsFZEHvHVcY0xxvgfT4An\ny48MRJO8JVoe2Jf4QlVnqmqsqp7BuS5aE9gPrFFVr6puA/4UkdD0DuLLlulTQF1VTUi6UUSKA4uB\n9314bGOMMQaceDMQmCwiNwJ7VfVvABEpCcwF7lXVk0BD4EPgW2CaiLyO00Itpqqx6R3El8E0MI3P\nD8Cu1RpjjMkFqvqtiKwXkW+A08CzItIOOKyq80RkAfCdiPwD/KCq/wUQkQ+B73BG+3bJ6Di+DKbj\ngXUi8j3nLv5GAHWAXj48rjHGGH/jw2umqto7xaZfkuyLAqJSSTMZmJzZY/gsmKrqLBH5BLiJc/3V\n0UD7lF2/xhhjCjibTjBt7j06K1JuF5GbVPV/vjy2McYY/+HvE93n1bXL2/LouMYYY/KjAE/WH/lA\nrsyAJCJBAKp6yv33tdw4blouKVqEHsO6UKJkcYIKBTFr0occiI7l+QFPc8Z7hr079jHh1cl4vd6z\naa6tczX9Rr/Aji27wQPb/9jFmyOm0qL1XTS8sx6/btjElLGzAGh0VwPKhJTi4xkL8qqI2dZj0LNU\nvbIKJ0+cZNSA/7B7RzQPtrmXZ3u2p2ndRziecPy8NF16Pck11wte7xnGD30b3biVlm2b06hZA35Z\n/xtvjpoGQJN7GlImpDRzp8/L5VLljN5DnqfalZdx8sRJhvUbR8Kx4wx4vQdBQUGcOnmSvi+M4FDc\n4WRpur78FDfUqUlgYABT35zDyiVraPX4fUTe1ZAf1/9K1GvvANC0eWOCQ8sw+93/5kXRsqXwJYV5\nvE9rLi1xKUGFAlkw7Ut+X7sJgKv/VYMuI5+hc8Pnk6WpfsMVPDX4CaK37cPj8bB3617mTviYxg82\npHbjWmz5eRufTPoMgLqRtSkZXIJlc1fmdtFyxNr1P/DSK324otrleL1w5RXVeLzNY/QeMJgzZ84Q\nFhrCsMEDKBSU/M/y5i1b6dajF20ffYRHWj4AwKz357JoyTJq3XAdLzz3LAALFi0mLj6eto/anYd5\nwWfBVEQuA0bgTNpwBggQEXC6fV9R1b2+OnZGmvz7NnZvj2bahDmUCSnNyKkD2LM9mjmT/8v6NT/T\nquP9NGxaj5UL1yRL99PajQx9aWyybbc0uZnubfox/O2+FC5SGO+ZM9x5XyN6PzM0N4uUo265/WaK\nFb+Uzq16Ur5iWbr1eZplC1dRJqQUB2PiUk1zfZ1rqFglgk6telD58oq8MrQbnVr1oFHT/6Nzq56M\nmTL4bP3cdX8kLz01IJdLlTNua1KfYiUupcNDz1O+Yjl6DHiWw4eO8PGc+SxbuJqWrZvT+skHzwZH\ngNo3Xc/l1avQvmU3SpYqwez5k1i5ZA2RdzWkw0PP85/pIyhSpDBnvF7uffBOuj7xSh6WMOvqNbuJ\nA7sOMG/yAkqGlKT7uC4MajOMoEJB3PlYE47EHk013eYftjB5wNRk22rddgMjO4+j6+jOFCpcCK/X\nS/27biKqx6TcKIrP1Kl9I6OHDzn7ut/goTz60INENr6NCW9M4pPP5vPQ/S3O7j+WkMCI0WO5+V91\nk33O4mUrmDHlLTp26UZCwnECAjx8+vkC3hw/OreKYlLwZTfvVGAKUFlVq6hqJZyZJD4FpvnwuBk6\nevhPSpYuDkDJ0sU5En+U8pXLob9uBWD9mp+oXf+G89Kl1qd/6uQpAA7HH6FY8Utp0fouPpuziDOn\nz/iwBL5V8bLy/PbzHwBE7zlA2QphrF76HZPHzUwzTe1617N66XcA7Nq2h+Ili1G0WFFOnHDq51D8\nEYqXuJSW7f7Nx7MWcNpP66fSZRXZ+JMCEL1nPxEVyjKi3wSWLVwNwKG4w5QqVTJZmvX/+4mXnx0M\nwJ9H/+KSS4oAcOLECQDi4w5TvEQxWj1+Hx/OmOe3dfPXkb8oVrIYAMVKXMpfh52pT5u2acLKj1dx\n6tSp1BOm0kt32n3vn4f/pGjxS2jcsiErP1nt178rIFlvFzit1Ya3NgCg4S0N+O77tcn2FylcmDfH\njyEsNCTZ9sTWa3CZMvz111/MfH8uj7S8n6Ag/51u3eMJyPIjP/BlLoJUdYmqnv32qOopVf0YuMSH\nx83QV4vWUDYijKkLJjBy6iDeHjWD7Zt3cVPD2gDUqX89pUNKnZeucrWKDBzfg9HTBnHDTTUBZ9aO\ngMAAgkPL4MXLNTcICceO88LgTrR4rFmuliunbPtjBzfdciMej4dKVStQvmJZihQpnG6akNAyHI4/\ncvb14fgjhISWISDAQ2BgACFhwXi9ULNWDY4dS6DX0K482OZeXxclx23R7dS7pQ4ej4cqVStSvmI5\nihYrCjgnWy3b/JtFny07L93x407gbPHwXXy9whl7F+AJIDAwgNDwYLx4uf7Gazh2LIF+I17kkXYt\nzvuM/G798h8ILhfM4Nl9eSGqK/9941PCK4ZRsVp5fvjqJzypRU0g4rJyPDPsSV6M6orUvhJw/rAG\nBAZQKqQkXi9cXrMqJ46doM3LrWj0wK25WawctW3bDrq+9DLtOnbi2/+tJSEhIVlgjI1N3vMTEBBA\n4cLn//bOeL2cOnXKeb/Hw48//0LRokXp/+owZr0/N1fKkuM8nqw/8gFfnsbsFJEo4BPO3WdaDmgJ\nbPbhcTPU+O4GHNh3kD6dhlH1ysq8MLgTA7uOpFv/p2jSvCG/rPvtvJ/93p37mPHGXFYv/o5yFcMZ\n+e5A2jXrwoK5Sxg5ZQArF37DI0/ex4w3P6RD98fo/fRQXhryLMFhZYg/eChPyplV/1u9gZq1rmLi\nzBFs1e3s2Lrngr+wAQEBeL1ePp2zkPHTh7Hsi1W0ebolUyfO4ZkXH+fFJ/vTe/jzhIQHExcT76OS\n5LxvV63l+huvZvL7Y9i8aRvbt+46O9n2q2N6sXbNBtZ991OqaRtG1qf5g3fybLuXAfho9nwmzRrF\n4vkreaJTK96eMIPnej5Jl8d7MfD1HoSGhxCbRrd6fvSvJnWI3x/PxB6TKH95BG17PcrRQ3/ywbiP\n0kwTszuG+e8uZMPKHwmNCKH7hOfo98hgVs37mu7jurBu2Qaatm7CgqmLaPHMvUS9+Cbtej9GqZCS\nHIlLvds4v6pSuSKdOnbgzsjG7N6zlw6dunD69Okk7/CmmTalh+5vQYfOz9GsSSRTpr1Hp6faM27i\nm7wVNY4+A4cQc/Ag4WFhOV8IH/L30by+DKaPA48C7YCy7rZoYAnwgQ+Pm6FratVg/TfOH7ztf+wi\nJMz5g96/izMuqnb96wgOK5MsTfzBQ6xe7HRj7t8Tw6HYw4SGB/PVojV8tWgN5SuV43K5jK2bdhAY\nGAhA7IE4ypYP87tgCjBlwiym4Ayoen/x2+danWn83mNj4gkOPVdnoeHBxB2MZ/nC1SxfuJoKlSO4\nQqqy+fdtBAY59XPwQCzlyof7VTAFmDRuOoybDsAny6dxKO4wg0b2ZOe23bwzcVaqaerdUocnOrWi\ny+O9+OdvZ9nEJQtWsmTBSipWKU/1Gpejv20hMMjpLDqwP5aICuF+FUyrXVuV3753BhxFb9tHZalE\n3L542vdrh8cDpUJK0n38c4ztdu7++CNxR9mw8kcAYvfFcTT+KKVDS7F++Q+sX/4DYRVCqXBFBXZv\n3kNgoFM3h2IOE1wu2O+CaXhYGHdGOouPVKpYgdCQEDb+vokTJ05QuHBhDsQcJCws3elfz2p6RyRN\n74hk1+496OYtXCXC6VNOYC5bNozoffv9Lpjml1G5WeWzbl535O5nOPMc/td9fATMdycUzjPRu/ZT\n47rqAIRHhHLs72O07vQgdW+pBcAdLRrx3cp1ydI0uqsBD7S7B4AyIaUpHVyK2CRBoHXnlrz3H6d7\nJaiQc44SVi7E7wIFQDW5jF5DuwJw0y03ohu3nNuZxvf9+29+4LY7/w+AK6+uxsEDcSQcOzfi94ku\nrZgS5QSaQm79hJcL86tgAXBFjar0G/EiAPVurcumX7fQtHljTpw4yeSo1K8pFyt+KV17PcXzT/bh\nrz//Pm9/x65teMsNzoUKFQKgXEQYBw/4V93E7I2l6jWXARBctgwxuw/S75HBjOw8ltc7jeVI3NFk\ngRScEbqRDzcCoGRwCUqULsHh2HOXC+5+ohnz3/0CgEC3O7RMeGmOJHmPv1iwaDHTZ84GIDY2jrj4\neFrcezeLlzm34i9dvpIG9W5OM703lRPZNydP4dmOTwJw0r3OfOBADOGZDMom5/hyNG97oDvwNU43\nrweoB4wRkYGqmmcT3S/4cAkvvNqZkVMHEhAQwLjBbxN/8BAvD3+ONp1a8suG31n7tXO23Ou1bozu\n+x++XbGOV17vRv1GdQkMCmL84LfPDoa4plYN9u6IPns7xMovvmbszCHs2rqHmH3pzo2cL23VHXg8\nHt6eO5rjCScY9NIo2jzdkrr/V4vgkNKMmjyQjT9uYtLo6Qwc3YOhvcay8cdN6MYtvDHndc6cPsOY\nwW+e/bzral/N7h3RxMc69bN0wVe8OWckO7bu4kD0wbSykS9t2bQdj8fD9I+jSEg4Qd/uwxgR1Y/C\nRQrx1qxReL1etm3ZyesDJzJ0fG8G9hjJHXffRqnSJRkR1Q+Px4PX66X/S68Rsz+WG+rUZNf2PcTF\nOr0XX36+gnc/HM/2LTvZHx2Tx6W9MKvnfUPbXo/ywoTn8AQEMHtU8g4ob5Jujfb92/Le8Nn8/M0v\ntO/fjusbXEtgUCCzR39w9ndV7drLidkdw9F4Z8XGdUvX0+ON7uzbuZ/4A/7X29Po1ga83Hcgy1et\n5tSpU/R/pSdSvTq9Bw7mo0/mUT6iHM3vdsZZ9Ow7gCH9+7Bl23ZGjYsiet9+CgUFsXTFCsa+PpyS\nJUqw4cefqFK5MqHu4KRmd0TSun1Hql1elfIREellxfiAJ+XospwiIt8CjdJaNUZV62f0GXfUbOmb\nzF0E/jl5LK+zkK8dO2kzVqalboWr8zoL+daEBf55y1ZuKVwyxGd9sUc3/5rlv/clq9fM8z5iWzXG\nGGNM3rMBSGmyVWOMMcZkTj65XzSrcmvVmKSjeb+3VWOMMcYk5fHz0by+HIBUCGgDNMFpkQLsBRaJ\nyHRVPZ1mYmOMMcaP+LKbdwawFRgFxOCM5q0APIAz1WBbHx7bGGOMyTW+DKYRqppy+YKtwCoR+cqH\nxzXGGONvbABSms6IyP3A56p6EkBEiuC0TM9fv8sYY0yBZdMJpq0NMBgYJSLF3G1/Aktxphg0xhhj\nHDaaN3Wqugdon9o+EVkONPbVsY0xxvgXG82bBhHpnM7uCr46rjHGGJPbfNnN+wJOl+6+VPYV8uFx\njTHGmFzly2DaApgAdFPVZAOOROQ2Hx7XGGOMv/HzAUi+XILtV+Ae4GQqu1/01XGNMcb4H4/Hk+VH\nfuDLlimq+k8a2zf48rjGGGP8jI3mNcYYY7LJz0fz+vepgDHGGJMPWDA1xhhjssm6eY0xxuS5/DKQ\nKKssmBpjjMl7NgDJGGOMyR5rmRpjjDHZ5ectU//OvTHGGJMPWDA1xhhjssm6eY0xxuQ5W4LNGGOM\nyS4bgGSMMcZkj8fPByBZMDXGGJP3/Lxl6vF6vXmdB2OMMcav+Xe72hhjjMkHLJgaY4wx2WTB1Bhj\njMkmC6bGGGNMNlkwNcYYY7LJgqkxxhiTTQX+PlMRqQl8CoxR1TcymaYiMAPnZGQf0EZVT4rISWA1\n4AG8wO2q6lf3HonIGOBm4AzwvKquS7IvEhgKnAIWquqQtNKkU0elgTnAn6r6UC4WLcflVF2527sC\no4DSqvpPrhbEx7JYTxf8u/R3GdRTEeAt4BpVrZtHWTTpKNAtUxG5FJgALL3ApIOBKFVtCGwF2rvb\nD6lqY1Vt5P7rb4H0VuAKVa0PPIlTN0mNB+4DGgB3iEiNdNKkVUeTcE44/FpO1pWItAHCgb25lf/c\nksV6yurv0m9lop5GAj/gnKSbfKhAB1MgAWiG03ICQESuEpFlIrJERD4WkZKppLsN+Nx9/jkQ6T73\n7yk84Hac1gCqugkoLSLFAUSkKhCnqtHuScICnHKnlqYEaddRB+CbXCmNb+VUXRUHPlbVvnlQhtxw\nIfX0hfv+836XBUCa9eR6JXG/yZ8KdDBV1TOqejzF5iigo6o2AZYAXVJJeqmqnnSfxwAR7vNLRGSm\niKwWke6+ybVPlQMOJnkd625Lbd9BnHKXTWV7OdKoI1X9O+eznSdyoq5igXIXUZ2k5kLqKQaISON3\nebFLr54upt/NRavAXzNNxb+AySLiAQoDazN4f9LW6IvATPf5KhH5SlU3+CCPuSW9lnZa+1Lb7u8t\n9szIqbq62GWlngoiqws/Y8H0fH+rauOkG0TkZmA4zvWK1sBfIlLEPXuuAEQDqOrbSdIsA64F/CmY\nRpPkbBgoz7mutmjOtcDBKfde4HgqaaJJo44uIjlVV0m7Mi/G62EXWk8X2/cks9KrJ+MHCnQ3bxp+\nEpGmACLysIg0UtXvkgwqisYZGPGA+/4HgEUicqWIzHLTBQH/B2zMiwJkw2LgQQARuRHYm9i9pKo7\ngRIiUtkt3z3u+5ekSBPtpjmvjpIcx4P/n3nnRF3tTdF95+91kpqs1FNSF2OdpCbNekriYvjdXLQK\n9Kox7pd2NFAFOInTeugDvAacBo4Bj6rq4RTpygHvAUWAncATqnpaRIbjDCQ4DcxT1RG5VZacIiLD\ngIY4ZXgWuBE4rKrzRKQB8DpOC+ojVR2bWhpV/SW1OnLTLQNK4bRCNgKDVXVl7pUw5+RAXXVW1V9F\npDfQBLgJ57LCt6raK9cL5CMXWk9p/C7vT/k7vNhkUE9zgUrA1cB64G1VfT/PMmvOU6CDqTHGGJMT\nrJvXGGOMySYLpsYYY0w2WTA1xhhjssmCqTHGGJNNFkyNMcaYbLJgaowxxmSTzYBkfEpEqgBfq2ol\n93UwsBzoo6oLfHjc7ThL4G3zwWdXAxbi3GjfB/ga2IyzIk5tVR2eRro7gRvT2p/BMSOAGqq6Io19\nHwH3qOqhC/1sXxKRujgrCN2tqmfyOj/G+IoFU5MbvHB2ybvPgdd8GUiTHtNH6gPrVbWLiNwC6tKW\nugAABQdJREFU/KWq97v7Us7gc5aqfgl8mcVjNgKuAs4LpsBkYEB+C6QAqrpWRNYDL+FMzmDMRckm\nbTA+5bZMVwNVgc+ABUkXexaR24AB7suTwFOqutNtWX7gpuvppl2Es3hycZyWzv4M0idrmbqLF0wA\n6uAE2zGq+pGI3ISzMPcJd3sXVd0kIpWAN4Ci7jH7ADuA+UBpnKXVagOX4czs9DkQqapt3M8cizMf\nbzzQDmdaxcT917nHDAIKucf8SURW4EzFWB+o7pbtW84F0fGqOi5JmW4Apqvq9e7rZjjzSMfhBPYu\nqlpJRARncemTQEmgr6ouEZEBOHPClgOuwwl4N7h1FK2q/xaRhm7Z9wB1ge+An3HWIQ0BmqlqtIg8\nA7R1y5wAPKyqR0UkBGe2q/LWOjUXK7tmanJDAPAuUCRFIC2K0zV6n6o2AibiTCOX6A9Vfdh9fhUw\n1V1s/Cfg4UykT+kxIFxV6+Gsl9lORAKA6UA3Vb0dJwAm5vFNYJSqRgL/Bt4BtgMjgCWq+iTwPPCL\nqj7opkk8O50BdHDz9RVwV4r9M4Gn3UUVngWmJMlnMVW9G2eR6J6qugOYBsxIGkhdTUk+7/EkoLVb\nllJJjlcOJ4A2AboBw5KkqaGq9+Es4B6F03NQF7jWDfrgBNHuOEH2MSDezfsG3DllgUuAJm6Zd+Is\nCoGqxrmv62DMRcq6eU1uKAf8AlwjIo+q6mx3e02cVUM+dluNAUDSlsuaJM9j3UWTwfnDHJyJ9Cnd\nBKwEUNUjwL0iUgonwCau7rMSmOM+bwQUF5HEgHQcCM+osG5LrJSq/u4ea4K7vZ37bxggwBQ337jH\nSXy+MkU501MJ+D3JcYup6q/uvo9wAxrOCiQj3flfC+O0KBN96/67B9jvBm9w5sQt5T7/3a0zRCQu\nRZrE98QDC0XkDM68uklXgNmF04L/PoPyGOOXLJia3BCtqqNE5COcdV5/U9UfcYLTzpRL3iVxIsnz\nUyn2eTKRPiUv5/fGpLzO4Umy7ThOqzfZtUinxzTD4wSms/84kJBavt3PTlrWC1klJOXJxOkkzycC\ns1R1uohcg9MlnehUGs+THj/l9mR5FJEKON3WV6lqnIiMvIB8G+P3rJvX5AYPgNvieQqnJRkC/AGE\nun/cEZFbReTJ9D4jhQtJD05LN3F5vVIi8h3OykD73FGn4Kze8p37fDXwiPv+UBEZm5nCqmo8cFBE\nartpX3SvJybuPwrscK9v4i7f1y+Djz2D06JMaTdO6xQgFjgjItXd1/cneV9Z4Df3+cM4q/mkJqtL\nfIUDB91AGgzckeIYVXCuNxtzUbJganLD2dafO6J1CvAhTsuzDU535wpgEM71xWRp0niNqibgdGNm\nJj3AXGC7iHyDM6p2lKqexBkcNFpElgOdca5hgnNt8T4RWYUz6GjZBZS5LTDBzVcDnGukSbUDXhGR\nr4CpnBsFnNaIwNXA4yIyKMX2RbgnCKrqxbmuOU9EFuK0gBNbkKOBGe721UC823pMr57Tyktq/xc/\nAFvcE5QooD/whIjUd4NrJWBdGp9njN+z0bzG+DkR+RyY4I7ObQ785I5ovg/oqKrN8jh/Q4Ajqmpd\nv+aiZddMjfF/TwEficg6nGu1n4jIUZyep055mTG3+/xG4J68zIcxvmYtU2OMMSab7JqpMcYYk00W\nTI0xxphssmBqjDHGZJMFU2OMMSabLJgaY4wx2WTB1BhjjMmm/wfVX1ptdgOccQAAAABJRU5ErkJg\ngg==\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x7f04c70b9e80>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Cross-validated performance heatmap\n",
+    "cv_score_mat = pd.pivot_table(cv_score_df, values='score', index='C', columns='gamma')\n",
+    "ax = sns.heatmap(cv_score_mat, annot=True, fmt='.1%')\n",
+    "ax.set_xlabel('Kernel coefficient (gamma)')\n",
+    "ax.set_ylabel('Penalty parameter of the error term (C)');"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Use Optimal Hyperparameters to Output ROC Curve"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "y_pred_train = pipeline.decision_function(X_train)\n",
+    "y_pred_test = pipeline.decision_function(X_test)\n",
+    "\n",
+    "def get_threshold_metrics(y_true, y_pred):\n",
+    "    roc_columns = ['fpr', 'tpr', 'threshold']\n",
+    "    roc_items = zip(roc_columns, roc_curve(y_true, y_pred))\n",
+    "    roc_df = pd.DataFrame.from_items(roc_items)\n",
+    "    auroc = roc_auc_score(y_true, y_pred)\n",
+    "    return {'auroc': auroc, 'roc_df': roc_df}\n",
+    "\n",
+    "metrics_train = get_threshold_metrics(y_train, y_pred_train)\n",
+    "metrics_test = get_threshold_metrics(y_test, y_pred_test)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAfcAAAFvCAYAAABXQIIJAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAIABJREFUeJzt3Xl4FFXWx/FvCKvKTgKCIip6XHABN0DFARVFccMRB2fE\nDVxwYxTfUUecUVQGBPdxH/fdERBwRdDRQdxwQ5GjOCKKKGEHkQAh7x9VHToh6XRCupOu/D7Pw0O6\nqrrq9O3l1L11696swsJCREREJDrqVHcAIiIiUrWU3EVERCJGyV1ERCRilNxFREQiRsldREQkYpTc\nRUREIqZudQcgpTOzjcBcYAOQDSwHrnL3aVu4378CO7v72Wb2BjDM3T9NsP0gd38w/HsKcEWi7SsQ\nx0fAVkB9YCdgDpAFzHb3k81sHlAI/Ebw+n8DRrr7s+HzN8Y9B+BHdz8yXHcd0D9c9wlwnruv3NKY\nS3kNBwJr3P2LcrbbFWjt7u+Y2YlAX3cfVEUxDAGGA3e4+8iq2KdUjpldCOS6+9+qcJ/HAJcBRwLf\nsek7kUXwvfgUuMjdF4XbNwZuAI4GCsJ/TwGj3H1j3H4vA84iyAF1gdeAq1PxPakqZrYX8DjQ1d3X\nVnc8NZ2Se81VCBzm7gsBzKw7MMnMdnX3JVVxAHc/ItF6M8sGbgYeDLc/siqOG+5r//AYOwDfuPse\nJTYpBE5z9xnhdrsAM8zsc3f/Cigs5TmY2R+Aw4F93H2dmT0PXA1cWVWxxzkL+C+QMLkDJxF8195x\n9wnAhCqMoR/Bj/LDVbhPqQR3/2dV7s/MtgHuBbq7e6GZlfxOZAG3A7cAfwofv0xw0ru3u+ebWXPg\nWWAX4OzweaOAHsCR7v6zmTUC7gAmAYdV5WuoSu4+y8zGAzcRnPBIAkruNVcWm2qluPu7ZjYX6GZm\ns4B3Cb60nd29p5kdDNwKNAfygD+6+3dm1hB4FDgQmAd4bJ9m9l243btmNhD4K0FSfR8YDLwCNDWz\n2cAxwJvAH4EFwAxgZLhdc+Ayd3/ezBoQnF13A74kqDm3cfezKlkGsdf/jZlNJUjcX8WvK+FL4AJ3\nXxc+fgvY7CTGzM4A+gL5wKEE5XI9MIqgJWG4uz9oZn8DtnP3weHz/gZsB3wEDASOM7Mcgh/Zu8L4\n6hEk/bOBPsBVQL6ZNSM4EfiTux8Z/vDeC+xD0ELzmLuPDo+zMdz/ZUBr4GZ3v63EaxhFUM67mdn2\nYZm0C/f3JHAnQS2uH5ve1yHu/puZvQm8CpwA7AxcR/A+/omgtnesu39f4nhlvrdm1g64B7DwWEPd\n/dXw5K3Uz0q4z2uB04AGBCc9l7n7ZiNrlbYdsD3wAdDF3X8ys9OAi4CDgf8BdwOnhtvd5+7XhvEk\n+91pCzwGtAmP+4y7D0+wvOizEr4fDwAdgHXh+/d4eeVRwgXAVHf/MW5Z/Hei0MwmA2PDRccAbQkq\nBRvDbZaZ2R+B78xsJLAYuJjg5PfncJvfwlaHUk/ey/ht6AY86O67hNscFnsclkM7YG/g6fC1bh+r\nlJjZrcBv7n51We+/mZ0CXEvQOrEOuMTd3yb4TH9tZje5++LS4pWArrlnlnoEyQigFfBx+OO0DTAR\nuDL8st0OPBdudzaQS5CwTgZ6l9xp+INzM9DD3XcDtib4ATgb2ODue7j7vBJPaxWu2xv4M3BjuHww\nwY9ee+BcgtptVQ2DGP/6MbPHzOxLM3vLzLpBcHbv7rPC9U2BU4AXy9hfb+BvQEdgd2AYcAgwiKCp\nO6Zk/IXufh9BYvm/MOmeRJBU9gj3tT9wqrtPBsYDt7v7FSX2NxJYGpb5ocCQsIUmZg9370KQgG8K\na2ZF3P0vYQxXuPv14eI+wNHufgdBYjsK6AzsCTQjeK9iDg1f79nAaGC+u+9OcPJ0dinlNYiy39vH\nCD6PRpBknghPXqCMz4qZnQ78PiyrncN/F5Q8aFnbufv8sAxvNrOtCE5kBsWdHHQNW4g6AReGzbqx\neJL57gwF/uPunYC9gJ3MrHWC5cSVx/3AtPC97QvcYWbtE5VHKX5P8NkpVVjjPhuYHi7qAbwW3/wO\n4O55BJ+THkBX4Ad3/6bENuvc/aVSjlHWb0P8a6WUx32APu5+OzCNoAxiTgSeK+f9/2f4/D2AIcDx\nYZxLCU4wjiujWCSk5J4hzKwPQQ0u9kWuy6bm3UMJvrDTAMLr0h3NbLtw3Th3Lwy/GJNL2X1vYLq7\n/xI+Po2gJpNINvBI+PfHBLUjCJLFv8PjzQc2+8GoDDPrEu47tr/7gdHuvifBD8EkM2sSt/2TBC0M\n3xDUNksz292/dff14Xavh4lhFkENKGnuPg7Y3903hq0GHxKcUCVyDEHtEndfBoyj+MlXLO6PCWo2\nuWXsJz7pvx/uK7b/R919bfi6Hi6x/0lhIpgFNAL+HS4v6/UfSinvbZhYfwfcFr6W/wHvAMeGzyvr\ns9IXeMjdV4dx/IvgBLSkRNvdSdDk/CzwlLvPjnveY2E8eWE8sROnZL87i4Cjwpr9Onf/Y/gdKWs5\nYXnUJagF3xPucz5Bq1evcsqjSHhJrAvB5yjek2Y228y+BpYQfMZjJ2wtCFoeSvNLuL5F+HeyKvPb\nAMU/hy8QnKDGvsfrPOi3U9r72i8u3gvMrL27v+vuw+L2/QFBy4EkoGb5mu0tM9tAcBI2j+BMdo2Z\nARS4++pwu2YEP0ixH7Ysgk43OQRf5hVx+1wGbFPiOK0IOuwBwVk8QHicshS4+2+xvwl+sCBoZlwa\nt90CgmbsynjSzGId6n4GTnH3n8IYz4+L93kzu4bgx/vVcNkfzaw+Qa3jSeAPpex/VfzrAVbH/V2h\nE18zawXcGf54bSQ4Ebst8bPIIXg/YpYB28Y9XgHg7hvDWns25Ysv+9L2H3+CEHv9BeFxSns/45X1\n3jYl+My9G35msghqeFNj+ytj382AYWZ2Lps6iC0q5bhlbheWzf3AfWyqUcbEx7osjD8WTzLfnVsI\nPgd3A9ua2d3u/vdSlv/T3a+LO1bLMLb4z1d82ZdVHvFahMcoWR6nufsMM6tHcClpUty+FlP2SWnr\ncF+Lqdj3sTK/DVC87CcAY8Pv4wlsahlJ9P4fT9B6NtPM5gN/DpvlCbfpXIHXUCspuddsRR3qyvET\nQS30wJIrzGwZwY9vTE4pz1/MplpNrMdtowrGGrOS4icP25a1YRKKOg/FM7OtgXbu/nXc4rrAejPr\nCfzi7rM96FD3APB2yX1UQMkf3+ZlbHcjwbXBPd19g5k9kcS+fyFIBLFrqi2pWK0q2f3HbOn+y3pv\nFxH0GdgvLtEARc26ZfkJeNHd7y7nuGVuF7Ya/B9Bh7DRBHdJxLSK+7sFxRNO/L5L/e6ERgOjzawj\n8KqZvePuU0tZ/t+45ywGCs2sqbvHTqwrWvZl9SnJAnD39RbcFTIW2C9c9wrwlJnVC1ujAAj7hBwA\nnEHwHuaa2b4ed9dL2Nrwd+AGL94TfTFxteS434aS34sWZb0QD677f0DQ9+VEgn4dkOB9dffv2NQB\n8AyCHv+VrSTUSmqWr9nK+oKXXPc+QQ3iQAAz28nMHgvXzQCON7M6Ye3ymFL29TLQ3czahzXEewm+\nWOuB7DCZJhvbB8DJZpYVdirqk+A1lLevspZvT9BzfkcAM+tN8OP5PkHTfayWAEEN4PMkYijr2AuB\nTuHrKVl+6wlqHxDUymaFiX0fguvv25SyXbzJBNeuYzX/fpR+2aSyJhP0om4U/nifk2D/iT5rMaW+\nt+5eQNBEPwSChGtm/7Kgk11p+449fhE4Pbx2jJmdG16HLSnRdtcTXE64jKAGHv/+nBrG2prg/Yid\n5CX13TGze80s1hnzO4LPQmFZy2M7DMvjVeC8cD87EzT/v1FOecRbQpBASzsZj3kcaGBBhzfCmu3H\nwKPhSQ9m1iLc7iF3/yE82bgZeCyMK3aCdD+wr29+i9nLwMGl/DYsDMutVXgJ4bQEcULQND8YqBfr\nE0MZ72u4z9fDEwkI3qP4fgQ5lH35QUJK7jVXeZ3Q4n9M1hJ0TLnTzL4k+CLFmr4eIDhb/5bgR3Bc\nyX24+wKCJPMmwW00GwmaHhcS9Pqeb0GHtcKSzy3FvcBagnv07yToLZv0a0li/7j7HOBSYHLYnPo3\n4PiwqXU0QU/pz81sDtCToCNYecrqHPQ88CvB63mUTeUKQWenUWY2BhhDcI3wS4JOQZcBg8zsZIJb\njM43s+dKHOcaoIWZfUXQq/8md59ZTjzlxV3E3f9N8OM8k+AEZz7Be1KR/cdL9N4OAQ4LX8tHwLfh\n56rMY3lwW+Ak4OPwfTyO4H7rkq+j1O3MbG+CE6Ibwj4FlwD/jDsZ/ZLghGQWQYfGOSXjKee7cy9w\nY3jML4B3w2vzZS2PdwHQMyyPF4BzyiuPEq+5gOBuhAPK2i68Tn0tMMKCOxkguPz0C/BpGN9/CHrc\nXxr3vOsIkvnEML4PCS579aOEsn4b3P1b4CGC++zfZtOJS1nGE/TBKPr+lPW+etAL/hXgQzP7gqDW\nHt/B8yCCSoskkKX53CWVzGw0kO3ul1d3LFK1avJ7a3G3eVZ3LJVlZn8BdnX3c6o7lprCgttJvyG4\nk0S19wR0zV2qlJkdR1CbOJhg9LljCWrWkuH03qbdPcCXZtY21pFUuJjgrggl9nKoWV6q2ksEzXxf\nEVz/ezVsHpbMl0nvbcY3SXowFOx5bLptrlYzs04Elw6uqu5YMoGa5UVERCJGNXcREZGIyahr7hs2\nFBQuW7amusOItObNt0JlnHoq59RTGaeeyjg9cnIaJ3OrajEZVXOvWzeZAbpkS6iM00PlnHoq49RT\nGddcGZXcRUREpHxK7iIiIhGj5C4iIhIxSu4iIiIRo+QuIiISMUruIiIiEaPkLiIiEjFK7iIiIhGT\n8hHqwsH+JxDMAXx3iXVHADcCG4BX3P2GVMcjIiISdSmtuZvZVsAdwBtlbHI7cBJwCNDbzHZLZTwi\nIiK1Qaqb5dcCfYCFJVeY2Y7AEnf/yd0LgZeBw1Mcj4iISOSlNLm7+0Z3zy9jdRsgL+7xImDbVMYj\nIiJSG9SkWeEqPOuNpMdz0+by4ZxF1R1GpGRnZ1FQUFjdYUSayjj1KlPG63K+oKDJghRFFE3P/umW\nCj+nOpP7TxSvqbcLlyWUk9M4ZQFF0UOTvmT6Z1v2RVq07DcAcps3qoqQJJSdrfPZVFMZJ2dtq1ls\n2Kbcn98qUVgvmCI2a/1WaTlebZXO5F7sW+bu35tZYzNrT5DU+wKnlbeTvLxVKQqvZqjqWvKSlWsB\naNmkYVLbl3Ym3rJJQw7YLZf+vTpWWVy1XU5O48h/lsfNncwni2ZV2/Gz62RRsFE192SsWrsMgBYN\nm1foeZUr4wZ0zt2Lfh37VvB5UhEpTe5m1gUYC+wArDezk4GJwHfu/iJwAfAMUAg87e5zUxlPdUsm\ncVc0GZenoom5NiQdSZ34hL60kglD0q9Fw+aVSrj6vai5sgoLM+rMtjATPkhlJfFkE3d11pL1ZU2P\nLS3n6q4Vl6VkQq/OGpo+y6mnMk6PnJzGFb6+VJM61GW0+IReVhJX87YkUpGEXVNrxZWtAYpI1VJy\nrwLPTZvLqx/MB4IEriQu5SXq0q5VViRhK4mKSCJK7hVUWpN7rKZ+9IHtldBrodISeWVq1krYIlJV\nlNwroGQNPUY19cxVFdeuS0vk5SVqXasUkVRSck9SfGJXDT0zVVUNuyTVuEWkplFyT6C0TnJK7Jnr\nk0WzWJ6/gmYNmhYtU2IWkShSck/gwzmLWLYqn+aNG6jpPQOVrKnHEvuI7ldVY1QiIqmn5F6G56bN\nZcnKtbRs0pCbh3Sv7nCkhGSulZdscm/WoCmdc/dKeWwiItVNyb2EWFN8rBn+gN1yqzmi2qGiHduS\nuVauJncRqa2U3EuINcWrGT69SrsenogSt4hI2ZTc46gpPrUS1c51PVxEpOrUqe4Aaor4W93UFJ8a\nsdp5aXQ9XESk6tT6mnvJa+y61a3qxWrsqp2LiKRHrU7uJUec0zX2qjdu7mSmzn8b2HSdXEREUqtW\nJnfV1itmS4ZojfVqP7x9D3V+ExFJk1qZ3NUjvmIq2pM9nnq1i4ikX61L7uoRX7Zxcyfz+XtfbDYV\nqa6Vi4hkllqV3NUjPlBWM3tZA8OoJ7uISGapVck9NglMbbvGXjKZl5XEWzRszsE77MfR7XqnNT4R\nEalatSK5xzrQxa6z16bEDptfM090HVzzjIuIZL5akdzjZ3erLc3x8bV1XTMXEaldIp/ca2MHupL3\nluuauYhI7RL55B67zl6bauyxxK57y0VEaqdIJ/f4WntUr7OX1VlOiV1EpPaKdHKvDbX2inSWExGR\n2iHSyR2IdK09Rp3lREQkXmSnfI01yUfZuLmTi5rhRUREYiKb3GtLkzygnvAiIlJMZJM71I4m+RYN\nm+v6uoiIFBPJ5K4meRERqc0imdyj3iQffy+7muRFRKSkSCZ3iG6TvAapERGR8kQuuUe9ST7WiU6J\nXUREyhKp+9yjPF97bCS65fkr1IlOREQSilTNPcrztcePRKfr7CIikkikau4QvWvt8TV2jUQnIiLJ\niFxyj5KSU7eqxi4iIslQcq/B1HlOREQqIzLJPX5610wWP4WrOs+JiEhlRKZDXVQGroldXwfUeU5E\nRColMjV3iE5nOnWcExGRLRGZmnsUaLx4ERGpCkruNYimcBURkaqg5F5DxGrt6kAnIiJbSsm9hlCt\nXUREqoqSew2iWruIiFQFJfcaQB3pRESkKkXqVrhMED9ITUwssatJXkREqoKSexqVHCs+JjZuvJrk\nRUSkKqQ8uZvZLUBXYCMw1N0/ilt3IfBHYAPwkbtflup4qpPGihcRkXRI6TV3M+sBdHT37sAg4I64\ndY2BYcDB7t4D2NPMDkxlPDWBOs2JiEiqpbpD3eHABAB3nwM0M7NtwnXrgHygiZnVBRoBS1Mcj4iI\nSOSlOrm3AfLiHi8Ol+Hu+cD1wP+A74D33X1uiuMRERGJvHTfCpcV+yNslr8a6AjsCHQ1M3UXFxER\n2UKp7lD3E2FNPdQWWBj+vTvwrbsvAzCzd4D9gOL3iZWQk9O41OXZ2VkJ19cE2XVqfoxQ8+OLCpVz\n6qmMU09lXDOlOrm/DvwdeMDMugAL3P3XcN08YHczaxA20e8PvFTeDvPyVpW6vKCgMOH6mqBgY82P\nMSencY2OLypUzqmnMk49lXF6VOYEKqXJ3d1nmNlMM5sOFAAXmtkZwHJ3f9HMbgbeMrP1wLvuPj2V\n8VSn+IlhREREUinl97m7+9UlFs2KW/cA8ECqY6gJNDGMiIiki8aWTyPd4y4iIumg5C4iIhIxSu4i\nIiIRo+QuIiISMUruIiIiEaPkLiIiEjFK7iIiIhGj5J4GsQFsRERE0kHJPQ00gI2IiKSTknuaaAAb\nERFJFyX3FFOTvIiIpFvKx5avjcbNnVzUFB9L7GqSFxGRdFFyT4FPFs1ief4KmjVoSouGzemcu5ea\n5EVEJG2U3KtQrMYeS+wjul9V3SGJiEgtpOReRcbNnczU+W8DFNXWRUREqoOSexWIT+yHt++hJngR\nEalW6i1fBWKd55TYRUSkJlByryK6j11ERGoKNctvgZId6ERERGoC1dy3QHxiVwc6ERGpKVRz30K6\n5U1ERGoa1dxFREQiRsldREQkYtQsXwnqSCciIjWZau6VoI50IiJSk6nmXknqSCciIjWVknsFqDle\nREQygZrlK0DN8SIikglUc68gNceLiEhNp5q7iIhIxCi5J2nc3MksXbususMQEREpl5J7kmLTuupa\nu4iI1HRJJXcza2lm+4d/17oTglitXdO6iohIJig3UZvZAOA94JFw0Z1mdk4qg6ppVGsXEZFMkkwt\n/DJgHyAvfDwMODdlEdVQqrWLiEimSCa5r3D3NbEH7v4bsC51IYmIiMiWSOY+98VmdgbQyMy6AKey\nqRYvIiIiNUwyNffzgQOAxsCDQCOgVl1zFxERySTJ1NyPdveL4heY2fnAvakJSURERLZEmcndzDoD\nXYBhZrZV3Kp6wLUouYuIiNRIiWrua4HWQDPg0LjlG4ErUhmUiIiIVF6Zyd3dvwK+MrNp7v5e/Doz\nOznlkYmIiEilJHPN/SczGw20Ch83AHoBL6QsKhEREam0ZHrLPw4sBboBM4Ec4PRUBiUiIiKVl0xy\n3+Du/wB+cfd/AscDF6Y2rJpDs8GJiEimSSa5NzKz7YCNZrYTsB7okNKoahCNKy8iIpkmmeQ+Gjgc\nuBn4FFgMvJvKoGoajSsvIiKZpNwOde4+Ifa3mbUAGru72qlFRERqqESD2NQBBgOdgHfd/Wl332Bm\n+Wb2T3eP9HX3cXMn88miWSzPX0GzBk2rOxwREZGkJaq53wm0AGYA55tZK+BL4H5gfBpiq1bxiV3X\n20VEJJMkSu77uvvBAGb2L+B7YB5wqrvPTPYAZnYL0JVgZLuh7v5R3LrtgKcJhrT92N2HVPgVpECs\nh3yLhs0Z0f2q6g5HRESkQhJ1qCuas93dfwUcOKiCib0H0NHduwODgDtKbDIWuNnduwIFYbKvduoh\nLyIimSxRci8s8Tjf3QsquP/DgQkA7j4HaGZm2wCYWRZwCDApXH+xu/9Ywf1Xufhau3rIi4hIJkrU\nLN/WzM6Oe7xt/GN3fyiJ/bcBPop7vDhcNpdgpLvVwG1m1gV4x92vTjryFFGtXUREMl2i5D6D4rPB\nvRf3uBBIJrmXlFXi73bArcB84CUz6+PuryTaQU5O41KXZ2dnJVyfjMc/fYGla5eRs1ULzus2oNL7\nyXRbUoaSPJVz6qmMU09lXDMlmhXurCrY/08ENfWYtsDC8O/FwDx3nwdgZlOBPYGEyT0vb1WpywsK\nChOuT8b074PuBHu36rRF+8lkOTmNa+1rTyeVc+qpjFNPZZwelTmBSmaEui3xOvB7gLDpfUHYOY/w\n+v3/zGzncNv9CDrtVQtdaxcRkahIZsrXSnP3GWY208ymAwXAhWZ2BrDc3V8E/gw8Enaum+Xuk1IZ\nTyK61i4iIlGR0uQOUEonuVlx676l+HX9aqVau4iIREG5zfJmto+ZfWRmc8LHw83soNSHJiIiIpWR\nzDX3u4Cz2dQR7lnglpRFJCIiIlskmeS+3t0/jz1w96+BDakLSURERLZEMsl9g5ntSDhinZn1ofj9\n6iIiIlKDJNOh7nLgRcDMbAXB5DEDUxmUiIiIVF4yyX2du+9tZjkE48uvTHVQIiIiUnnJNMtPMrMP\ngAFAgxTHIyIiIluo3OTu7rsCFxCMA/+umU02s1NTHpmIiIhUSlLDz7r7THf/C8GAM98Dj6c0qjSL\nDT0rIiISBeVeczezbYGTgVMIpml9BtgjxXGllYaeFRGRKEmmQ91HBAPXXO7uH5W3cabS0LMiIhIV\nZSZ3M9vW3RcCPQkHrTGznWLr3f1/qQ9PREREKipRzX0scBrwGsEANvED1xQCO5X2JBEREaleZSZ3\ndz8t/PMYd/8qfp2ZdUtpVCIiIlJpiZrlmwEtgYfM7DQ21dzrAY8Cu6Y+PBEREamoRM3y3YA/A/sC\n0+KWbyRoqhcREZEaKFGz/CvAK2Z2vrvfm8aYREREZAskapY/y90fBtqZ2fUl17v7tSmNLE1iA9i0\naNi8ukMRERGpEoma5TeG/0d67nYNYCMiIlGTqFn+0fD/68yssbuvMrPWBB3ppqcrwHTQADYiIhIl\n5Y4tb2Z3Av3NrAXwLnARcE+qA0sHjSkvIiJRlMzEMZ3d/V9Af+ARdz8V6JjasNJDTfIiIhJFyST3\n2P3tfYFJ4d+RmdddTfIiIhI1yST3r81sNtDY3T81s4HA0hTHlXJqkhcRkahKZla4QcBewOzw8ZfA\nxJRFlCZqkhcRkahKpubeCDgO+LeZvQj0BvJTGlWaqEleRESiKJnk/gDQBLgv/Lt1+L+IiIjUQMk0\ny7d29wFxjyeb2VspiqdSnps2lyUr19KyScPqDkVERKTaJVNz39rMtoo9MLOtgRqVRT+cswiAA3bL\nreZIREREql8yNff7gDlm9lH4eD9geOpCqpyWTRrSv1ckbr8XERHZIuUmd3d/yMymAF2AQuBid1+Q\n8shERESkUhImdzM7BtgN+K+7v5iekFJPM8GJiEiUlXnN3cz+DvwVaAs8YGZ/TFdQqaZ73EVEJMoS\ndag7CjjM3YcBPYCz0hNSeugedxERiapEyX2tu28AcPcVQHZ6QhIREZEtkSi5F5bzWERERGqgRB3q\n9jCzx8p67O4DUxdW6qgznYiIRF2i5P6XEo+npjKQdFFnOhERiboyk7u7P5rOQCqrMkPPqjOdiIhE\nWTLDz9ZoGnpWRESkuIxP7qChZ0VEROIlldzNrKWZ7R/+HYkTAhERkagqN1Gb2QDgPeCRcNGdZnZO\nKoNKlVhPeRERkShLphZ+GbAPkBc+Hgacm7KIKiDWmS5Z6ikvIiK1QTLJfYW7r4k9cPffgHWpCyl5\nlelMp57yIiISdcnM577YzM4AGplZF+BUNtXiq50604mIiBSXTM39fOAAoDHwINAIGJTKoERERKTy\nyq25u/ty4KI0xCIiIiJVoNzkbmY/UMqkMe7ePiURiYiIyBZJ5pr7IXF/1wcOJ2iaT4qZ3QJ0BTYC\nQ939o1K2GQl0dfeeye63ojRhjIiI1BbJNMt/X2LRN2b2GnBrec81sx5AR3fvbma7AQ8B3Utssztw\nKCnuga/b4EREpLZIplm+V4lF2wM7J7n/w4EJAO4+x8yamdk27r46bpuxwNXA35PcZ6XpNjgREakN\nkmmWHx73dyGwkqAHfTLaAPHN8IvDZXMBwlvs3gRKtg5UKTXJi4hIbZJMcr/c3T+uouNlxf4ws+bA\nWQS1++3j11U1NcmLiEhtkkxyHwOUbJpP1k8ENfWYtsDC8O9eQCvgHaAhsJOZjXX3yxPtMCencdHf\n2dlZmy2L9/inL/DeDx+zPH8FOVu14LxuAyr5MmqXsspTqpbKOfVUxqmnMq6Zkknu883sLYLJY4o6\nvbn7tUk893WCa+kPhKPbLXD3X8PnvwC8AGBmOwAPl5fYAfLyVhX9XVBQuNmyeNO/n8ny/BU0a9CU\nvVt1KnMW+VPrAAAfh0lEQVQ72SQnp7HKKQ1UzqmnMk49lXF6VOYEKpnk/l34r8LcfYaZzTSz6UAB\ncGF4nX25u79YmX1WVLMGTRnR/ap0HEpERKRGKDO5m9kf3f1Jd79uSw7g7leXWDSrlG2+p/JN/yIi\nIhIn0djyGTlnu4iISG2XzMQxIiIikkESXXPvbmbzS1meBRRqbHkREZGaKVFy/wT4Q7oCERERkaqR\nKLmvLWVceREREanhEl1z/yBtUVTCc9PmsmTl2uoOQ0REpMYpM7m7+1/SGUhFfThnEQAH7JZbzZGI\niIjULBndW75lk4b079WxusMQERGpUTI6uScSmwlORESktolsctdMcCIiUltFMrnHz9/er2Pf6g5H\nREQkrSKX3MfNnczU+W8DqrWLiEjtFLnkHmuOP7x9D9XaRUSkVopccgfUHC8iIrVaJJO7iIhIbabk\nLiIiEjFK7iIiIhGj5C4iIhIxSu4iIiIRo+QuIiISMUruIiIiEROp5K7JYkRERDI0uT83bS5LVq7d\nbLkmixEREcnQ5P7hnEUAHLBb7mbrNDqdiIjUdhmZ3AFaNmlI/14dqzsMERGRGidjk7uIiIiUTsld\nREQkYpTcRUREIiYyyV23wYmIiAQik9x1G5yIiEggMskddBuciIgIRCy5i4iISESSu663i4iIbBKJ\n5K7r7SIiIptEIrmDrreLiIjERCa5i4iISCDjkntZM8KJiIhIIOOSe6IZ4URERCQDkztoRjgREZFE\nMjK5i4iISNmU3EVERCIm45O7BrAREREpLuOTuwawERERKS7jkztoABsREZF4kUjuIiIisomSu4iI\nSMQouYuIiESMkruIiEjEKLmLiIhEjJK7iIhIxNRN9QHM7BagK7ARGOruH8Wt6wncBGwA3N0HpToe\nERGRqEtpzd3MegAd3b07MAi4o8Qm9wL93P1QoImZHZ3KeERERGqDVDfLHw5MAHD3OUAzM9smbv1+\n7r4w/DsPaJnieERERCIv1cm9DUHSjlkcLgPA3VcDmNm2wJHAyymOR0REJPJSfs29hKySC8wsF5gI\nXODuCWeAeWjSlyxZuZbc5o3IyWkMQHadYJexx7LlVJbpoXJOPZVx6qmMa6ZUJ/efiKupA22BWDM8\nZtaYoLZ+lbtPLW9n0z9bAECXXXLIy1sFQMHGQoCix7JlcnIaqyzTQOWceirj1FMZp0dlTqBS3Sz/\nOvB7ADPrAixw91/j1t8C3OLuU5LdYcsmDenfq2PVRikiIhIhKa25u/sMM5tpZtOBAuBCMzsDWE6Q\n+P8E7Gxmg4FC4Cl3fzCVMYmIiERdyq+5u/vVJRbNivu7UaqPLyIiUttohDoREZGIUXIXERGJGCV3\nERGRiFFyFxERiZh0D2JTZcbNncwni2axPH8FzRo0re5wREREaoyMrbnHJ/bOuXtVdzgiIiI1RsbW\n3AGaNWjKiO5XVXcYIiIiNUrG1txFRESkdEruIiIiEaPkLiIiEjFK7iIiIhGj5C4iIhIxSu4iIiIR\no+QuIiISMUruIiIiEaPkLiIiEjFK7iIiIhGj5C4iIhIxSu4iIiIRo+QuIiISMRk9K5yISFTddddt\nuH/F0qVL+O2339huu+1p0qQJN9wwutznvvLKZLbZZhsOPfR3pa6/885bOOWUAbRps22l43vvvXf5\n7LMPOe+8SwGYMuVVbrzx70yc+BpNmjQF4KabrqNnz8Pp1u2QouedcsrxPP74c3z11ZcMH34lO+20\nM4WFheTn53PQQd0455zzAFi+fDm33XYzP/wwnzp1smjfvgOXXjqMJk2aAPDVV19yzz13sn79Otav\n38DBBx/KWWcNrvDr+OKLz7nzzlupV68ee++9L+eeO4SNGzdy88038cMP89mwYQMnnfR7jjrqmGLP\nKyws5N577+KllyYyefIUAFasWM411/yFDRs2cM0119Gu3XYUFBRw2WUXM2rULTRs2JAXXniOgoIC\n+vcfUPFCrwAldxGRGuiii4YCQaL+7rtvGTLk0qSf26dP34TrL774si2Kbf369dxzz52MG/dvVq1a\nD8Abb7zGdtttz5tvTuWEE/oleHZW0V+dO+/HiBH/KHp86aVD+PzzT9l7730ZMeJajjqqD7179wHg\nrbemcvXVw7jrrvtZs+ZXrr9+OCNHjqVDhx0pKCjg2muvZPLkCfTte2KFXsuYMf/g+utvon37Dowa\ndQNffDGLlStXsHbtWu66637y8/M59dQTN0vuTzzxCNtuW/zkaNq0Nzj++JPIzW3DpEkTOP/8i5g0\naTy9ex9Nw4YNATj55P6cd95Z9Op1JK1atapQrBWh5C4ikkE++WQmTz/9BGvX/sZFFw3l448/4q23\nplFYWEi3bgdz5pmDeOih+2natBk77bQzL7zwHFlZWcyfP4+ePY/gzDMHcfHF53HZZX/hzTffYPXq\nVcyf/z0LF/7EJZdczkEHdeOJJx5h6tTXadu2HRs2bGDAgNPZd98uRTG8+eYb7L//ATRs2JBVq9az\ncuVK5syZzZVXXsuTTz5aTnIv22677c6PP/5As2bNWL16VVFiB/jd7w5n/PgXcJ/DV199SY8ePenQ\nYUcAsrOzueaa64sSaMxjjz3Ehx++T1ZWFoWFhWRlZXH55Veyww4dirZZunQJ7dsHjw84oCsffvge\nBx3UjdWrV1FYWMiaNWvYeuutN4v197//A40aNeLBB+8rWrZq1Up22KEDLVu2ZNWqlaxZs4Z33nmb\nsWPvKPbc4447kfHjn2fw4AsqVU7JUHIXESnHc9Pm8uGcRVW6zwN2y6V/r46Veu53333L00+Po27d\nunzyyUzuuedfZGVlccopJ9C//2kAZGUFNeQ5c2bz1FMvUFBQwCmnHM+ZZw4qtq+8vDzGjLmD99+f\nwYsvjmP33fdk3LjnefbZCaxevYo//OEkBgw4vdhzZs78kIMP7lH0+M0336B79x4cdFA3Ro++kcWL\nFydVKy0sLCz6e82aNXzwwQyOPPJovv9+Hrvssutm23fsuAvffz+P+fPnsccenYqta9So0WbbDxx4\nNgMHnp0whm23bctnn33KPvvsy4cfvk/dunXZY49O5Oa25pRTjmfNmjVcddXwzZ5X2vFat27Djz/+\nQH7+Wtq0acuTTz5K//4DuP32saxdu5YzzjiHNm3asM8+nXnppYkJ49pS6lAnIpJhOnbchbp1g7pZ\ngwYNuPDCwVx88XmsXLmclStXFtt21113o379+qUmI4C9994XgJycXH79dTULFvxAx467UK9ePZo3\nb7FZEgVYvHgxubm5RY+nTHmVI47oTZ06dTjssF5Mm/Z6gugLCc87+PTTj7nkkvO58MLBDBhwEv37\nn0bHjruQlZVFQcHGUp+bnZ1NVlYWGzeWtr7irrxyOA89dD+XXXYxTZo0obCwkM8++5S8vEU8//xE\nHnvsGe655042bNhQ7r569OjJ+++/y/jx/+bAA7vy008LWLlyBbvssiunn34mjz32LwByc3PJy6va\nk8WSVHMXESlH/14dK13LToW6desB8PPPP/PMM0/x6KNP0aBBQwYOPHWzbbOzsxPuK379ppp0Vukb\nFxNsk5e3iNmzv+Suu24FID8/n222aUz//qfRrFkzVq1aXexZBQUFNGgQNJ/HX3M///yz2XnnoIzb\nt+/AQw/dv9kRv/nma4499nhWr17F7NlfFGu2X7FiOb/9tpY2bdoULUumWX7HHXfi9tvvBuDFF8ex\nevUqvvjiM/bb7wCysrJo1SqHJk2akpe3iG23bZuwRBo1asSNN94MwKhRN3LOOecxbdoUOnXam9zc\n1ixc+FP5xVpFMrLmPm7uZJauXVbdYYiIVKsVK5bTokULGjRoiPscfvnlZ9avX7dF+2zTZlu+++5/\nFBQUsGzZMubM+WqzbVq1akVe3i9AUGs/+eT+PPzwUzz88FM89dQLrFy5kp9+WsB++x3IG2+8RkFB\nQdG2e+21T6nHveiioYwdOwqA9u13oFWrHCZOHF+0/q23ppKdnc1OO3Wkd+8+zJgxnTlzZgNBB7+b\nbx7JzJkfFNvnwIFnc+ed93HHHfcW/R+f2AFGjryeb7+dS0FBAa+99jLdux/Kdtttz+zZXwDw66+r\nWbw4j5Yty7rMULjZkm++cbbeemu22257WrRowc8/L2TRol/IyQlaO/Ly8or+TpWMrLl/smgWAJ1z\n96rmSEREqs8uu+xKw4aNGDJkEHvvvS8nnNCPW24ZVdTUXpbY9fjY//GaN2/BEUf0ZvDgM+jQYUf2\n2KMTdeoUrwd26bI/n332Kf36HcfUqVO45prriq3v0+dYpk59ndNPP4t58/7HhRcOpn79+rRo0ZLL\nLvu/UmPq1Glv2rXbjkmTJnDccSdy3XUjufXW0UyY8ALZ2XVo23Y7rr32BiCoIY8ZcwejR9/IunXr\nqFOnDr179+HYY49Puuxi+vY9gRtv/DtZWVn07n00O+64Ex067MgHH7zHkCGDKCzcyJAhl1K/fn3e\nf38GCxf+xIknnsxtt93Mt9/O5ddff+WSS87nkEN6FPV3eOKJRxg27GoAevToxV//egUTJ45n6NAr\ngOByRJcu+1c41orIiu/QUNOdc8PrhQUFhTTc9z8AjOh+VTVHFD05OY3Jy1tV3WFEnso59VTGlffK\nK5M58sijyc7OZuDAU7n11n/SqlVO0fp169Zx7rln8sILzxfdCifJO//8sxkx4h9J195zchonc52k\nmIxslhcRkdRZsmQx5557BhdccA5HHXVMscQOUL9+fS644GLGjBlTTRFmrnHjnqdXryNS3iyvmrsU\no9pOeqicU09lnHoq4/SoFTX3dTlfqDOdiIhIAhmX3AuaLADUmU5ERKQsGZfcAVo0bE6/jonHThYR\nEamtMjK5i4iISNky8j53EZGo25IpX2N+/nkhK1aswGw3brttDKeddjq5ua0rHdP06e8wc+YHXHLJ\n5QBMmDCBa665hkmTprDNNtsAMGLEcI466lgOPLBr0fP69TuWZ5+dwGeffcJ1113DjjvuVDTNa7du\nBxdN1bps2VJuu+1mFixYQFYWdOiwE5deOqxo319++QX33nsnGzasZ9269Rx66GGbjZWfjM8++5S7\n776devXq0bnzfkXTzD7zzBNMnRpM39q37wmbTYDzn/+8yVNPPUa9evVo2bIVw4dfz6pVqxg+/C9s\n3LiRa665rmiyncsvv5jRo2+jQYMGPPfc02RnZ3Pyyf0rHGtlKbmLiNRAWzLla8xHH73Phg0FmO3G\n0KHDtiie/Px87r//bu6//5GiZS+99BLt2m3HW29NpW/fE5Laz377HcDf/34jABs3buSSS87nwAO7\nseeenbjuumvo2/cEjjjiKACmTp3C1VcP44477uXXX1dzww3XMmrUrbRvvwMbNmxg+PC/8Mork8ud\n4raksWNHMnLkWNq1246bbrqOOXNms/XW2zBlyms8+OBjrF+/ngED+nHUUccUm2lu3Ljnuf32e2jY\nsCEjRlzLO++8xZIli+nXrz/NmjXjpZcmMnjwBbz44gv06dOXBg0aANC//wAGDz6DXr2OoHnzFhWK\ntbKU3EVEMsw999zJl1/OYuPGjZxyyh/o2fMIZsyYzkMP3U+DBg1o1SqHCy+8lEce+Rf169endevW\nPP74I1x55XBee+1l1q79je+/n8fChT8xdOgVHHDAQTz22EO8+eYbtGu3HevWreP0088qNlTstGlT\nOOigrkUJa/ny5Xz11VcMG3Y1zz33dNLJPV6dOnXYbbc9+PHH+TRq1Ij8/PyixA5w+OFHMn7888yd\n+w2fffYJPXseQfv2OwBQt25drr32hs2meX3kkQeZOfPDYuPJX3HF1Wy/ffuibZYvX067dtsBcMAB\nB/HBB+8xcODZ/POfD5CVlUX9+vWpX78+a9b8Wmz/sTHoN2zYwLJly8jJyWXevO/YZRejWbPmrFq1\nkl9/Xc2MGdMZM6b4NK99+57A+PH/5uyzz61wOVWGkruISDnGzZ1cNOx1Vemcu1elOgZ//PFHLFu2\nlLvuup/8/HwGDTqdQw45jHHjnmPo0CvYc89O/Oc/06hXrz5HHXUMubmt6dbtEJ544tGifSxevJgx\nY+7g3Xf/y8SJ49llF2PixPE888x4li9fzoAB/Tj99LOKHXfmzA/p2fOIosfTpk3hiCOOoGvX7owe\nfSPLli2tcK10zZpf+eijDzjmmOOYP38eu+5qm23TseOuRdO8xs8pD6VPu3rmmYPKbapv3bo1X3wx\niz337MSHH77PVlsF87XHEvmMGf8lN7cNLVq03Oy5kye/yEMP3U/PnofTqdPefP/9PH788QdWrVpJ\nmzZtefzxRzj11D9y221jyM/P56yzBpGb25p99unMmDEj05bc1aFORCSDfPHF58ya9RmXXHI+w4Zd\nQmEhLF26hF69jmTUqBE8+eSjmO1Bs2bNij0vfsCyffbpDGya5vXHH+ezyy67UrduXVq1asXuu++x\n2XEXL87bbJrXY489luzsbHr06Mm0aVMSxh0bx37mzA+55JLzGTJkEAMGnMyAAX9ip512TjjNa926\nVT3N67U88MDdDBt2Kc2aNSd+8pfPP/+U++67m+HDry/1uX37nsDzz09k8eI83nzzDXr2PJzp099h\n4sQJdOmyP3l5v7BkyWJ2330PTjvtdB5//BEgPdO8xlPNXUSkHP069q0xt9/WrVuP44/vx4ABfyq2\nvE+fvnTtejBvv/0mf/nL0KKpR0uzpdO8/vzzQtzncOONN7JhQwFr165l7tyvOfnkU8Pm6c1HrYvN\nPx+75l5YWMh5553FzjvvAgTTvMYSYbxvvvmak046hSVLljB79hccfnjvonXLly8nP38trVtvmuY1\nmWb5nXfuyO233wME19HXrcsHwH0OY8eOYsyY22nVqvgscPn5+Xz22ScceGBXsrOzOeSQw/j888/o\n2fMIbropKOuRI6/nnHPO57XXXqZLl/3DaV4XJFGuVS+jau6Llv1W3SGIiFSrPffsxPTpb1NYWMja\ntWu5/faxQJDU6tevxwkn9OOww3rx/ffzqFOnTtF0q4m0adOW7777lo0bN7J06RK+/nrOZtu0apVT\nVPOcMuVV+vcfwIQJE3j44ad4+ulxLFmymF9++Tmc5vXVolr2q6++ROfOXTbbX1ZWFhdeeCljxwbz\nue+44040adKUl16aWLTN1KlTaNSoETvs0IGjjz6Gd975D+5BbOvWrWP06Bv55JOZxfZ75pmDNpvm\nNT6xA9xww9+KprV9/fVX6N79EAoKChg16gZuuunmUsd9z87O5h//GMGyZUsBmD37y6Lr/wBz5sym\nadNmtG3bjubNq2ea13gZV3OvXy+7/I1ERCJqn306s9de+3DeecE18d///lQgaGK/5JILaNy4MU2b\nNuNPfzqTunXr8o9/jKBp02YJp3lt1aoVhx3WK5zmtUM4zWvx39pgmtdP6N79EKZOncL1148stv7o\no4NpXk87bSDz5n3HkCGDqF+/Pq1a5RRNdVraa8nNzeXllydxzDHHccMN/+CWW0bzwgvPUadOHbbf\nvn1R8/hWW23NmDG3M3r0Taxfv546depw9NHHcvTRx1a4DI877kRGjBhOVlawj/btOzBjxnQWLfqZ\nUaNuKKrxX3TRUJYsWczixYs57rgTueKKq/i///tz+LpaMWTIJUX7fPLJx7jyymsA6NnzcP761/9j\n/Ph/F01xm45pXuNl3MQx9fZ6C9CkMamiiSDSQ+Wceirjinnllcn07t2HrKwsBg78A3feeW+xDnL5\n+fmcd95Z3H//I9SvXx9QGVfEueeeyciRY2jZslX5G5dQKyaOERGRqpeXt4jBgwcyZMggjjnmuM16\nvjdo0IBzzx3Cfff9s5oizFzPP/8MRx3Vp1KJvbIyrlleRESq3sCBZzNw4NkJt+ne/RC6dz8kTRFF\nxymn/CHtx8yomvvqDq+xPH9FdYchIiJSo2VUci+s+xvNGjTVdK8iIiIJZFSzfNaGRupIJyIiUo6U\nJ3czuwXoCmwEhrr7R3HrjgBuBDYAr7j7DamOR0REJOpS2ixvZj2Aju7eHRgE3FFik9uBk4BDgN5m\ntlsq4xEREakNUn3N/XBgAoAHwwo1M7NtAMxsR2CJu//k7oXAy+H2IiIisgVSndzbAHlxjxeHy0pb\ntwjYNsXxiIiIRF66e8snGmWn3BF46q5uW4WhiIiIRFOqO9T9xKaaOkBbYGHcuviaertwWZmePP/y\nCg/BJxWXk9O4ukOoFVTOqacyTj2Vcc2U6pr768DvAcysC7DA3X8FcPfvgcZm1t7M6gJ9w+1FRERk\nC6R84hgzuwk4DCgALgS6AMvd/UUzOwQYDRQC/3b3W1MajIiISC2QUbPCiYiISPkyavhZERERKZ+S\nu4iISMQouYuIiERMjZ04RmPSp145ZdwTuImgjN3dB1VPlJktURnHbTMS6OruPdMdXxSU8zneDnga\nqAd87O5DqifKzFdOOV8I/JHg9+Ijd7+seqLMbGbWiWBU11vc/e4S6yqU92pkzV1j0qdeEmV8L9DP\n3Q8FmpjZ0emOMdMlUcaY2e7AoQR3jEgFJVHGY4Gb3b0rUBAme6mgROVsZo2BYcDB7t4D2NPMDqye\nSDOXmW1FUK5vlLFJhfJejUzuaEz6dCizjEP7uXtswKE8oGWa44uC8soYguRzdboDi5BEvxVZBD+E\nk8L1F7v7j9UVaIZL9FleB+QTVALqAo2ApdUSZWZbC/Rh00BvRSqT92pqcteY9KmXqIxx99UAZrYt\ncCTBh0kqJmEZm9kZwJvA92mOK0oSlXEOsBq4zczeCcfckMops5zdPR+4Hvgf8B3wvrvPTXuEGc7d\nN4ZlWZoK572amtxL2qIx6SUpm5WjmeUCE4EL3H1Z+kOKnKIyNrPmwFnALeFyfY6rRlaJv9sBtxIM\npNXZzPpUS1TRE/9ZbkzQ+tQR2BHoamZ7VVdgtUS5vxc1NblX6Zj0UqpEZRz7wr4MXO3uU9McW1Qk\nKuNeQCvgHWAcQeIZm97wIiFRGS8G5rn7PHffCEwF9kxzfFGRqJx3B75192XuvoHgM71fmuOLugrn\nvZqa3DUmfeqVWcahWwh6bE6pjuAiItHn+AV37xR2UDqJoCf35dUXasZKVMYFwP/MbOdw2/0Ar5Yo\nM1+i34t5wO5m1iB8vD/wTdojjJZiNfPK5L0aO/ysxqRPvbLKmOBDsxSYQfAhKwSecvcHqynUjJXo\ncxy3zQ7Aw+7eq3qizGzl/FbsDDxC8Dme5e4XVFugGa6cch4MnA2sB9519yurL9LMFJ40jQV2ICjH\nBQSXRb+rTN6rscldREREKqemNsuLiIhIJSm5i4iIRIySu4iISMQouYuIiESMkruIiEjEKLmLiIhE\nTI2d8lUkasL72R14N1wUG0NgqLt/XsZz/gZku/u1W3Dcw4AXgY/DYzYI/740HOilIvs6Cuji7iPN\nrBuw0N3nmdmtwGPu/skWxPk3giF5/xfGWRf4ATjP3VcleN62wG7u/mZljy0SNUruIum1qJoGq/k8\n/rhm9gxwHnB32U/ZnLu/BrwWPjwLeJZgiNc/V1Gcj8WfyJjZP4C/AokGRelJMASqkrtISMldpAYw\nMwPuIxiZqglwTfzQv2aWDfwL2IWgtv+Ju19sZvWAfwI7A42Bp5McsfG/wG7hvo8FhgO/AmuAc919\nYZhYf0cwnecC4AzgNOAI4AXgFOAAM7sMuBa4ARgJXOLu74X7ngKMAWYTnEg0ArYB/prknAXvAoPD\nfR0MjCKYGnMrYAjBiIo3huuXhGVRmfIQiRRdcxepGdoQJPQjgUuBktOT7gUc6O4Hu/shwKfh5D6X\nEozzfTjQFRhgZp0SHcjMGgLHAW+bWSPgAeCkcB+vAjeYWTOC5NnN3Q8jmNymdbiLQnefAHwKXBbX\nHF4IPEGQ9GOzCu5GMJzxPcAYdz8COAF40MwS/v6EY2ifxqbLGK2A88N93EEwqdE8guFlH3f32ypT\nHiJRpJq7SHrlmtm08O/YNfdTCGbYujkcv7s+0LLE82YDeWY2GZgMPOfuq8ysJ9DOzH4XbteAYOrN\nL0o8f+/wuLFjTnL3f5vZPsDP7h6b4estgmvcy83sVYITgPHAs+6+IGhgKKbk1JPPErQKXA6cDDzv\n7oVhnNuYWWy863wgF/i5xPMHhmNo1wE6A7cR1NYJtx0bnpw0JZj/oKRky0Mk0pTcRdKr1GvuZvY0\n8KS7P2pmewKT4te7+zrgMDPbl6DW/UGYBPOB6919XDnH/by04xIk+pJzoBeGx+xvZrsSzED1lpmd\nXN6Lc/dfzOx/ZnYAcCowNFy1lqB1YFk5uyi65m5mLwLfh9O1AjwODHb3/4SXEkqbRS/Z8hCJNDXL\ni6RXyZpuTC5B7RyCpNggfqWZ7WdmA939U3cfAcwkuP7+33B7zKyOmY0Nm9ST9TWQY2bbhY+PAN4z\nsw5mNtTdv3b3W4DxwD4lnrsRqFfKPp8EzgGau/un4bL/An8I42wV9q4vz4XAdWbWNnycC8wO+x+c\nwqYyio9jS8tDJBKU3EXSq6xpGG8BHjezV4B3gKVmdnPc9nOB35vZf81sKkFHsukEncdWmdm7BNem\nl7n78mSDcfe1BIn4ubDZvhdwDUEHus5m9p6ZvQF0IOhEF28KcJ+ZnVjidY0HBgBPxS27FDjJzN4m\nuKxQbmc6d/8R+Adwf7hoNEGP+BeBh4HtzewSgvI6y8yuA+4CVle2PESiQlO+ioiIRIxq7iIiIhGj\n5C4iIhIxSu4iIiIRo+QuIiISMUruIiIiEaPkLiIiEjFK7iIiIhGj5C4iIhIx/w9xblCgnOBxRAAA\nAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x7f04c6c2d978>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Plot ROC\n",
+    "plt.figure()\n",
+    "for label, metrics in ('Training', metrics_train), ('Testing', metrics_test):\n",
+    "    roc_df = metrics['roc_df']\n",
+    "    plt.plot(roc_df.fpr, roc_df.tpr,\n",
+    "        label='{} (AUROC = {:.1%})'.format(label, metrics['auroc']))\n",
+    "plt.xlim([0.0, 1.0])\n",
+    "plt.ylim([0.0, 1.05])\n",
+    "plt.xlabel('False Positive Rate')\n",
+    "plt.ylabel('True Positive Rate')\n",
+    "plt.title('Predicting TP53 mutation from gene expression (ROC curves)')\n",
+    "plt.legend(loc='lower right');"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## What are the classifier coefficients?\n",
+    "\n",
+    "coef_ is only available when using a linear kernel"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Investigate the predictions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "predict_df = pd.DataFrame.from_items([\n",
+    "    ('sample_id', X.index),\n",
+    "    ('testing', X.index.isin(X_test.index).astype(int)),\n",
+    "    ('status', y),\n",
+    "    ('decision_function', pipeline.decision_function(X)),\n",
+    "    ('probability', pipeline.predict(X)),\n",
+    "])\n",
+    "predict_df['probability_str'] = predict_df['probability'].apply('{:.1%}'.format)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>sample_id</th>\n",
+       "      <th>testing</th>\n",
+       "      <th>status</th>\n",
+       "      <th>decision_function</th>\n",
+       "      <th>probability</th>\n",
+       "      <th>probability_str</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>sample_id</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>TCGA-L5-A4OH-01</th>\n",
+       "      <td>TCGA-L5-A4OH-01</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2.874345</td>\n",
+       "      <td>1</td>\n",
+       "      <td>100.0%</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>TCGA-L5-A8NR-01</th>\n",
+       "      <td>TCGA-L5-A8NR-01</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2.705876</td>\n",
+       "      <td>1</td>\n",
+       "      <td>100.0%</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>TCGA-46-3765-01</th>\n",
+       "      <td>TCGA-46-3765-01</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2.289190</td>\n",
+       "      <td>1</td>\n",
+       "      <td>100.0%</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>TCGA-MT-A51X-01</th>\n",
+       "      <td>TCGA-MT-A51X-01</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2.224622</td>\n",
+       "      <td>1</td>\n",
+       "      <td>100.0%</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>TCGA-49-6743-01</th>\n",
+       "      <td>TCGA-49-6743-01</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2.195391</td>\n",
+       "      <td>1</td>\n",
+       "      <td>100.0%</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>TCGA-55-6981-01</th>\n",
+       "      <td>TCGA-55-6981-01</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2.176503</td>\n",
+       "      <td>1</td>\n",
+       "      <td>100.0%</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>TCGA-86-7955-01</th>\n",
+       "      <td>TCGA-86-7955-01</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2.126591</td>\n",
+       "      <td>1</td>\n",
+       "      <td>100.0%</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>TCGA-E2-A1LI-01</th>\n",
+       "      <td>TCGA-E2-A1LI-01</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2.012024</td>\n",
+       "      <td>1</td>\n",
+       "      <td>100.0%</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>TCGA-80-5611-01</th>\n",
+       "      <td>TCGA-80-5611-01</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1.957443</td>\n",
+       "      <td>1</td>\n",
+       "      <td>100.0%</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>TCGA-EI-6513-01</th>\n",
+       "      <td>TCGA-EI-6513-01</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1.947071</td>\n",
+       "      <td>1</td>\n",
+       "      <td>100.0%</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                       sample_id  testing  status  decision_function  \\\n",
+       "sample_id                                                              \n",
+       "TCGA-L5-A4OH-01  TCGA-L5-A4OH-01        0       0           2.874345   \n",
+       "TCGA-L5-A8NR-01  TCGA-L5-A8NR-01        0       0           2.705876   \n",
+       "TCGA-46-3765-01  TCGA-46-3765-01        0       0           2.289190   \n",
+       "TCGA-MT-A51X-01  TCGA-MT-A51X-01        1       0           2.224622   \n",
+       "TCGA-49-6743-01  TCGA-49-6743-01        1       0           2.195391   \n",
+       "TCGA-55-6981-01  TCGA-55-6981-01        0       0           2.176503   \n",
+       "TCGA-86-7955-01  TCGA-86-7955-01        0       0           2.126591   \n",
+       "TCGA-E2-A1LI-01  TCGA-E2-A1LI-01        1       0           2.012024   \n",
+       "TCGA-80-5611-01  TCGA-80-5611-01        0       0           1.957443   \n",
+       "TCGA-EI-6513-01  TCGA-EI-6513-01        0       0           1.947071   \n",
+       "\n",
+       "                 probability probability_str  \n",
+       "sample_id                                     \n",
+       "TCGA-L5-A4OH-01            1          100.0%  \n",
+       "TCGA-L5-A8NR-01            1          100.0%  \n",
+       "TCGA-46-3765-01            1          100.0%  \n",
+       "TCGA-MT-A51X-01            1          100.0%  \n",
+       "TCGA-49-6743-01            1          100.0%  \n",
+       "TCGA-55-6981-01            1          100.0%  \n",
+       "TCGA-86-7955-01            1          100.0%  \n",
+       "TCGA-E2-A1LI-01            1          100.0%  \n",
+       "TCGA-80-5611-01            1          100.0%  \n",
+       "TCGA-EI-6513-01            1          100.0%  "
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Top predictions amongst negatives (potential hidden responders)\n",
+    "predict_df.sort_values('decision_function', ascending=False).query(\"status == 0\").head(10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAeQAAAFmCAYAAAC81ukqAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAIABJREFUeJzs3Xd4W+XdxvHv0bA8ZGc6y9lATgKhQMIIEEIgzJbZsvfe\npWVDKaPsTdmz0AWlUCi8jDBLCCMBAgHCOmFkTydx4iXJGuf9Q5adacu27KMj3Z/r8uUhWfo9ke07\nz3OeYdi2jYiIiDjL43QBIiIiokAWERHJCgpkERGRLKBAFhERyQIKZBERkSygQBYREckCvnTuZJrm\nbcB4wAvcYlnWf9e6bS/gRiAGTLYs64bOKFRERCSXtdpDNk1zIrClZVm7APsDf17vLvcAh5IM7H1M\n0xyZ6SJFRERyXTpD1u8Bhzd+vBooNk3TADBNcxiw0rKsxZZl2cBrwKROqVRERCSHtTpk3Ri0ocZP\nTwNea/waQD+gcq27LweGZ7RCERGRPJDWNWQA0zQPBk4G9mnhbkaHKxIREclD6U7q2he4AtjXsqya\ntW5aDPRf6/OKxq9tkm3btmEot0VEJK+0GnxGa4dLmKZZBrwPTLIsa8VGbp8F/IpkEH8EHGNZ1o8t\nPKRdWVnTws3uVl5eitrnXrncvlxuG6h9bpcH7Ws1kNPpIR8J9AKebZzMZQP/A2ZZlvUScDbwTOPX\n/9VKGIuIiMhGpDOp6zHgsRZu/wDYJZNFiYiI5Bvt1CUiIpIFFMgiIiJZQIEsIiKSBRTIIiIiWUCB\nLCIikgUUyCIiklWWLl3C7rvvxM8/N6+inTz5FSZPfqXDj11fX8enn04H4J///CvffPN1hx8zUxTI\nIiKSdYYOHcbDD9+f8cf9/vvv+OSTjwE47riT2Gqr0Rl/jvZKey9rERGRrmKao4hEwnz++QzGjNm+\n6esvvPAcb731Ol6vl912250jjzyWysrlXHXV5fj9frbZZju+/HIm9933CM8880+mTPkftm2z8867\nctJJp3H33bdRX1/P4MFDmDXrSyZOnMTjjz/MLbfcSZ8+fVm6dClXXnkJjz/+d2699QaWLFlMLBbj\n1FPPZMyY7Zk8+RVeeOE5CgoK2HzzLbjggksz1mYFsoiIbFTJtX8k8PKLGX3MyIGHUHftDWnd94wz\nzuX666/m4YefAMC2baZMeYeHHvoLAGeffQp77LEXzz77L/bcc2+OOOJoHnzwXlLnJRiGwUMP/QXD\nMDj88IM54ohjOOaYE5gz5ycOPPAQZs36EsOA3Xffgw8/fJ9DDz2MDz6YwsSJk3jzzcn07l3O5Zdf\nxZo1qzn//LP529/+xTPPPMUdd9xDeXkfJk9+hYaGBgoKCjLyb6NAFhGRrFRRMRDTHMk777wJQFXV\nKhYuXMD555+FbduEQmGWLFnCvHlz2Guv5EGE48dP4PvvvwUgEAhw7rmn4/V6qa5eTXV19UafZ8KE\nPXjggT9z6KGH8f77U7nkkit45pmnmDXrC7766gts2yYabSAWi7H33vtyxRUXs88++7P33vtmLIxB\ngSwiIptQd+0NafdmO8tJJ53GhReex29+cwR+v59ddhnPxRdfsc59/vEPG8NITolK9Y6XLl3KM888\nzd/+9jSBQCEnnHDkJp9j2LDhrFixguXLl1FXV8vAgYPw+/2ccMIpTJq07onDxx13Evvssz/vvvs2\n559/Fg888DhlZWUZaasmdYmISNbq0aMnu+02kRdffIH6+no+/3wGkUgY27a55547aWhooKJiYFOv\nePr0jwBYs2Y1PXv2JBAoxLK+Z9mypUSjDRiGQTwe3+B5dt55Vx599EHGj58AwJZbbsXUqVOAZM/8\nkUcewLZtHn30QXr27MWRRx7L6NG/YNmyJRlrqwJZRESy2tFHH09l5TL69u3HEUcczbnnnsFZZ51C\nr169KCgo4PDDj+all57nggvOBcDj8TBihElhYRHnnHMa7777Ngcf/GvuuutWTHMU77zzFs888891\nnmP33ffg7bffYI899gJgzz33pri4hLPPPoXLL7+Ibbcdg2EYFBcXc9ZZp/D735+DYRhssYWZsXa2\neh5yJ9B5yC6m9rlXLrcN1D6360j75sz5mbq6WkaP/gVvv/0GM2d+xiWX/CHDFXZMps5DFhERyVrF\nxcXcfvtNGIaBx+PhD3+4xumS2kWBLCIirta3bz8efPBxp8voMF1DFhERyQIKZBHJCQ3xBv43/y0c\nmBcjkhEKZBHJCfdMv4ejXvkNHy3+wOlSRNpFgSwiOWHKvCkALKtf6mwhIu2kQBYR10vYCaYtmAZA\nbUOtw9VIRy1duoR99tmd888/i/POS645Tm3SkY5Vq1Zyxx03A/DllzNZvXo1AFdccXFnlJsxmmUt\nIq73Y9UPVIWrAKiL1jlcjWTCkCFDuPfehwGorq7mlFOOZdy4XdLaO7pnz15N22u++ur/cdRRx9G9\ne3duvvmOTq25oxTIIuJ6ny79uOnj2mjubp6Rr8rKyujVqzffffctf/vb40SjUTweL1dccRW9e5dz\n/fVXsXLlSqLRKKeeeiaDBw/hj3+8jDPPPJepU6cwZ87P3HDDrZx66nHcc8/D3Hvvndxzz0MAPPnk\nY5SVlTF27I7cffdtjbtxlXDlldcQCBRu8Ng77jiu09qpQBYR11s7kNVDzpxrP/ojL/+U2eMXD9zs\nEK7dpfUDK9aeLL9kyWLWrFnD5Mkvc8ABh7DnnnsxZco7/OUvj3D44UexevUa7r//Uerqapk27UMA\nDAN22GEntthiBBdddDl9+/YDDDbbbHNWrlxBXV0tJSVBPvhgKrfeejfXX381l156JRUVA/nvf//D\n888/y7hxu2z0sTuLAllEXO+TpdObPtY15Nwwf/48zj//LBKJBIFAIVdddR233XYjZ555HgBjxmzP\nX//6F4YMGUYoVM8NN1zDbrtNZK+99mXp0nUPfFh/Kdwuu4xn+vRpjB69NYFAgN69e/Pdd99w6603\nYNs2sViUUaO2YsiQoRs8dmdSIIuIq60MreTH1T8wqvcovlvxnYasM+jaXW5IqzfbGda+hpzi8RhA\nMlyTw9YGgUCARx/9K7Nmfclrr73CRx+9z8knn97iY0+YsCcvvPAsq1dXMXHingAUFRVu8HzABo99\nxRVXZ6aBG6FZ1iLiap8t+wSAfTZLnltbryHrnLCx/V1GjtyKzz77FICZMz/DNLfkhx8s3nxzMltv\nvQ0XXXQZ8+bNXed7PB7PWsctJh909OitmTv3Z6ZP/5CJEycBsNlmI5qObnznnTf5/PMZzJ79fYuP\nnWnqIYuIq326tDmQ7/n4HmqjGrLOBcZGzkY69dQzueWW63j55Rfx+/1cfvnVBAIBHn74AV566QW8\nXi/HHHPCOt+z7bZj+OMfL2ucYd38oKNH/4IffphNnz59Afjd7y7itttu5Kmn/kYgEOCaa24E4JFH\nHmx67KOPPr7T2gs6fjHjdESau+Vy+3K1bYe8+EumLf6Qqsuq6HdHP0b12pI3DpvidFkZl6uvX0oe\ntK/V4xc1ZC0irhVLxJi5/DNG9tySboXdCBYENalLXEuBLCKutTqymlAsxPDumwFQ7A9q2ZO4lgJZ\nRFwrHAsBUOQrAiDoD+oasriWAllEXCu00UCu0RGM4koKZBFxrfV7yCX+EhJ2gnA87GRZIu2iQBYR\n1wrFksFb6G3sIReUAtqtS9xJgSwirhWOJ3vIhb5CINlDBqjTdWRxIQWyiLhW8zXkYiB5DRnQxC5x\nJQWyiLhW6hpycw85Gcha+iRupEAWEdfa2CxrgDodMCEupEAWEdcKbdBDTl5D1qQucSMFsoi4Vrhx\nlnXTNeTGWdYashY3UiCLiGs1XUP2rnsNWWciixspkEXEtVLLntbeGATUQxZ3UiCLiGvVbzCpSxuD\niHspkEXEtVLXkAvX7yHHFMjiPgpkEXGt9dchBwsaryGrhywupEAWEddqXvaU6iFrpy5xLwWyiLhW\nqodcvMHGIApkcR8Fsoi4Vii+7mlPAW8Ar+HVkLW4kgJZRFwrHAvhNbz4vX4ADMMgWFCqZU/iSgpk\nEXGtUCzUtEtXStAf1JC1uJICWURcKxwLNc2wTinxlyiQxZUUyCLiWuFYuGlTkJSgP6hZ1uJKCmQR\nca1QrL5pH+uUEn+QSDxCNB51qCqR9lEgi4hrhWJhivzrXkMuKdDSJ3EnBbKIuJJt24TjoQ17yL7G\nM5EVyOIyCmQRcaVoIkrCTjTt0pWiM5HFrRTIIuJKoVg90LxLV0pQZyKLSymQRcSVmk962nDZE6iH\nLO6jQBYRV1r/YIkUnfgkbqVAFhFXagrkjSx7Ag1Zi/sokEXElVInPW1s60zQkLW4jwJZRFwp3HjS\nU9EmriFr2ZO4jQJZRFxpk9eQ/allTwpkcRcFsoi4UqhpyHrdQG6aZa1JXeIyCmQRcaVwK7OsdQ1Z\n3EaBLCKu1LQOeb1Z1qkha82yFrdRIIuIK6V26trUkLXWIYvb+NK5k2mao4EXgbssy3pwvdvmAPOB\nBGADx1qWtSTThYqIrC3UNMt63UAuTl1DjmnIWtyl1UA2TbMYuBd4exN3sYH9LMsKZbIwEZGWbOoa\nssfwUOwrUQ9ZXCedIeswsD+wqV6v0fgmItJlNrWXNSQndmnZk7hNq4FsWVbCsqxIK3d72DTN903T\nvClDdYmItKj5GnLxBreV+Eu0MYi4TiYmdV0FXAjsDmxtmuavM/CYIiItSvWQ19+pK/m14qbbRdwi\nrUldLbEs65+pj03TfA3YGnihpe8pLy/t6NNmNbXP3XK5fbnUNtsXA6CiTznl3ZLtSrWvtLCEUFV9\nTrUXcuv125hcb19r2hrI61wrNk2zDHgWONCyrCjJXvJzrT1IZWXurg8sLy9V+1wsl9uXa22rqq0G\noG5NnMqGmnXa5ydANBFl6bLVeD1eJ8vMmFx7/daXD+1rTTqzrMcAdwJDgKhpmr8B/g+YY1nWS6Zp\nvgpMN02zHphpWdbzHStbRKR14fjGt86E5s1CQvEQQU+wS+sSaa9WA9myrM+BPVq4/T7gvkwWJSLS\nmpZmWaeWQoVj4abjGEWynXbqEhFXCsdCBLwBPMaGf8ZSIZ2aiS3iBgpkEXGlUCy00eFqaF4KpZnW\n4iYKZBFxpVAstMEuXSmppVCp3bxE3ECBLCKuFI6HNzjpKaXQmwzqegWyuIgCWURcqcUha39qUpcC\nWdxDgSwirhRuIZBTPeRwXNeQxT0UyCLiOgk7QSQe2eQ15EJdQxYXUiCLiOu0tAYZmjcLCSmQxUUU\nyCLiOqmg3dhJT8mvK5DFfRTIIuI6qaHoTc6yXmunLhG3UCCLiOu0tI81NAe1riGLmyiQRcR1UuuL\ndQ1ZcokCWURcJ5zuNeS4AlncQ4EsIq7T2ixrXUMWN1Igi4jrNE3q0jpkySEKZBFxndS14eJWTnvS\nNWRxEwWyiLhOqGnZk057ktyhQBYR10ntUb3Ja8je1KQuXUMW91Agi4jrhGL1wKavIfu9fryGl1C0\nvivLEukQBbKIuE5q9vSmNgZJ3las057EVRTIIuI6zeuQNx3Ihb5CXUMWV1Egi4jrhFLrkDexlzUk\nw1rrkMVNFMgi4jqpa8hF/o3v1AXJQE7dT8QNFMgi4jpNs6xb6CEX+oqaetIibqBAFhHXSesasreQ\ncDyEbdtdVZZIhyiQRcR1WtvLOnlbEQk7QTQR7aqyRDpEgSwirpMasg60MGRd3HQEo64jizsokEXE\ndSLxCAABb2CT92k+YELXkcUdFMgi4jqRWJiAN4BhGJu8T2FTD1lrkcUdFMgi4jrheKTF4WponvCl\n3brELRTIIuI6kXi4xeFqWOuACe1nLS6hQBYR14nEIi3OsIa1jmBUD1lcQoEsIq4Tjodb3BQEdA1Z\n3EeBLCKuE4lHCLTaQ1Ygi7sokEXEdVKzrFuS6iHrxCdxCwWyiLhKwk7QkGhofcjaq3XI4i4KZBFx\nlaZNQXwt95Cblz2phyzuoEAWEVdJDUGnuw65XkPW4hIKZBFxlVQPuVDXkCXHKJBFxFVS14Rbm2Wt\nvazFbRTIIuIqzQdLtDZkXQyohyzuoUAWEVeJNO681dqQdWqnLq1DFrdQIIuIq4Rj6fWQm/ayViCL\nSyiQRcRVUj3k1pY9Feq0J3EZBbKIuEpTIKd7/KJ6yOISCmQRcZXUkHVRmrOsNWQtbqFAFhFXSbeH\n7DE8BLwB9ZDFNRTIIuIqzcueWr6GDMlh65DWIYtLKJBFxFVSk7QKWxmyTt6niFCsvrNLEskIBbKI\nuEokzWVPkDzxSbOsxS0UyCLiKs2HS6Q3ZK1ryOIWCmQRcZVIG4ask4GsHrK4gwJZRFwl3IZJXYW+\nIsLxMAk70dlliXSYAllEXCXdZU+gE5/EXRTIIuIqqUldha1snQlrnfgU13VkyX4KZBFxlXBbeshe\n9ZDFPRTIIuIq6Z6HDM37WWstsriBAllEXCUSS82yTmdSV2o/a/WQJfspkEXEVVKzrFPnHbek6Rqy\n1iKLCyiQRcRVIvEwHsODz+Nr9b5Ns6y1W5e4gAJZRFwlEgtT6C3EMIxW71uYuoYc1TVkyX4KZBFx\nlUg8ktamIABFXvWQxT0UyCLiKuF4mEAa22ZC8zXkkK4hiwsokEXEVcKxcNo95OZZ1gpkyX4KZBFx\nlUg83LThR2tS15A1y1rcQIEsIq4SjkXaMGSdCmRdQ5bsp0AWEVeJxNMfstZOXeImCmQRcY1YIkbc\njqc9ZB30BwGoi9Z1ZlkiGdH6ynrANM3RwIvAXZZlPbjebXsBNwIxYLJlWTdkvEoREdY+WCK9HnKw\noBSAmoaaTqtJJFNa7SGbplkM3Au8vYm73AMcCowH9jFNc2TmyhMRaZY6ejHda8hBf2MgRxXIkv3S\nGbIOA/sDS9a/wTTNYcBKy7IWW5ZlA68BkzJboohIUqSNPeTSxh5yrXrI4gKtBrJlWQnLsiKbuLkf\nULnW58uB/pkoTERkfakh69RkrdYEvAF8Hp+GrMUV0rqG3Aatby4LlJeXZvhps4va52653D63t22Z\nnfyT1T1YutG2bOxrZYEywna969sO7n/9WpPr7WtNRwN5Mev2iCsav9aiysrc/d9qeXmp2udiudy+\nXGjbksqVACQaPBu0ZVPtC/pKWV2/xvVtz4XXryX50L7WtHXZ0zo9YMuy5gGlpmkONk3TBxwAvNnG\nxxQRSUvTWci+9K4hA5T4g5rUJa7Qag/ZNM0xwJ3AECBqmuZvgP8D5liW9RJwNvAMYAP/sizrx06s\nV0TyWCSWmtSV3ixrSE7sqq2qwbbttI5sFHFKq4FsWdbnwB4t3P4BsEsmixIR2ZjmdcjpB3KwIEjc\njhOKhSj2F3dWaSIdpp26RMQ1Uj3ktgxZl/rLAKiN1nZKTSKZokCW/Gbb+Kd9CNGo05VIGtrTQ25e\ni1zdKTWJZIoCWfJawf/eovvB+1P627PAtp0uR1oRaZzUle7GIAAlBcn9rLUWWbKdAlnymm/m5wAU\nvvAchU886nA10prmIes29JAbt8/UkLVkOwWy5DWv9T0AidIyglddAR995HBF0pJwO3rIOmBC3EKB\nLHnN9/23JIKlVP/1KUgk4PDDMZYvd7os2YRIR64hay2yZDkFsuSvhga8P/1I3BxJdLfdqbvyWli8\nmOIH73W6MtmEtp72BM1nIquHLNlOgSx5y/vzTxixGLGRowAIH31c8utzfnayLGlB0+ES7eghK5Al\n2ymQJW/5vv8WgHhjINu9ekEggGfJIifLkhY0DVm3pYdckFyHXKcha8lyCmTJW97vvwMgZiYDGcOA\ngQPxLlIgZ6umIeu2TOrSkLW4hAJZ8pavMZDjo7Zs/uLAgXgql0NkU0eAi5NSQ9aF7ZrUpWVPkt0U\nyJK3vNZ3JLp3J9Gnb/MXBw0CwLN0iUNVSUvCqcMl2rB1ZtCva8jiDgpkyU/hMN45PxMbuWVyqDql\nMZC9izVsnY3as+wpqJ26xCUUyJKXvD/MxkgkiKeuH6cMHAiAR4GcldqzdWbAGyDgDWhSl2Q9BbLk\nJZ/VOKFr5HqBnBqy1sSurBSOhfF5fPg8rZ4cu46gP6gesmQ9BbLkpaYJXZsIZO/ihV1dkqQhEo+0\nabg6JVhQSm2DJnVJdlMgS17yWusteUppGrJe3NUlSRoi8TCFbRiuTgn6S6nRkLVkOQWy5CXfd9+R\n6F2O3bv3ujf06oVdWKhryFkq3M4ecmlBKbUNNdg6YlOymAJZ8k9dHd75cze8fgxgGMQHVGjIOktF\nYuE2LXlKKS0oxcamLlbXCVWJZIYCWfKOb3byyMWNBjKQGFCBZ8UKCIe7sixJQ3LIuqjN35faratW\nE7skiymQJe+kzkDeYMlTo8SACgA8S3QdOdtE4hEK29FDTu1nrYldks0UyJJ3vD//BEB88y02enu8\nMZC9CuSsYts24Vi4fbOsm/azrs50WSIZo0CWvOOdPxeA+JChG729qYe8SNeRs0k0EcXGbtOmICna\nz1rcQIEsecc7bx6230+i/4CN3p6oaAxkzbTOKqltMwvbcPRiis5EFjdQIEve8c6fR6JiIHi9G709\n3r9xyFqBnFVCsbbvY53SfMCEhqwleymQJb/U1+OpXE588NBN3kU95OzUfLCEhqwlNymQJa94F8wH\nID5kyCbvY3fvgV1crN26skwkljxYoj1D1qkTn7TsSbKZAlnyStOErsGbDmQMg3j/AdocJMuEO9BD\nDvoblz2phyxZTIEsecUzfx4AiZYCGUgMGIhn5UoIhbqiLElDe85CTmk+E1nXkCV7KZAlr3jnJQO5\nxR4ya11H1lrkrJEasm7v1pmgWdaS3RTIkle881OBPLTF+8UHJJdEaaZ19gjHk6MVhe05XMKvSV2S\n/RTIklc88+dhFxdveMrTehIDGo9h1OYgWaMuWg9Aib+kzd8bTM2yVg9ZspgCWfKKd/685HC1YbR4\nv9SQtbbPzB51jb3bksZtMNvC5/FR5CuiVmciSxZTIEveMFZX4ale0+r1Y2jeHMSzSEPW2aIumjw6\nsT095OT3BXUNWbKaAlnyRvP149YDuXlSlwI5W6R6yMF29JAhObFLgSzZTIEsecMzL70lTwB2WTfs\nggI8lcs7uyxJU0eGrAFKC8o0qUuymgJZ8ka6M6wBMAwS5X3wrFjRuUVJ2jo6ZB30B6mL1pKwE5ks\nSyRjFMiSN9LapWstid7leFZUgm13YlWSro4Gcmotcp16yZKlFMiSN5p26WphH+u1JcrLMUIhjDr9\nAc8GHR2yTp34tCayJmM1iWSSAlnyhnf+PBI9emCXlqV1f7t3OQBGZWVnliVpqm1oDOSC9gVyv5L+\nACyq1UQ9yU4KZMkPto13wfz0rh83SjQGsmeFAjkb1MWSQ9bFvuJ2ff/gsuTIyPzquZkqSSSjFMiS\nFzzLl2GEw2nNsE5JlPdJfq96yFmhLlpHsa8Ej9G+P1tDUoFcMy+TZYlkjAJZ8oInzUMl1pZo3F5T\nPeTsUBetbfeELoDBpUMBmF+tQJbspECWvNDWGdawdg9Za5GzQW1DbdMxiu0xsHQQoECW7KVAlrzQ\ntAY5zRnWoGvI2aYuWtfuGdYAhb5C+pX015C1ZC0FsuQF748/ABAfOjzt77HLG2dZa3MQx9m23eEh\na4DBpUNYVLuQaDyaocpEMkeBLHnB9/VXJIKlJIYOS/t7Er0aryFryNpxoVgIG7vjgVw2hISdYFGt\njtWU7KNAltwXCuH9YTbxrUaDpw0/8j4fiZ49NWSdBZp36Wr/kDWstfRJw9aShRTIkvN8332DEY8T\nG711m783Ud5HPeQskDrHuL0nPaUM0UxryWIKZMl5vq9nARDbeps2f2+idzmeqiqI6pqjkzq6j3VK\n8+YgCmTJPgpkyXm+WV8BENv6F23+3qaZ1qtWZrQmaZvMD1nP7WhJIhmnQJac5/v6S2yfj9iIkW3+\n3kRqpvVyDVs7qflgiY71kAeUVODz+JinHrJkIQWy5LZ4HN+33xA3R0Eg0OZvt7UWOStkasja6/FS\nERyoIWvJSgpkyWnen37ECIXaNVwNa+3WpUB2VKqHnDpCsSMGlw2lMrSc+mh9hx9LJJMUyJLTfLO+\nBNp3/RjWuoasAyYclakha4AhpcnryAtq5nf4sUQySYEsOa1pQtfo9gayDpjIBpkasgYdwyjZS4Es\nOa05kNu+Bhl0wES2aO4hd2yWNWhzEMleCmTJXbaN75uviA8dhl1a1q6HSA1ZG+ohO6q2oTGQO3Da\nU8rgxiHrueohS5ZRIEvO8ixehGfVqnYPVwMQDGIXF+PRAROOyuyQ9VAAfqr6ocOPJZJJCmTJWR3Z\nEGRtid7lGrJ2WKY2BgEoLypnVM8t+d+Ct7FWfd/hxxPJFAWy5KyOzrBOSZSXJyd12XYmypJ2yOQs\na8MwuGKnq0nYCW78+E8dfjyRTFEgS87yfzIdaP8M65RE73KMhgaM6jWZKEvaoS6W7CEX+4oz8nj7\nDt2fHfuN4/U5r/LxkukZeUyRjlIgS07yfvsNBe+9S3SHnUj069+hx0poty7H1TbUUuIP4jEy8yfL\nMAyu2vk6AG6Yfg22Rj8kCyiQJScV33c3APW/u7DDj5Va+mRUamKXU+qitRkZrl7bTv3Hsd+wX/Hx\nkmkc+N99eerbv1PTUJ3R5xBpCwWy5BzPvLkEXnye2Kgtadhr3w4/np3aHEQTuxxTF63LeCAD3DT+\nNnYbOJFPl37MBVPOY7u/b8VdM26jtqEm488l0hqf0wWINKmrI/D2G/g/eB/P8mV4VlRi1NYQGzGS\n2JjtiY7Zntj2O4DX2+LDFD90H0Y8Tv1vLwBPx//Pqf2snVcXraO8uE/GH3dg6SCeP+j/WFizgH9b\nT/PYVw9xyyc38NhXD/GnXW/iCPPojD+nyKYokMVxvs8+pejhBwi89TpGffOG/7bXi11YROF338JL\nLwAQHzyU0JlnEzr6eAhuuATGWL6cwqf/QXzwECKH/CYj9ekasrNs2+6UIeu1DSwdxEXbX8YZvzib\nR758kAe+uJfz3jmTDxZN5ebd7ujU5xZJSSuQTdO8CxgHJIDfW5Y1Y63b5gDzG2+zgWMty1rSCbVK\nrqmtpeSuIVsvAAAgAElEQVSW6yl67GEM2yY2bDiRQ35Nw/4HEB88BLt7DzAMPPPm4p/5Gf6pUyh8\n/lmCV15G8W03Ez7qGMJHH098y60AMJYto+Tm6zDCYerPOR98mfn/ZvMBExqydkJ9rB4bm2AG1iC3\nprSgjIt3uJzfjDiCM948mWe+f4rPl83gqV89x5DGDUVEOkurf7FM05wAbG5Z1i6maY4EngB2Wesu\nNrCfZVmhTqpRcpB/+keUnncm3vnziG22ObW3/5norruBYWxw38TQYUSGDiNy6GHUXXktRX99nKIn\nHqP4kQcpfuRBottsBwb4v5gJQLz/AMJHH5exWpuHrDWpywmZ3BQkXcO6DeeVX7/JdR9dxWOzHuaA\nF/bhmQNeYKveo7usBsk/6VxgmwS8CGBZ1vdAd9M01/7NMBrfRNLi//B9uh1xCJ5FC6n/3UVUvfsR\n0fETNhrG67N796b+4stZ+cV3rHnin0T22Q/f11/h+3oWDbvtTu2fbmL1G+9CUVHG6rV79MD2eNRD\ndkgmNwVpi4A3wI273cYNu97CsvqlHPzi/kxfMq1La5D8ks6YXj9gxlqfr2j82o9rfe1h0zSHAe9b\nlvWHDNYnOcb36cd0O/YIiMep/ue/aZi0T/seqKCAhgMOouGAgzBWV4HX2+4DJFrl9SY3B1m+rHMe\nX1qUyX2s2+OMbc6hZ1Evzv/f2Zz42lG8e+RHDAhWOFKL5Lb2TEFdvxtzFXAhsDuwtWmav+5wVZKT\nfF/OpNtRv4FImOrH/tb+MF6P3b1H54Vxo8SAAXgXL9L2mQ5IBXLQX+pYDYeNOJKbxt9OVaSKM986\nhVgi5lgtkrvS6SEvJtkjThkANE3asizrn6mPTdN8DdgaeKGlBywvd+4XqyuofRuxYgUcfyTU1sBT\nT9Ht6OxdTrLR9g0fBl/MpJwwlGd++U1XcePPpm9NHIA+3Xu2Wn9ntu/iib9jxsppPPvNs9z/9R3c\nOOnGTnuuTXHj69cWud6+1qQTyG8C1wKPmaY5BlhkWVYdgGmaZcCzwIGWZUVJ9pKfa+0BKytzd9F9\neXmp2rc+26bs5FMILF1K7VXXEdrrAMjSf6NNta+kvB/FQNVX3xPbJnPXp7uSW382F6eWmzX4Wqy/\nK9p307g7+XjBJ9z8wc3s0GtXdq3YrVOfb21uff3SlQ/ta02rQ9aWZU0DPjNN80Pgz8C5pmmeaJrm\nwZZlVQOvAtNN03wfWG5Z1vMdrFtyTODfTxN47WUadhlP6JzfOl1OuyQGDATAs3Chw5XkHydmWW9K\nWaAbj+z9BAB/eP9SDV1LRqW1UHMjE7VmrXXbfcB9mSxKcodn3lyCf7iURLCUmvsebnWXrWwVH5gM\nZO9iBXJXc2qW9aaM6bs9x4w6nqe++zv/+PavnDz6NKdLkhyhvayl88TjlP72LDy1NdTefDuJQYOd\nrqjdEgOSs2rVQ+56tQ3JQA4WON9DTrlip6sJ+ku59ZMbWB2ucrocyREKZOk0RQ/eR8H0j4gccDCR\nI7J3Elc6EgMHAeBZvMjhSvJPasi6OAuGrFP6FPfhwu0vZVV4FXfMuMXpciRHKJClU3hnfUXJLdcT\n79OXmtv/nNamH9ksUd4H2+/Hu3CB06XknWwbsk45/RdnMazbcP4y61G+qvzC6XIkByiQJfPCYcrO\nPR0jGqXm3gexe/VyuqKO83hI9K9QD9kBTm8MsikBb4BbJ9xF3I7z+3fPIxqPOl2SuJwCWTKu5Kbr\n8H3/HaGTTyO6595Ol5Mx8YoKPEuXQFR/eLtSNmwMsikTB+3JMSOP5+sVX/HgF/c6XY64nAJZMsr/\n/nsUP3x/8sCIq693upyMSlQMxLDtZChLl6mNJtemZlsPOeXaXW6gT3Ff7phxC7NXWU6XIy6mQJaM\nMdaspvT8s7G9XmoeeBRKsvMPaHslKhqXPi3STOuuVBetw8CgyJedG7J0L+zBrRPuIhKPcNQrv+bn\n1T+2/k0iG6FAlowJXn4x3kULqb/wUmJjtne6nIyLNwayR4HcpeqidRT7S/AY2fvn6lfDD+TKna5h\nYe0CDvjvvny9Ylbr3ySynuz9CRdXCbz4PIXPP0t0zFjqL7jE6XI6RaKicS2yArlL1UVrs3a4em2/\nG3sRt064i5WhFRz84v48Zz2DrcNIpA0UyNJhniWLCV56AXZxcXKo2pfWBnCuE69IrkXWkHXXWh2p\noqygc0/zypSTR5/Gw3v/hXgizrnvnMEJk49iaZ3mHEh6FMjSMYkEpeefjWf1amqvvZH4Zls4XVGn\nUQ+564VjYVaFV9G/ZIDTpaTt0C0O472jpjG+YgJvzJ3M/s9PYmGN1q9L6xTI0iGFTzxKwXvvEpm0\nN+ETT3G6nE5ll3UjESzFu0hrkbtKqnfZP+ieQAYYUjaU/xz0f1y245Usql3IYf93EMvrlztdlmQ5\nBbK0m3e2RfC6q0n07Entnx9w/W5crTIMEhUVeBapt9NVltQtBnBVDznFY3i4aPvLOH+7C/l5zU8c\n8fIhrImsdrosyWIKZGmfhgZKzzkdIxym5o57SfTt53RFXSJRMRDP6tVQW+t0KXkhFcj9Svo7XEn7\nXTnuGk7a6lS+Xfk110272ulyJIspkKVdiu+6Ff9XXxA+6lgaDjjI6XK6TGrpk1dbaHaJJbXJIesB\nwQqHK2k/wzC4cfxtjOw5in9++ze+WP650yVJllIgS5v5Pv2Y4j/fSXzQYGpvvNXpcrpUQmuRu9SS\nuuR/fPq7uIcM4Pf6uWm327GxueL9i0nYCadLkiykQJa2qa2l7NwzwLapuf8R7FJ3LEfJlHjjucha\n+tQ1lqQmdbnwGvL6xldM4ODNfs1ny2bwrPUvp8uRLKRAlra58EK8c+cQOvd3RHfe1elqulzTucgK\n5C6xpHYxPo+P3kXlTpeSEdfucgPFvmKum3Y1tVHNQ5B1KZAlbQVvTobHHiO21dbUXXal0+U4Qj3k\nrrWkbjF9i/vh9XidLiUjKkoHcs6257MiVMljXz7kdDmSZRTIkp7aWoKXXQR+P9UPPAqBgNMVOSIx\nILU5iCZ1dbZ4Is6y+qU5MVy9trO3PY+ehT154It7qQqvcrocySIKZElLyZ23JnuFl1xCfMutnC7H\nOYWFJHqXay1yF1gRqiSWiLluU5DWlBaUcf6Yi6huWMMDM3WGsjRTIEurvN9+Q9EjDxAfPBSuzM+h\n6rXFBw1K/uckGnW6lJzWvCmIu2dYb8zJo0+jX0l/Hpv1EMvqlzldjmQJBbK0LJGg9NILMGIxam+5\nHYqLna7IcbHR22BEIvi+/9bpUnJa8wxr965B3pQiXxEXbX8ZoViI2z+52elyJEsokKVFgX8/jf+T\n6UR+dRANe+3rdDlZITZmLAC+z2Y4XEluW1zbuAY5mHs9ZIBjRh7PiB4m//j2ST5fpp8lUSBLS+rr\nKbnpOuziYmpvuMXparJGdMz2APhmfuZwJbltaQ6tQd4Yv9fPrRPuwsbm0qkXEk/EnS5JHKZAlk0q\nevJxvMuWEjr97KYdqgTiI0wSJUH8n6tX05ncfLBEunat2I3DRxzFV5Vf8NdvHne6HHGYAlk2yqip\npvi+u0iUdaP+3POdLie7eL3Ett0O72wLo6ba6Wpy1pJa9x8skY5rdrmBboHu3PTx9Syq0fr2fKZA\nlo0qevgBPKtWETr3fOzuPZwuJ+vExmyPYdv4vpjpdCk5a0ndYnoW9qTQV+h0KZ2qT3Efrtn5emoa\nqjn59WMJxUJOlyQOUSDLBoxVKyl66H4SvXtTf/rZTpeTlaLbNU7s0rB1p7Btm8W1i3NyhvXGHDvq\nBI4aeSxfVM7k0vcuwLZtp0sSByiQZQPF99+Dp7aG+t9dBMGg0+VkpdjY5MQu/+ea2NUZahqqqY/V\n5eQa5I0xDIPbJtzNdn3G8G/raR77Sttq5iMFsqzDWLGCoiceJd5/AKETT3W6nKyV6D+AeL/+yR6y\nejMZ17QGOcd26WpJoa+QJ/d7ivKiPlz14RW8/NOLTpckXUyBLOsofvh+jPp66n/7eyjM7Wt3HRUb\nsz3eZUvxLNa+1pnWtAY5h2dYb8yAYAVP/+o5SvxBzn7rNKYunOJ0SdKFFMjSxKhaReFfHiXepy/h\nY090upys17QeWcPWGZfra5Bbsk2f7fj7L5PnJZ84+Ri+qvzC4YqkqyiQpUnRow/hqasldO7voKjI\n6XKyXmrHLq1Hzrx51XOA/BqyXtv4igk8vPcT1EfrOHHyMawIrXC6JOkCCmQBwKheQ9FjD5Po1YvQ\nCSc7XY4rxLbdDtswtGNXJ/jf/LfxeXyM7bu906U45oDNDuKyHa9kUe1CznjzJGKJmNMlSSdTIAsA\nRY8/gqd6DfVnnw8lJU6X4wp2sJS4ORL/FzMhpj+WmbKkdjFfVM5k5wHj6Rbo7nQ5jvr92IvZf9gB\nfLBoKpe9dZnT5UgnUyBLsnf8yAMkevQgfMppTpfjKtGdd8Wor6PgjclOl5Iz3pz3OgD7Dd3f4Uqc\n5zE83D/pYbboPoK7pt/FR4s+cLok6UQKZKHo/nvwVFVRf+7vsYOlTpfjKqFTzwSg+P67tfwpQ96Y\n8xoA+yiQASgtKOP+SY9gYHDp1AtoiDc4XZJ0EgVynvMsXULxIw8k1x2ffpbT5bhOfIRJZL9f4v9s\nBv6PpzldjuvVRmt5f9F7jOq5FUPKhjpdTtbYru9Yztr+LGZXWTz85f1OlyOdRIGc54pvvwUjFKL+\nkis0s7qd6s/9PQBF993tcCXu996Cd4nEI+w3TL3j9d245430Lirnzhm3sqBmvtPlSCdQIOcx7w+z\nKXz678S2GEH4qGOdLse1YjuNI7rjOAJvvYH3u2+dLsfV3pir4epN6VHUg2t3uYFQLMQ1H17pdDnS\nCRTIeazkpusw4nHq/nAN+HxOl+Nq9ecle8nFD97rcCXuFY1HeXveG5QX9WG7PmOdLicrHT7iKMb2\n3YFXfn6JL5Z/7nQ5kmEK5DxV8PYbBF79P6Jjd6Dhlwc4XY7rNeyzH7ERJoHnn8Vrfe90Oa70p2l/\nZEVoBQdvfigeQ3+aNsYwDK4cdw0AN07/k8PVSKbppz4PGVWrCF7wW2y/n5o77gHDcLok9/N4qLvs\njxixGN2OOQzPsqVOV+Qqz89+lke/egizx0j+sNPVTpeT1cZXTGD3gXvw3sJ3+WDRVKfLkQxSIOeh\n4OUX4V22lLrLriS+1Winy8kZDQceTN3lf8S7YD5lRx+GUVPtdEmu8M2Kr7lwym8J+kt5cr+nCBZo\n6V1rmnvJ1+rs5ByiQM4zgRefp/C/zxPdfsfkntWSUfUXXELohFPwf/0VZScfD5GI0yVltakLp/Dr\nl35FKBbi/kmPsHmPLZwuyRW27TOGA4YfzGfLZvDqzy87XY5kiAI5j3jmziF42YXYxcXU3P8weL1O\nl5R7DIPaW+4gsu/+FEx9l+4H7Ytn3lynq8o6tm3z2FcPceTLh1IbreXuiffzy+Gay9AWf9jpanwe\nH9dNu0qbheQIBXKe8CxZTPfDDsZTVUXtdTcTH7650yXlLp+P6kf/SvjIY/DP/Jwek3aj4JX/c7qq\nrFEdWcMZb57MlR9cRs/CXrxw8Kscu+UJTpflOpv32IKTtzqNudVzeOLrR50uRzJAgZwHjMpKuh12\nEN75c6m75ArCOs2p8xUVUXPfw1Tf+xBGLEq3U46j7NQT8P70g9OVOWrG0k/Y89nxvPTTC+zQbyfe\nPGwKO/Uf53RZrnXRDpfRLdCdO2fcxqrwSqfLkQ5SIOc4Y8UKuh15KL4fZlN/zvnUX3y50yXllchR\nx1L1xhSiY7cn8PKL9Bi/I8GLfpd3w9j10Xqu+fBKDvjvPiyomc8FYy/mpUMmU1E60OnSXK1nYS8u\n2v5S1kRWc/unNztdjnSQAjmH+T6eTo9J4/F//RWhE0+l7prrtcTJAXFzJKtfe4c1Tz5FfPhmFP3j\nSXrt8Au6HXYwgf/+B8Jhp0vsNLZt88bcyUz898489OV9DCodzAsHv8IVjdc/peNOGX0Gw7ttxhOz\nHuO9Be86XY50gAI5F9k2RQ/eR/dD9sezbCm1f7yW2lvvVBg7yTBo+NWBVL03neoHHqVh3C4UTH2X\nsjNPodeo4ZSefhKBF57DqF7jdKUZkbATvDPvTfZ/fk+Of+1I5tfM4+xtfst7R05n14rdnC4vpxR4\nC3hwr8fweryc8/bpLK9f7nRJ0k6GA2vY7MrKmq5+zi5TXl6Kk+3zLJhP6YW/peC9d4n36UvNo08S\n3WV8xh7f6fZ1tq5sn/fHHyh8+h8EXn4Rb+MQtu33E91tdyK/PJDIvr/E7ts3Y8/XFW37seoHnrX+\nxXOzn2FR7UIADtzsEC7Z4QpG9hzVqc+d7z+bD35xH9d+dCUTB+3JMwe84LrdzvLg9Wu1R6RAzjDH\nfqgSCQr/9gQl112Np66WyKS9qfnzgxn9gw558UvT9e2zbbzffkNg8isUvPYK/q+/aropOvoXRPfc\ni4ZJexPdcVyHlqp1Vtuqwqt48ccXeNZ6ms+WzQAg6C/l4M0P5ZStz2Dr3r/I+HNuTL7/bCbsBMe9\negRvz3+T07c+i+vH3+KqUM6D10+B3NWc+KEyKispO+8MCt59h0S37tRefzORI4/plCHqPPilcbx9\nnnlzk+H81pv4P/4IoyG5xjTRuzeR/X5F5ICDiO6+Z5vDOZNti8ajvDP/LZ61/sWbcyfTkGjAY3iY\nOGhPjjCPZr+hv6LYX5yR50pXNrx2nSmd9q0MreTgF/djdpXFUSOP5a6J97nmWn0evH4K5K7W1T9U\n/qlTKD3ndLzLlxGZtDe1d99Pol//Tnu+PPilya721dVR8NH7FLzxOoHJr+CpTF4fjA8cROjEUwgf\ncwJ2eXlaD9XRttm2zawVX/Ks9S9e+OE5VoRWADCy5yiOMI/hsBFH0K+k8372WpN1r12Gpdu+laGV\nHPPqb5i5/HP2G/pLHtjrUUoLyrqgwo7Jg9dPgdzVuuyHyrYpvvNWim+/Gbxe6v74J0JnnQuezh2i\nyoNfmuxtXzyOb8anFD73DIX/+TdGfR12QQGRAw8hdMrpxLbfscVRkfa2bWndEv4z+1mes/7Fd6uS\n5z33LurNr7c4nCPMo9m69zYYWTBhMKtfuwxoS/tqG2o48fVjeX/hFIaUDeXRvZ9ku77ZfaRlHrx+\nCuSu1iU/VJEIpb8/l8LnnyU+aDDVj/2V2JjtO/c5G+XBL40r2mdUryHw3DMUPfEYvh9mA8nrzZHD\njyLyywNIDBm6wfe0pW310Xpen/sq//7+ad5b+C4JO0GBp4B9hu7PkSOPYc9Be+H3+jPZpA5zy2vX\nXm1tXzQe5fZPb+aez+/E6/Hyh52u4Zxtf5u115Xz4PVTIHe1zv6hMlatpOykYymY/hHRsTuw5u/P\npD1kmQl58EvjrvbZNv4PplL05OMUTH4FIx4HGieD7TGJ6I7jiO6wI3bPXmlNCvp4yTSetf7FSz/+\nl9po8r5j+27PEeYxHLL5r+lR2LNLmtUernvt2qi97Zu6cArnvn0Gy+qXssegSdw36RH6FPfphAo7\nJg9ePwVyV+vMHyrvzz9Sdszh+H7+ifDBv6bm3oegqKhTnmtT8uCXxrXtM5YvJ/DGaxS89jIFU6dg\nRKNNt8VGmPgm7Eb1L8YS3XEciWHDwTAIx8LMWPYJ7y14l//++Dzzq+cCUBEcyOEjjuII82jXnMDk\n5tcuHR1p34rQCs5/5yzenv8mvYvKeXSfJxlfMSHDFXZMHrx+CuSu1lk/VP7pH1F24tF4qqqo/91F\n1F1xVadfL96YPPilyY321dbi/+xT/J9Mx//xdHyffYqnrpZVRfD2cJi2RREfb1bI56U1RIgBUOwr\n4cDNDuYI82h2rdgtM0ObiQREoxAIdPyxWpEzr90mZGJS3qNfPch1064mbse5atx1nLPtb7Pi+j/k\nxevX6j+0O+bD57nAc89QesF5kEhQ8+cHCB9zvNMlSbYLBonuvgfR3fdgQc18Xpr9H9754UWmrfqS\nBDYQwpsIsfUS2HMO7LHIz65lW1I0IEZi4BTi/Wdjl5VhB0uxg8HkW2lp8nPDA7aNgY2xZg2eyuXJ\nt4UL8c6dg3fuHDxLF+NZtRKjqgojHscOBEh0647du5zottsRG7sD0R12Im6O1A5yXcQwDM7c5lzG\n9N2eU984gT9N+yMfL53GrbvdSf/gAKfLExTIWc2oqSZ45WUUPvMUibJuVD/xD6ITJjpdlmS5SDzC\nzGWf8cGiqfxv/tvMWPYJAB7Dw9h+O7LX4H3YuWI820R60v2zL/E3TMe/6GO8H3+Gkfg0IzUkevQg\n0as39vDNsQuLMGrWYKxejXfuz/i+/Rqe/gcA8X79adhrHxom7UN094nYwdKMPL9s2g79duKtw6dy\n1pun8PqcV3l/4XtcssMVnLTVqV2+dlzWpSHrDMvUsIvv4+mUnXsG3vlziW6zHTUPPU58c+ev5eXB\nsJKr2rcqvJLPl83g82Wf8fXKWfxYNZu51XOIJZLD0B7Dw64VEzhk819zwg5HY9e1MHQcjeJZugTv\nooV4Fi/CqKnBqK3FqG18X5f8mISd7NUaYJd2I1Hem0R5HxL9BhAfOoz4kKEQDG78OeJxvN99i3/G\nJ/inf0TBlHfwrFoFNG4bOm6XZDjvsCPxESZ2t+5p/1u47bVrq0y3L2En+Nd3/+S6aVdRFamiwFPA\njv3HsVP/nRkQrKBPcV9G9hzFkLKhGXvOluTB66dryF2toz9UvpmfUXz37QRefw3b46H+dxdSf9Hl\nUFCQwSrbLw9+abK+favCK3n5p5d48Yfn+WjxB9g0/w53D3Rn8+4j2LbPdoyv2J2dB+zSNDM6K9sW\nj+Ob+RkFb79JwTtv4f9y5ro39+tPYsjQ5PvUW//+JPoPID6ggsTAQU07lmVl+zKos9q3KrySh764\nn3fmv8XXK77a4PbBpUOYMHAiZ21zHiN6mhl//pQ8eP0UyF2tPT9URk01BW++TuG/n6Zgyv8AiI7d\ngdprbyS2U3Yd3p4HvzRZ2T7btpm2+EP+/u2TvPLTSzQkkttp7thvHBMGTmRM37FsXb4tfYr6bHKS\nTra2bW3GsmUUTHkH3zdf45v9PV7rezxLFmMkEhu9v+33Ex8ylPhmmxPYahQ1/QYRH74Z8eGbkRhQ\n4cjEx87SFa/fitAKZlV+yfL6ZSyrX8bny2bw0eL3WR1ZjdfwcuJWp3DJDn+gV1GvjD+3G34+O0KB\n7IC0fqhsG8+cnyl4710K/vcWBe++07RfccP4CdRfcAnR8ROycrJLHvzSZFX7fqiazfOz/81/fniu\naUnSFt1HcPSo4zl0899QUTow7cfKtralLRZLThpbugTPkiXJ90uX4F0wH++cn/D+/BOe1as3+Da7\nsDA5hD5ss6aQjm+2eTKs+/bLyt+vljj1+sUTcd6c9zp/+uiP/LzmJ3oW9uSuiffzy+EHZPR5XPvz\nmSYFsgM29UNlrFhBwQfv4X/vXQqmTsG7YH7TbbFRWxI58BAiBx1KfETnDQllQh780jjevkU1C3nl\n55f4z+xn+bIyOYRb7CvhV8MP5LgtT2Rc/13atVQlG9rWWYxVK+ldtZTqGV82hbT355+TYV27YZvt\n4hLiw4Y3B/WgwST69CXRt2/yfXmfrLlMlOL069cQb+Avsx7l5o+vIxwPc/yWJ/GnXW8i6N/EfIE2\ncrp9nS1jy55M07wLGAckgN9bljVjrdv2Am4EYsBky7JuaF+5Oaa+Hv/H0yiYOgX/1Cn4Z33ZdFOi\ne3ciBxxMw4SJNOy+R3KTBskqtm0zt3oOny37lK8qv2RhzQIW1S6gpqEGr+HF6/HRPdCd3kXl9C7q\n3fi+nLJAGYXeIgp9hRT7iin0FVLoK6LQW0iRv5gSXzHF/hI8hoeEnaA+Vs+C6vl8u/JrvqicyXsL\n/sf3q74DwGt42WvwPhxmHsm+Q39Jib/E4X+V7GX37AXmUCKbbbXeDTZGZWUyoOf8hO/nVFg3fv7N\nrE0+ZqJnz2Q49+lHok8fEv36Ex88JDlEPmQoiUGDwZ9d24d2pgJvAWdvex57Dt6Ls946lX98+1fe\nmvcGV+50DYebR2Xtlpxu0moP2TTNCcDFlmUdZJrmSOAJy7J2Wev2b4C9gSXAe8AZlmV938JD5mQP\n2Vi1Ev8nH9PtqxlE352C78svMGLJma52QQHRHcfRsPseRCdMJPaLbTt0rq2TcvF/sbFEjPnVc5ld\nNZt54R+Y+vMHfL5sBivDK9e5X4GngLJANxJ2nGgiRk1Ddbuez8Ag4A0Qjoc3uK3QW8iuFbux15B9\nOWizQykvzty2qLn42q2tze2z7eTQ988/4Vm8CM+yZXiWr/e2bBmeNRsOhwPYHg+JgYOaAjo+ZGhy\nAlrjTHO7e4+MDotn0+sXiUf482d38MDMewjHw/yifFsOH3Ek+w87gMFlQ9r1mNnUvs6QkSFr0zT/\nBMyzLOuJxs+/BXa0LKvWNM1hwN8sy5rQeNvlQI1lWQ+08JDuDuREAqOyEt8PFr7vvkku4fj0Y3xr\n/R/E9nqJbbMt0XG70jBhItFxu0Bxbqzvy5ZfmlgixprIGlZHVlEVrqK6YQ3VkWqqG6qpaaihpmEN\nNQ011EZrk2+NH9dH64nbMRJ2gnAszJqGNdQ0VJOw1500NLh0CGP7bs/YvjuwbZ+xDO02jN5Fvdfp\nBcQSMVaGV7KivpIVoUoqQ8upaaghHAsTjoUIx0OEmj5Ovq+L1jXeJ0SRv5hiXzH9SwawZa+t2LLX\naLbrO5YiX+dsh5otr11n6bT2hcPJa9iLF+OdPxfvvMa3uXPwzJuLd+mSjX5boqxbMrAHDCDRv4LE\ngAHJ2eH9B5Do0ze50UrjZivp9LSz8fVbUDOf66ddzUs//rdptn9FcCCDy4YwuHRI0/shZUMZVDqY\nfiX98Xo23hnJxvZlUqaGrPsBM9b6fEXj135sfF+51m3LgfTGX8NhjJoasO2mXX9SH6fz1nx/2nj/\nxqS9BScAAAtESURBVLdoFCMUanyrh1AIo76+6XMjFMKor8OorsaoXoNn9Wo8S5fiWbq4aQJWil1c\nTMNuE4mO25mSfSexYrOtoMS9w4uhWIjqhmpi8SgxO0Y8ESOaiBFLxCiLBVi+cnVT6NTHQusETigW\nJhIPY9s2CRJg2yRsGxubhJ1oft/4NQMDr8eLBw9ejwfD8BBPxJseOxSrJxwLUxutYXW4iqpIFasj\nq1kT2XivpSUew0OJP4jP8OL1eCnwBBhQMoCynqMYXDqEET1Mdhw2huGFW9K3uG+rj+fz+Ohb3Det\n+4qLFRaSGDSYxKDBG1/1EAolJ5jNm9Mc0msFtu/br1t9CruwMLkbWkkQOxAAfwF2oCD5viCAXeCH\nYDGleJPhncYIm+31QiCAHSjELiqEQCF2YVHy8QsLk88ZKITCwHpfb/x4Y8+xXgduCAaPb3k9Nw47\nn9eXvcvkpf/ju+ofmL74I6bx4Qbf7jN8VBT2ZWDRACqK+lLmKyXoK8Zr+Cgo9FBTHyZGnLgdJ0ac\nmJ0gbscp8AYI+ksoKepOSUkPgv5Sgv4gwYIgJf4gQX+QkoIghd7Cpr8ta/+tSf0tiiXiROJhIvEI\nDfGG5PtEAw3xCJF4BAMDv8eP31tAgcePz+OnwFuAz+OjwFOA31uQvD315i2gvKg8Y9uPtmenrpae\nOa2qjJpqeo4ZvcmhoGxkGwaJvv2Ijd46uQHCFiOIjRxFbNRWxLcY0fQ/3JLyUnDx//KqwqsY+4+t\nm076ySZFviK6B3owoKSCrXqNpkdhT3oEetC9sAfdCrpRGiij1F9KWaAbpf5SggVBggWlTb+8Rb6i\nVn9xcv1/6dIJioqIjzA3OSHTqKnGs3hxclh86RK8ixfhqVye3GylafOV6uTHdXXJSWgNUYxoA0Qi\nGGuFYGFXtamNegFbAhc2fh7xwvxuMKcHzOmefD+vG8zrHmNu90V8WLrIwWoz67hRJ3LXHvdl5LHS\nCeTFJHvCKQNIXi9O3dZ/rdsqGr/WEqP38ApYXZV2kdnAALyNb60pL3fv9n/llFLzh/ZdG80Vbn79\nWpPLbYMsbV95KQyvAHZwupIuEwC2aHyT9KUzLe5N4DAA0zTHAIssy6oDsCxrHlBqmuZg0zR9wAGN\n9xcREZE2SGsdsmmaNwG7A3HgXGAMsNqyrJdM0xwP3Ebyau5/LMu6uxPrFRERyUlObAwiIiIi69FK\nbhERkSygQBYREckCCmQREZEs0J51yBlhmmZf4DvgEMuypjpVR6aZplkO/I3kkkE/cKFlWZ86W1Xm\nmKbpBf4CbEZyFdjFlmV95GxVmWOa5u7As8DJlmW95nQ9mdLSfvS5wDTN0cCLwF2WZT3odD2ZZprm\nbcB4kr9zt1iW9V+HS8oI0zSLgL8CfUmulrrBsqxXHS2qE5imWQh8DVxnWdbfN3U/J3vItwE/Ofj8\nneU44O+WZe0JXAnk2mEbxwO1lmXtBpwG5MysetM0hwMXAB84XUsmNe5Hv3njHvSnAfc6XFJGmaZZ\nTLJNbztdS2cwTXMisGXj67c/8GdnK8qoA4FPLcuaCBwJ3OVsOZ3mKmBla3dyJJBN09wDqAY2fdSK\nS1mWdbdlWc80fjoYWOBkPZ3gHzRvyFMJ9HSwlkxbDBxK8mczl0wi2Xuk8eCX7qZpZubMvOwQJhlU\nG99U2v3eAw5v/Hg1UGyaprsOc94Ey7KetSzrjsZPc/HvJaZpmsBIoNWef5cPWZum6QeuBg4G7unq\n5+8KjcPxLwNBYE+Hy8koy7LiJNejA/weeNrBcjLKsqwwQPL3J6e0tB+961mWlQAiOfi6AWBZlg2E\nGj89DXit8Ws5wzTND0nu9HiA07V0gjtJ7t9xUmt3/P/27j/2qrqO4/jTkWyOxfwj13SaNZavKRGJ\nGy1RmIICWqig5T+iSAVa5GxrTbOQqVuttdZ0rY2EUbkKp/6Dzh/DABHQYrE2aC+WQwg1xKmZYiUb\n/fH53HZGfhO/98K93+Pr8dc5O+d+7vt87/d+3+fzOZ/v531UE7KkhZRfoEOU1ScPAY8Cy22/Ub9A\nI/ZOb4jrW2r7CWCypFmU58kz+xfl8P2/65P0NeBsypDTiPMen13bjdjv3AeZpMuABcDF/Y6l12xP\nkTQRuA+Y2O94ekXSNcAm27uPJN8d84VBJG2kDJUfR5kY9DJwle0/H9NAjpL6vO5Ptl+v+/tt966o\n7QCoyWwecJntd/odT69JWgnc35ZJXZKWAi/aXl73nwM+3VkCty3qde5v6aSumcAyYKbtv/c7nl6p\nyzG/bHtv3d8OTLP9Sn8j6w1JvwE+QZlMeSrl8coi20++2/nHfMja9nmd7fqHb2VbknE1l9Jz/Imk\nCcCePsfTU3Xi0yJgahuTcUObepGPA7cDyw9fj76F2vS5ASBpLGUS7PQ2JeNqKnA6cHN91DemLckY\nwPbVne16w7hrqGQMffy3p6pVz0GqO4BVkuYCo4Eb+hxPry2kTOR6pE4sOQRcbPtgf8PqnqRLgG8B\nAiZJWmJ7Vp/D6prtzZK21ud0nfXoW6PeZPyI8of9HUnzgLmdUaoW+BKlwuHqxndufqdXOcL9DLhX\n0gbKv4re2Od4+iprWUdERAyArNQVERExAJKQIyIiBkASckRExABIQo6IiBgAScgREREDIAk5IiJi\nACQhR/SYpF9Kmv8+X3OtpAXDPT4cksZJ2inpnh62eaakz9Ttb0ua3au2I9qu3wuDRARge1U3x4fp\nXGCr7a/3sM0rgH3ANts/6GG7Ea2XhUEiulRXT1oBjKcslToG+DWlQs+Setp+4Mu2X5P0eUrFs7eB\nncBi4DZK8fllwL3AJykrMv3R9pK67N4o29+TdCmlvupbwAHgq7ZfkrSLUkFtNvBxYLHt3w0R8zhg\nDXAi8ECN70O2v1uP76KUbTwfmFFjE/C87Xn1nNuAOZTVv34FbAUeopQIXEYpqvKU7RWSrqcsufoW\nJWF/xfabkl6n1AyfTalA9UXb29/fJxDRDhmyjujeDOAM25OBayjVaj4GfIey/vBUSk3bWyWdACwH\nZtmeRimFeG6jrQnAZNtT6rrv2yR9uHOw8forbE+nVE+7s/H6A7ZnAncB3xgqYNvPAd8Hnmj0kJt3\n583tzwHX2T4HmChpoqTzgEvqNZ8PXATsqPH8sFETHEmnUdbSvsD2hcBe4OZ6eCylGMt04LeUClwR\nH0gZso7o3gRgE4DttyU9A/wLOBl4rPagRwO7gLOAPbZfreffAiCpUzd7B7Bf0hpKD3a17X80av2e\nAfzN9kt1fx2l50ljH2A3Zc3x4WoWaXjW9r/r9l9ru5OAp+o1HAQur9fxbm1NAv5g+8ARxDyui5gj\nRrQk5IjuHUcpr9YxipKQn7E9p3liLYQwaqiGauKbVidGfQH4vaRmD7pTv7n53s3e7MHDjh2pw59d\njR6izeZ7HukI29GKOaJVkpAjureD8iyVOrz8WWAzMFnSR23vk3QlJUmvBU6RdIrtFyX9GPhvOTZJ\n5wDjbf+CMlz9KUqvuGMncJKkU2u1nxnAlh5cwxvUwvCSxgPvVcN7E/BTSaMoiflx4GrKjcnxh527\nFbhb0pha9nEG5ecTEQ15hhzRvceAPZK2AD+nJKsXgJuANZLWAdcDW+qw7ULgQUnrKZOqHm609Rfg\nSkkbJa2lTJB6unPQ9j/r61dLehK4kDIhDLorZ3o/peTk+tr+UBOrDtU4tlAmg20ENgAP2N5HublY\nKmlx49wXKJPQ1tafxUcok8+6jTmiVTLLOiIiYgBkyDqixSTdDkzjf3ui22x/89hHFBFDSQ85IiJi\nAOQZckRExABIQo6IiBgAScgREREDIAk5IiJiACQhR0REDIAk5IiIiAHwH8VPbOe7g74LAAAAAElF\nTkSuQmCC\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x7f04c43ea9e8>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Ignore numpy warning caused by seaborn\n",
+    "warnings.filterwarnings('ignore', 'using a non-integer number instead of an integer')\n",
+    "\n",
+    "ax = sns.distplot(predict_df.query(\"status == 0\").decision_function, hist=False, label='Negatives', color = 'red')\n",
+    "ax = sns.distplot(predict_df.query(\"status == 1\").decision_function, hist=False, label='Positives', color = 'green')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Pos</th>\n",
+       "      <th>Neg</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Label / Predict</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>Pos</th>\n",
+       "      <td>240</td>\n",
+       "      <td>33</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Neg</th>\n",
+       "      <td>76</td>\n",
+       "      <td>422</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                 Pos  Neg\n",
+       "Label / Predict          \n",
+       "Pos              240   33\n",
+       "Neg               76  422"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from sklearn.metrics import confusion_matrix\n",
+    "conf_mat = confusion_matrix(predict_df.query(\"testing == 1\").status, \n",
+    "                            predict_df.query(\"testing == 1\").probability, \n",
+    "                            labels = [1, 0])\n",
+    "cols = {'Pos': conf_mat[:,0].tolist(), 'Neg': conf_mat[:,1].tolist()}\n",
+    "df_conf = pd.DataFrame(cols, index = ['Pos', 'Neg'])[['Pos', 'Neg']]\n",
+    "df_conf.index.name = 'Label / Predict'\n",
+    "df_conf"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'The F1 score is 0.815'"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from sklearn.metrics import f1_score\n",
+    "f1 = f1_score(predict_df.query(\"testing == 1\").status, predict_df.query(\"testing == 1\").probability)\n",
+    "'The F1 score is {:.3}'.format(f1)"
+   ]
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/algorithms/scripts/SVC-htcai.py
+++ b/algorithms/scripts/SVC-htcai.py
@@ -1,0 +1,295 @@
+
+# coding: utf-8
+
+# # Create a Support Vector Machine with rbf kernel to predict TP53 mutation from gene expression data in TCGA
+
+# In[1]:
+
+import os
+import urllib
+import random
+import warnings
+
+import pandas as pd
+import numpy as np
+import matplotlib.pyplot as plt
+import seaborn as sns
+from sklearn import preprocessing, grid_search
+from sklearn.svm import SVC
+from sklearn.cross_validation import train_test_split
+from sklearn.metrics import roc_auc_score, roc_curve
+from sklearn.pipeline import make_pipeline
+from sklearn.preprocessing import StandardScaler
+from sklearn.feature_selection import SelectKBest
+from statsmodels.robust.scale import mad
+
+
+# In[2]:
+
+get_ipython().magic('matplotlib inline')
+plt.style.use('seaborn-notebook')
+
+
+# ## Specify model configuration
+
+# In[3]:
+
+# We're going to be building a 'TP53' classifier 
+GENE = 'TP53'
+
+
+# In[4]:
+
+# Parameter Sweep for Hyperparameters
+n_feature_kept = 2000
+param_fixed = {
+    'kernel': 'rbf'
+}
+param_grid = {
+    'C': [10 ** x for x in range(-1, 4)],
+    'gamma': [10 ** x for x in range(-5, 0)],
+}
+
+
+# *Here is some [documentation](http://scikit-learn.org/stable/modules/generated/sklearn.linear_model.SGDClassifier.html) regarding the classifier and hyperparameters*
+# 
+# *Here is some [information](https://ghr.nlm.nih.gov/gene/TP53) about TP53*
+
+# ## Load Data
+
+# In[5]:
+
+if not os.path.exists('data'):
+    os.makedirs('data')
+
+
+# In[6]:
+
+url_to_path = {
+    # X matrix
+    'https://ndownloader.figshare.com/files/5514386':
+        os.path.join('data', 'expression.tsv.bz2'),
+    # Y Matrix
+    'https://ndownloader.figshare.com/files/5514389':
+        os.path.join('data', 'mutation-matrix.tsv.bz2'),
+}
+
+for url, path in url_to_path.items():
+    if not os.path.exists(path):
+        urllib.request.urlretrieve(url, path)
+
+
+# In[7]:
+
+get_ipython().run_cell_magic('time', '', "path = os.path.join('data', 'expression.tsv.bz2')\nX = pd.read_table(path, index_col=0)")
+
+
+# In[8]:
+
+get_ipython().run_cell_magic('time', '', "path = os.path.join('data', 'mutation-matrix.tsv.bz2')\nY = pd.read_table(path, index_col=0)")
+
+
+# In[9]:
+
+y = Y[GENE]
+
+
+# In[10]:
+
+# The Series now holds TP53 Mutation Status for each Sample
+y.head(6)
+
+
+# In[11]:
+
+# Here are the percentage of tumors with NF1
+y.value_counts(True)
+
+
+# ## Set aside 10% of the data for testing
+
+# In[12]:
+
+# Typically, this can only be done where the number of mutations is large enough
+X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=0)
+'Size: {:,} features, {:,} training samples, {:,} testing samples'.format(len(X.columns), len(X_train), len(X_test))
+
+
+# ## Median absolute deviation feature selection
+
+# In[13]:
+
+def fs_mad(x, y):
+    """    
+    Get the median absolute deviation (MAD) for each column of x
+    """
+    scores = mad(x) 
+    return scores, np.array([np.NaN]*len(scores))
+
+# select the top features with the highest MAD
+feature_select = SelectKBest(fs_mad, k=n_feature_kept)
+
+
+# ## Define pipeline and Cross validation model fitting
+
+# In[14]:
+
+# Include loss='log' in param_grid doesn't work with pipeline somehow
+clf = SVC(random_state=0, class_weight='balanced',
+                    kernel=param_fixed['kernel'])
+
+# joblib is used to cross-validate in parallel by setting `n_jobs=-1` in GridSearchCV
+# Supress joblib warning. See https://github.com/scikit-learn/scikit-learn/issues/6370
+warnings.filterwarnings('ignore', message='Changing the shape of non-C contiguous array')
+clf_grid = grid_search.GridSearchCV(estimator=clf, param_grid=param_grid, n_jobs=-1, scoring='roc_auc')
+pipeline = make_pipeline(
+    feature_select,  # Feature selection
+    StandardScaler(),  # Feature scaling
+    clf_grid)
+
+
+# In[15]:
+
+get_ipython().run_cell_magic('time', '', '# Fit the model (the computationally intensive part)\npipeline.fit(X=X_train, y=y_train)\nbest_clf = clf_grid.best_estimator_\nfeature_mask = feature_select.get_support()  # Get a boolean array indicating the selected features')
+
+
+# In[16]:
+
+clf_grid.best_params_
+
+
+# In[17]:
+
+best_clf
+
+
+# ## Visualize hyperparameters performance
+
+# In[18]:
+
+def grid_scores_to_df(grid_scores):
+    """
+    Convert a sklearn.grid_search.GridSearchCV.grid_scores_ attribute to 
+    a tidy pandas DataFrame where each row is a hyperparameter-fold combinatination.
+    """
+    rows = list()
+    for grid_score in grid_scores:
+        for fold, score in enumerate(grid_score.cv_validation_scores):
+            row = grid_score.parameters.copy()
+            row['fold'] = fold
+            row['score'] = score
+            rows.append(row)
+    df = pd.DataFrame(rows)
+    return df
+
+
+# ## Process Mutation Matrix
+
+# In[19]:
+
+cv_score_df = grid_scores_to_df(clf_grid.grid_scores_)
+cv_score_df.head(2)
+
+
+# In[20]:
+
+# Cross-validated performance distribution
+facet_grid = sns.factorplot(x='C', y='score', col='gamma',
+    data=cv_score_df, kind='violin', size=4, aspect=1)
+facet_grid.set_ylabels('AUROC');
+
+
+# In[21]:
+
+# Cross-validated performance heatmap
+cv_score_mat = pd.pivot_table(cv_score_df, values='score', index='C', columns='gamma')
+ax = sns.heatmap(cv_score_mat, annot=True, fmt='.1%')
+ax.set_xlabel('Kernel coefficient (gamma)')
+ax.set_ylabel('Penalty parameter of the error term (C)');
+
+
+# ## Use Optimal Hyperparameters to Output ROC Curve
+
+# In[22]:
+
+y_pred_train = pipeline.decision_function(X_train)
+y_pred_test = pipeline.decision_function(X_test)
+
+def get_threshold_metrics(y_true, y_pred):
+    roc_columns = ['fpr', 'tpr', 'threshold']
+    roc_items = zip(roc_columns, roc_curve(y_true, y_pred))
+    roc_df = pd.DataFrame.from_items(roc_items)
+    auroc = roc_auc_score(y_true, y_pred)
+    return {'auroc': auroc, 'roc_df': roc_df}
+
+metrics_train = get_threshold_metrics(y_train, y_pred_train)
+metrics_test = get_threshold_metrics(y_test, y_pred_test)
+
+
+# In[23]:
+
+# Plot ROC
+plt.figure()
+for label, metrics in ('Training', metrics_train), ('Testing', metrics_test):
+    roc_df = metrics['roc_df']
+    plt.plot(roc_df.fpr, roc_df.tpr,
+        label='{} (AUROC = {:.1%})'.format(label, metrics['auroc']))
+plt.xlim([0.0, 1.0])
+plt.ylim([0.0, 1.05])
+plt.xlabel('False Positive Rate')
+plt.ylabel('True Positive Rate')
+plt.title('Predicting TP53 mutation from gene expression (ROC curves)')
+plt.legend(loc='lower right');
+
+
+# ## What are the classifier coefficients?
+# 
+# coef_ is only available when using a linear kernel
+
+# ## Investigate the predictions
+
+# In[24]:
+
+predict_df = pd.DataFrame.from_items([
+    ('sample_id', X.index),
+    ('testing', X.index.isin(X_test.index).astype(int)),
+    ('status', y),
+    ('decision_function', pipeline.decision_function(X)),
+    ('probability', pipeline.predict(X)),
+])
+predict_df['probability_str'] = predict_df['probability'].apply('{:.1%}'.format)
+
+
+# In[25]:
+
+# Top predictions amongst negatives (potential hidden responders)
+predict_df.sort_values('decision_function', ascending=False).query("status == 0").head(10)
+
+
+# In[26]:
+
+# Ignore numpy warning caused by seaborn
+warnings.filterwarnings('ignore', 'using a non-integer number instead of an integer')
+
+ax = sns.distplot(predict_df.query("status == 0").decision_function, hist=False, label='Negatives', color = 'red')
+ax = sns.distplot(predict_df.query("status == 1").decision_function, hist=False, label='Positives', color = 'green')
+
+
+# In[27]:
+
+from sklearn.metrics import confusion_matrix
+conf_mat = confusion_matrix(predict_df.query("testing == 1").status, 
+                            predict_df.query("testing == 1").probability, 
+                            labels = [1, 0])
+cols = {'Pos': conf_mat[:,0].tolist(), 'Neg': conf_mat[:,1].tolist()}
+df_conf = pd.DataFrame(cols, index = ['Pos', 'Neg'])[['Pos', 'Neg']]
+df_conf.index.name = 'Label / Predict'
+df_conf
+
+
+# In[28]:
+
+from sklearn.metrics import f1_score
+f1 = f1_score(predict_df.query("testing == 1").status, predict_df.query("testing == 1").probability)
+'The F1 score is {:.3}'.format(f1)
+


### PR DESCRIPTION
The `rbf` kernel SVC takes much more time to train than does the LinearSVC. Therefore, I narrowed the search space of the two hyper-parameters: penalty `C` and kernel coefficient `gamma`.

In addition, I removed the cell of _Top predictions amongst negatives_, since the predicted probabilities are either 0 or 1, which might not be very informative. If it should be added back, I would be happy to do it.

Moreover, the section of coefficients is removed since this is only available to SVCs with linear kernel.

As for the results, the rbf kernel is very powerful and achieved an AUROC larger than 99% for the training data. But it cannot be well generalized to the testing data. Still, the testing AUROC (90.2%) is better than the LinearSVC (89.2%). The F1 score of this SVC (0.777) is also slightly better than the LinearSVC (0.768).
