### PR TITLE
New algo VotingClassifier

### DIFF
--- a/algorithms/VotingClassifier-paulseignourel.ipynb
+++ b/algorithms/VotingClassifier-paulseignourel.ipynb
@@ -1,0 +1,855 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Create a logistic regression model to predict TP53 mutation from gene expression data in TCGA"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/sharimoskow1/anaconda/envs/cognoma-machine-learning/lib/python3.5/site-packages/sklearn/cross_validation.py:44: DeprecationWarning: This module was deprecated in version 0.18 in favor of the model_selection module into which all the refactored classes and functions are moved. Also note that the interface of the new CV iterators are different from that of this module. This module will be removed in 0.20.\n",
+      "  \"This module will be removed in 0.20.\", DeprecationWarning)\n",
+      "/Users/sharimoskow1/anaconda/envs/cognoma-machine-learning/lib/python3.5/site-packages/sklearn/grid_search.py:43: DeprecationWarning: This module was deprecated in version 0.18 in favor of the model_selection module into which all the refactored classes and functions are moved. This module will be removed in 0.20.\n",
+      "  DeprecationWarning)\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "import urllib\n",
+    "import random\n",
+    "import warnings\n",
+    "\n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "import seaborn as sns\n",
+    "from sklearn import preprocessing, grid_search\n",
+    "from sklearn.linear_model import SGDClassifier\n",
+    "from sklearn.cross_validation import train_test_split\n",
+    "from sklearn.metrics import roc_auc_score, roc_curve\n",
+    "from sklearn.pipeline import Pipeline, make_pipeline\n",
+    "from sklearn.preprocessing import StandardScaler\n",
+    "from sklearn.feature_selection import SelectKBest\n",
+    "from statsmodels.robust.scale import mad\n",
+    "from sklearn.ensemble import VotingClassifier\n",
+    "from sklearn.ensemble import AdaBoostClassifier\n",
+    "from sklearn.tree import DecisionTreeClassifier\n",
+    "from sklearn.decomposition import FactorAnalysis\n",
+    "from sklearn.externals import joblib\n",
+    "from sklearn.svm import SVC"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "plt.style.use('seaborn-notebook')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Specify model configuration"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# We're going to be building a 'TP53' classifier \n",
+    "GENE = '7157' # TP53"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# SGDClassifier Parameter Sweep\n",
+    "sgd_n_feature_kept = 500\n",
+    "sgd_param_fixed = {\n",
+    "    'loss': 'log',\n",
+    "    'penalty': 'elasticnet',\n",
+    "}\n",
+    "sgd_param_grid = {\n",
+    "    'alpha': [0.1],\n",
+    "    'l1_ratio': [0.0],\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# AdaBoost Parameter Sweep\n",
+    "adaboost_n_feature_kept = 5000\n",
+    "adaboost_param_fixed = {\n",
+    "    'algorithm': 'SAMME.R',\n",
+    "    'base_estimator': DecisionTreeClassifier(max_depth=1)\n",
+    "}\n",
+    "adaboost_param_grid = {\n",
+    "    'learning_rate': [0.5],\n",
+    "    'n_estimators': [50]\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Parameter Sweep for Hyperparameters\n",
+    "pca_n_feature_kept = 2000\n",
+    "pca_param_fixed = {\n",
+    "    'loss': 'log',\n",
+    "    'penalty': 'elasticnet',\n",
+    "    'n_components': 500,\n",
+    "}\n",
+    "pca_param_grid = {\n",
+    "    'alpha': [0.1],\n",
+    "    'l1_ratio': [0.0],\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "*Here is some [documentation](http://scikit-learn.org/stable/modules/generated/sklearn.linear_model.SGDClassifier.html) regarding the classifier and hyperparameters*\n",
+    "\n",
+    "*Here is some [information](https://ghr.nlm.nih.gov/gene/TP53) about TP53*"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 3min 42s, sys: 6.82 s, total: 3min 49s\n",
+      "Wall time: 3min 53s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "path = os.path.join('..', 'download', 'expression-matrix.tsv.bz2')\n",
+    "X = pd.read_table(path, index_col=0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 2min 33s, sys: 6.57 s, total: 2min 40s\n",
+      "Wall time: 2min 42s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "path = os.path.join('..', 'download', 'mutation-matrix.tsv.bz2')\n",
+    "Y = pd.read_table(path, index_col=0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "y = Y[GENE]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "sample_id\n",
+       "TCGA-02-0047-01    0\n",
+       "TCGA-02-0055-01    1\n",
+       "TCGA-02-2483-01    1\n",
+       "TCGA-02-2485-01    1\n",
+       "TCGA-02-2486-01    0\n",
+       "TCGA-04-1348-01    1\n",
+       "Name: 7157, dtype: int64"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# The Series now holds TP53 Mutation Status for each Sample\n",
+    "y.head(6)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0    0.645907\n",
+       "1    0.354093\n",
+       "Name: 7157, dtype: float64"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Here are the percentage of tumors with NF1\n",
+    "y.value_counts(True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Set aside 10% of the data for testing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Size: 20,468 features, 6,575 training samples, 731 testing samples'"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Typically, this can only be done where the number of mutations is large enough\n",
+    "X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=0)\n",
+    "'Size: {:,} features, {:,} training samples, {:,} testing samples'.format(len(X.columns), len(X_train), len(X_test))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Median absolute deviation feature selection"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def fs_mad(x, y):\n",
+    "    \"\"\"    \n",
+    "    Get the median absolute deviation (MAD) for each column of x\n",
+    "    \"\"\"\n",
+    "    scores = mad(x) \n",
+    "    return scores, np.array([np.NaN]*len(scores))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## SGD Calssifier¶"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# joblib is used to cross-validate in parallel by setting `n_jobs=-1` in GridSearchCV\n",
+    "# Supress joblib warning. See https://github.com/scikit-learn/scikit-learn/issues/6370\n",
+    "warnings.filterwarnings('ignore', message='Changing the shape of non-C contiguous array')\n",
+    "\n",
+    "sgd_clf = SGDClassifier(random_state=0, class_weight='balanced',\n",
+    "                        loss=sgd_param_fixed['loss'], penalty=sgd_param_fixed['penalty'])\n",
+    "\n",
+    "sgd_pipeline = make_pipeline(\n",
+    "    SelectKBest(fs_mad, k=sgd_n_feature_kept),  # Feature selection\n",
+    "    StandardScaler(),  # Feature scaling\n",
+    "    sgd_clf)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## AdaBoost Classifier"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Include loss='log' in param_grid doesn't work with pipeline somehow\n",
+    "adaboost_clf = AdaBoostClassifier(random_state=0,\n",
+    "                                  base_estimator=adaboost_param_fixed['base_estimator'],\n",
+    "                                  algorithm=adaboost_param_fixed['algorithm'])\n",
+    "\n",
+    "adaboost_pipeline = make_pipeline(\n",
+    "    SelectKBest(fs_mad, k=adaboost_n_feature_kept),  # Feature selection\n",
+    "    StandardScaler(),  # Feature scaling\n",
+    "    adaboost_clf)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## PCA Classifier"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Include loss='log' in param_grid doesn't work with pipeline somehow\n",
+    "pca_pipeline = make_pipeline(\n",
+    "    SelectKBest(fs_mad, k=pca_n_feature_kept),\n",
+    "    FactorAnalysis(n_components=pca_param_fixed['n_components']),  # Feature selection\n",
+    "    StandardScaler(),  # Feature scaling\n",
+    "    sgd_clf)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Voting Classifier"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/sharimoskow1/anaconda/envs/cognoma-machine-learning/lib/python3.5/site-packages/sklearn/externals/joblib/parallel.py:540: UserWarning: Multiprocessing-backed parallel loops cannot be nested, setting n_jobs=1\n",
+      "  **self._backend_args)\n",
+      "/Users/sharimoskow1/anaconda/envs/cognoma-machine-learning/lib/python3.5/site-packages/sklearn/externals/joblib/parallel.py:540: UserWarning: Multiprocessing-backed parallel loops cannot be nested, setting n_jobs=1\n",
+      "  **self._backend_args)\n",
+      "/Users/sharimoskow1/anaconda/envs/cognoma-machine-learning/lib/python3.5/site-packages/sklearn/externals/joblib/parallel.py:540: UserWarning: Multiprocessing-backed parallel loops cannot be nested, setting n_jobs=1\n",
+      "  **self._backend_args)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 4min 51s, sys: 24.7 s, total: 5min 16s\n",
+      "Wall time: 23h 39min 26s\n",
+      "... done 100_0_0 ...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/sharimoskow1/anaconda/envs/cognoma-machine-learning/lib/python3.5/site-packages/sklearn/externals/joblib/parallel.py:540: UserWarning: Multiprocessing-backed parallel loops cannot be nested, setting n_jobs=1\n",
+      "  **self._backend_args)\n",
+      "/Users/sharimoskow1/anaconda/envs/cognoma-machine-learning/lib/python3.5/site-packages/sklearn/externals/joblib/parallel.py:540: UserWarning: Multiprocessing-backed parallel loops cannot be nested, setting n_jobs=1\n",
+      "  **self._backend_args)\n",
+      "/Users/sharimoskow1/anaconda/envs/cognoma-machine-learning/lib/python3.5/site-packages/sklearn/externals/joblib/parallel.py:540: UserWarning: Multiprocessing-backed parallel loops cannot be nested, setting n_jobs=1\n",
+      "  **self._backend_args)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 6min 6s, sys: 28.6 s, total: 6min 34s\n",
+      "Wall time: 9h 33min 11s\n",
+      "... done 0_100_0 ...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/sharimoskow1/anaconda/envs/cognoma-machine-learning/lib/python3.5/site-packages/sklearn/externals/joblib/parallel.py:540: UserWarning: Multiprocessing-backed parallel loops cannot be nested, setting n_jobs=1\n",
+      "  **self._backend_args)\n",
+      "/Users/sharimoskow1/anaconda/envs/cognoma-machine-learning/lib/python3.5/site-packages/sklearn/externals/joblib/parallel.py:540: UserWarning: Multiprocessing-backed parallel loops cannot be nested, setting n_jobs=1\n",
+      "  **self._backend_args)\n",
+      "/Users/sharimoskow1/anaconda/envs/cognoma-machine-learning/lib/python3.5/site-packages/sklearn/externals/joblib/parallel.py:540: UserWarning: Multiprocessing-backed parallel loops cannot be nested, setting n_jobs=1\n",
+      "  **self._backend_args)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 6min 1s, sys: 27.7 s, total: 6min 28s\n",
+      "Wall time: 3h 57min 13s\n",
+      "... done 0_0_100 ...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/sharimoskow1/anaconda/envs/cognoma-machine-learning/lib/python3.5/site-packages/sklearn/externals/joblib/parallel.py:540: UserWarning: Multiprocessing-backed parallel loops cannot be nested, setting n_jobs=1\n",
+      "  **self._backend_args)\n",
+      "/Users/sharimoskow1/anaconda/envs/cognoma-machine-learning/lib/python3.5/site-packages/sklearn/externals/joblib/parallel.py:540: UserWarning: Multiprocessing-backed parallel loops cannot be nested, setting n_jobs=1\n",
+      "  **self._backend_args)\n",
+      "/Users/sharimoskow1/anaconda/envs/cognoma-machine-learning/lib/python3.5/site-packages/sklearn/externals/joblib/parallel.py:540: UserWarning: Multiprocessing-backed parallel loops cannot be nested, setting n_jobs=1\n",
+      "  **self._backend_args)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 6min 13s, sys: 25.7 s, total: 6min 38s\n",
+      "Wall time: 20h 34s\n",
+      "... done 0_50_50 ...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/sharimoskow1/anaconda/envs/cognoma-machine-learning/lib/python3.5/site-packages/sklearn/externals/joblib/parallel.py:540: UserWarning: Multiprocessing-backed parallel loops cannot be nested, setting n_jobs=1\n",
+      "  **self._backend_args)\n",
+      "/Users/sharimoskow1/anaconda/envs/cognoma-machine-learning/lib/python3.5/site-packages/sklearn/externals/joblib/parallel.py:540: UserWarning: Multiprocessing-backed parallel loops cannot be nested, setting n_jobs=1\n",
+      "  **self._backend_args)\n",
+      "/Users/sharimoskow1/anaconda/envs/cognoma-machine-learning/lib/python3.5/site-packages/sklearn/externals/joblib/parallel.py:540: UserWarning: Multiprocessing-backed parallel loops cannot be nested, setting n_jobs=1\n",
+      "  **self._backend_args)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 6min 24s, sys: 28.7 s, total: 6min 52s\n",
+      "Wall time: 5h 47min 47s\n",
+      "... done 50_0_50 ...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/sharimoskow1/anaconda/envs/cognoma-machine-learning/lib/python3.5/site-packages/sklearn/externals/joblib/parallel.py:540: UserWarning: Multiprocessing-backed parallel loops cannot be nested, setting n_jobs=1\n",
+      "  **self._backend_args)\n",
+      "/Users/sharimoskow1/anaconda/envs/cognoma-machine-learning/lib/python3.5/site-packages/sklearn/externals/joblib/parallel.py:540: UserWarning: Multiprocessing-backed parallel loops cannot be nested, setting n_jobs=1\n",
+      "  **self._backend_args)\n",
+      "/Users/sharimoskow1/anaconda/envs/cognoma-machine-learning/lib/python3.5/site-packages/sklearn/externals/joblib/parallel.py:540: UserWarning: Multiprocessing-backed parallel loops cannot be nested, setting n_jobs=1\n",
+      "  **self._backend_args)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 5min 44s, sys: 25 s, total: 6min 9s\n",
+      "Wall time: 20h 52min 35s\n",
+      "... done 50_50_0 ...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/sharimoskow1/anaconda/envs/cognoma-machine-learning/lib/python3.5/site-packages/sklearn/externals/joblib/parallel.py:540: UserWarning: Multiprocessing-backed parallel loops cannot be nested, setting n_jobs=1\n",
+      "  **self._backend_args)\n",
+      "/Users/sharimoskow1/anaconda/envs/cognoma-machine-learning/lib/python3.5/site-packages/sklearn/externals/joblib/parallel.py:540: UserWarning: Multiprocessing-backed parallel loops cannot be nested, setting n_jobs=1\n",
+      "  **self._backend_args)\n",
+      "/Users/sharimoskow1/anaconda/envs/cognoma-machine-learning/lib/python3.5/site-packages/sklearn/externals/joblib/parallel.py:540: UserWarning: Multiprocessing-backed parallel loops cannot be nested, setting n_jobs=1\n",
+      "  **self._backend_args)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 4min 51s, sys: 24.7 s, total: 5min 16s\n",
+      "Wall time: 21h 52min 1s\n",
+      "... done 33_33_33 ...\n"
+     ]
+    }
+   ],
+   "source": [
+    "prefixes = [\"sgd__sgdclassifier\", \"adaboost__adaboostclassifier\", \"pca__sgdclassifier\"]\n",
+    "param_grids = [sgd_param_grid, adaboost_param_grid, pca_param_grid]\n",
+    "weights = [(1.0, 0.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, 1.0),\n",
+    "           (0.0, 0.5, 0.5), (0.5, 0.0, 0.5), (0.5, 0.5, 0.0),\n",
+    "           (1.0/3, 1.0/3, 1.0/3)]\n",
+    "\n",
+    "param_grid = {}\n",
+    "for prefix, orig_param_grid in zip(prefixes, param_grids):\n",
+    "    param_grid.update(dict(zip([\"%s__%s\" % (prefix, p) for p in orig_param_grid.keys()],\n",
+    "                                orig_param_grid.values())))\n",
+    "\n",
+    "for weight in weights:\n",
+    "    \n",
+    "    param_grid.update(dict(weights=[weight]))\n",
+    "    \n",
+    "    estimators = [('sgd', sgd_pipeline), ('adaboost', adaboost_pipeline), ('pca', pca_pipeline)]\n",
+    "    voting_clf = VotingClassifier(estimators=estimators, voting='soft') \n",
+    "    assert np.all([p in voting_clf.get_params().keys() for p in param_grid.keys()])\n",
+    "\n",
+    "    voting_grid = grid_search.GridSearchCV(estimator=voting_clf, param_grid=param_grid,\n",
+    "                                           n_jobs=-1, scoring='roc_auc')\n",
+    "    %time voting_grid.fit(X=X_train, y=y_train)\n",
+    "\n",
+    "    weight_name = \"_\".join([\"%i\" % (100 * w) for w in weight])\n",
+    "    print (\"... done %s ...\" % weight_name)\n",
+    "    joblib.dump(voting_grid, \"../results/voting_clf_%s.pkl\" % weight_name)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Reload Estimators"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "weights = [(1.0, 0.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, 1.0),\n",
+    "           (0.0, 0.5, 0.5), (0.5, 0.0, 0.5), (0.5, 0.5, 0.0),\n",
+    "           (1.0/3, 1.0/3, 1.0/3)]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   sgd_weight  adaboost_weight  pca_weight     score\n",
+      "0    1.000000         0.000000    0.000000  0.885522\n",
+      "1    0.000000         1.000000    0.000000  0.909627\n",
+      "2    0.000000         0.000000    1.000000  0.921895\n",
+      "3    0.000000         0.500000    0.500000  0.924802\n",
+      "4    0.500000         0.000000    0.500000  0.915533\n",
+      "5    0.500000         0.500000    0.000000  0.891402\n",
+      "6    0.333333         0.333333    0.333333  0.917108\n"
+     ]
+    }
+   ],
+   "source": [
+    "sgd_weights = []\n",
+    "adaboost_weights = []\n",
+    "pca_weights = []\n",
+    "mean_scores = []\n",
+    "\n",
+    "for weight in weights:\n",
+    "    weight_name = \"_\".join([\"%i\" % (100 * w) for w in weight])\n",
+    "    sgd_weights.append(weight[0])\n",
+    "    adaboost_weights.append(weight[1])\n",
+    "    pca_weights.append(weight[2])\n",
+    "    mean_scores.append(joblib.load(\"../results/voting_clf_%s.pkl\" % weight_name).grid_scores_[0].mean_validation_score)\n",
+    "\n",
+    "result_dat = pd.DataFrame(dict(sgd_weight=sgd_weights, adaboost_weight=adaboost_weights,\n",
+    "                               pca_weight=pca_weights, score=mean_scores))\n",
+    "result_dat = result_dat[['sgd_weight', 'adaboost_weight', 'pca_weight', 'score']]\n",
+    "print (result_dat)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Use Optimal Hyperparameters to Output ROC Curve"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "optimal_weight = (0.0, 0.5, 0.5)\n",
+    "weight_name = \"_\".join([\"%i\" % (100 * w) for w in optimal_weight])\n",
+    "best_clf = joblib.load(\"../results/voting_clf_%s.pkl\" % weight_name)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "y_pred_train = best_clf.best_estimator_.predict_proba(X_train).T[1]\n",
+    "y_pred_test = best_clf.best_estimator_.predict_proba(X_test).T[1]\n",
+    "\n",
+    "def get_threshold_metrics(y_true, y_pred):\n",
+    "    roc_columns = ['fpr', 'tpr', 'threshold']\n",
+    "    roc_items = zip(roc_columns, roc_curve(y_true, y_pred))\n",
+    "    roc_df = pd.DataFrame.from_items(roc_items)\n",
+    "    auroc = roc_auc_score(y_true, y_pred)\n",
+    "    return {'auroc': auroc, 'roc_df': roc_df}\n",
+    "\n",
+    "metrics_train = get_threshold_metrics(y_train, y_pred_train)\n",
+    "metrics_test = get_threshold_metrics(y_test, y_pred_test)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAiAAAAGbCAYAAAD9bCs3AAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAAPYQAAD2EBqD+naQAAIABJREFUeJzs3Xd8ZGXZ//HPJNndZLNk+7ILS1W4QMpSRBCkK4qoCCLK\ng0oRHxXXHwj4KCCiUpSqSLUBIigCCkiR3ntf+gULLLC9J7vZZNPm98d9JjmZTJKZyWQm5ft+vfa1\nc86ccueeM3Ouc9dEMplEREREpJjKSp0AERERGX4UgIiIiEjRKQARERGRolMAIiIiIkWnAERERESK\nTgGIiIiIFJ0CEBERESk6BSAiIiJSdApAREREpOgqSp2AUjOzh4A90lY3AwuB24CfufvKfjr3kcCV\nwMbu/oGZnQ783N3Ls9x/feAPwLHu/kG07j3gQXc/uj/SHDv3g8CevWx2tbsfnWsem9lcYL207ZPA\nZHdfHm3zSeBsYEdgNXAjcKq7r87vL+obMxsL/B74k7s/lsN+JfsMo3NtDfwN2BKY7e5b9/c5ZfAx\nszbgF+7+qyKe81bgVne/MvptPD3DZmuAucBNwOnu3pp2jG2AHwN7A5OBRcDjwO/c/Zluzvtx4P8R\nft8mA/OB+4Ffu/ucAvxpA5aZbQ7cBWzn7nX9fb5hH4AQbmwvAN8HEtG6kYQb26+B7YBP9eO542Ph\n/wn4bw77fxrYP23dl4F+v3AI+VUTW76c8LfE83FJ9H/WeWxmEwnBx4mEH4q4ldE22wL3AfcCB0fb\nnwNsTtf8KJbtgG8Cf8lxv1J+hhB+1DcADqTj8xJJtwvhRl8U0cPZ+u5+ZWx1MkpHIrZuEnAYcApQ\nDpwcO8Y3CN/H56P35wDTgW8Dj5vZj939d2nn/QHwW+AB4CeE4GMz4P+Ar5jZ3u7+SsH+0AHG3d8y\ns1uAi4Ej+vt8CkCCOnd/Nm3dY2a2DvBLM/tEd9FyIbn7fMIFn61E+gp3n1W4FHXP3d+ML5tZHZDM\nkI8p2ebxdoQfmpt7eNo4HlgKHOLuLdH5E8CVZraZu7+d31/VJwk6B5O57NdJsT7DyETgFXe/u4jn\nlEGmGL9/KWZWCfwG+F6GdGT6fbnTzD4CHEUUgJjZ9oTg42p3/27a9v8ws98CF5jZy+7+QLTPbsDv\ngN+7+4mx7R+JSmNeJJRY79SnP3DgOwf40Mx+6+4v9eeJFID07DnCDWIj4Jmo2mEuUEl4an3c3T9r\nZqOAM4CvA1MAB85y9xtSB4pukKcC3yFE7fcAj8RPZma/IFTBlMXWfZNww92CcNO9jvDU+j+EL0MS\nmGNmqeqOOcAD0euNgPeAQ4GvAZ8lVH38CzjO3Ruic1QAZwKHE25IDwH/AP5KVD3Ul0zsRac8JgQg\nq3op6jwVuDAVfESao/8ru9vJzK4CpgL/JjzdrEcomTkKMEKVzkeAV4DvpgKBqAqpzd33iR1rT+BB\nYK8o/Q8QPouHzOwhd9/HzMoIxb/fiI7bBswiVBU9ZGZH0MtnGJ2rBvgF8CVgfWB29PdfFUvPe4TP\nazTwLULp1MPAD919djf50RadO2FmrVE+JIA/E378zwRGAJ9y9zfN7GvASYRrcTVwC3ByqvosKib/\nOuEmcAbwUeBNQskXhB/3bYF3CNffA5k/qeyvSTPbPTrXTkAjoUrvJHdfGr1/RPT3pG4u2xOK4S92\n9wti5+v1O9xNOscTbpYHAmOBlwifb+qm9kPgIuBId78mWrc3oQTv5+5+VnRdbkz4bp8GTACeBk5w\n95fT/o5Mn8uBwM+ArQmlhP8ETnH3NdG+lcCFwBcJVQrvAX9O+/uPi469MbAMuBX4qbuvit7vVAVj\nZlMJ35dPE37PXgHOdPfbYsdsA34A7EAoqRxBKOGd6e49lbZ9GxgF3NFT3qeppfMDwCnAKuC4brb/\nP+Ag4OeE7y6E7+oKwu9LJ+6+1Mx+BJiZVaV+O9NF+XIO8DmgivD78lN3fyr2e9x+LUT7XA3s6e6b\nRMvp95kngA0JDwpfTTvfS8B77n5QtNzna8HdF5nZA4Tv8de6yb+CUCPUnm1BuKjjP+BfIxSPfxE4\nN1p3C/C/wPnR+seB66MiwJTzCD8ufyQUsS8l/HDFdaqSiYoD/wo8G+1zNqFu8vfA7YQfIqL3zogd\nI90VhAvtwCjN3yZcpCl/jI57UbTNomhdMaZKTs/j7YAVZnaTma00s1Vmdn30xQbA3Re4+6sAZjba\nzD4NnAU8lkXx6K6EH8XjgSOBjwF3AhcQ8vNrhC/7tbF9usuH1Prno2NCuNkeG70+h5DPlxOCv2MI\nN5cbox+CO+jlM4y2e5xQzPwbQhDyCPAXM/tpWnqOI+TnEYTP+OOE66c7uxBumC9Er1M/+OXACcDR\nwI+im9zPgL8TfgwPJgREhwAPRjfvlA0I34MzovfHE+rnryNcUwcSgpx/pO2Xrtdr0sz2INzIVwNf\njf7+vYAH0o5dRvgh/jvhB/1R4Dwz+0xsm2y+w51E53gw2v5kwg3tQ+AuM9sLwN0vJnxe55vZhKjE\n76ro+GfHDrddlGenEYKuSYRgdt3YNpk+l/8BbgZej/LpdEJV4C2x/S4iXH8nAPtF750bBTWY2WGE\na/Xi6P1fRsf4fTd/9xTCg8OngJ8Srof3gFuiY8WdRcj/VPD6RUIg2JPDgTvcvTn9DTMrj/0bYWbr\nmdlPonT/NdomAXwGuM/dGzOdIDr2zcCnoiCS6Bj397DPTe5+Vg/BRzXh+7Fn9LceRGijck9UQtOd\n9Kp46HyfOYfwe7R/dI7U+bYkBPSpwLbP10LMjcCBZja6h3T3mUpAgoSZxRt+TiD8kJ0KPOHuL8be\nWwt8L/XliH7EPgsc6u43Rdvca2ZjgN+Y2d+BdYAfAue7+1mxbdaP9u0i+hKdBvzb3b8XWz+aUPqx\nkvAkCfBSL6UUt7v7/0WvHzSz/YAvAKdGX4wjCE9bF8XSNpVwgRZKtnm8HaFk4gpCXeyWhB/mh8xs\n+wxf/qWEp6VlhBtWb8YAX01V00Q3iu8C+7j7w9G68wk3qJpsGmK5+2ozez1afCNWPTWVUEJwWWpb\nM1tLuCFv6+7PmFlvn+FRhCDpk7Fi8HvNbCRwmpldEWvAuxw40N2T0bk+CvzCzMa7+4oM6X7G0qrO\nzAzCj+GZ7v7faN04wud0hbu3P1Ga2WuEm+tRhM8LwlPf99393mibrQjtfI5299QN4ueEHzgDXk5P\nl5ltSnbX5K8J+f2F2L5PAW8QbtKXR6sTwC/d/epomyeArxC+A/dm8x1297b0dBJKmrYBdnb356J1\nd0UlZucAO0frjiKUfJ0HtALjCE+88ZtODXCAuz8RpfEZ4F1CUHVKtE2nzyXyG+BOd2+/gZjZ28D9\nZrZ/tO0ewL3ufmO0ySNmthpYHC3vAbwbu04fjd6fkOFvhtA+ayKwi7un2oXcZaH91vmEkqqUl939\n27G07UwITDOK8nwn4PoMbyfoKOmMe5/wW3lOtDyBkJ9zujtPZHZ0zA2j36ZKQiCVr6MIDy/bpx6E\nzOxxQtXNnoSGrNlKv8+8QwgMv0wI5iE8lKwgPIxCYa6FlGcJ7fR2B/qtelYBSLAnXS/sVkIjx/T6\nwzfSIvN9CEXrd6bdYG8jRPJbA9MIeX07nd1ANwEIoUHlFEJE287df0u4MaduFtl4Km15LqHKA0Lr\ncAg3xbh/UNgAJNs8PgZocffno+XHo5v7Y4Qf/D+kNoyK6b9I+OE4mfDDuVsvpSAr0tqILIr+j9dx\nL4v+H0cfGoO6+zejdE4i3Gw3i9ILIWjKxp7AnAx18NcSSjl2IbRaB3g27aaWujlUE36ochFvh7IL\n4ceo003B3R8zs/cJgeQVsbeejL3uLX8z6fWaNLMqwg3+3LTv3RxCAPIZOgKQJLHvgLs3mdkSQr4A\n7Ev33+FvEL7DXQIlwnd/IfBibL8E4Xt+jpmNdfdad38vekq/JNrmSHd/P+1Y76WCjyiNC6NAKb2n\nWfvnYuEHYDpwVlq6HyVct58hVHk8CHzPzDYglPbdEXsQInr/u2b2AuH35k53jwcR6fYkPDSkN0q9\nltAOa4tYEJ7pt6ea7m1IKOnJFAgkCaV6iegYPyJcKz909/hva6pdVaZgJS5VhZuIvc6qB2I3diN8\nju2/P1FpypYAURVMtjrdZ9x9ThTMfJ2OAOTrwA3u3lzAayFlTvT/JjmkOWcKQILnCcWvqYaEjcAH\n7l6fYdv0bp4TCUWMmbp/thGe5lNFfEvT3l/QQ5omRv+nR6b5WJMhXanqt0ndnGcRhZVVHrv70+k7\nuvsTZlYLzEhb30L0VGFmjxK+NMcRgpjuZAwouitW7QsL3fkuI/xo1gOvAalSji6NT7sxgXCTS5da\nF7+JZ/qcIb+q1vj1nHoS7i4dnQIJz9wVOtN3qTuTo/97uibHE/6unxCqAeKSGc7X03dgAr1/hzMF\nIBMJDxfpN7pUkfo0QtsECFVAF0br781wrHkZ1i0mtFmJi6cx9RtxGR3BVjwNqa7sxxGqhr5BqFa5\n2MyeJJRUvezuN0QlrscSShJ+aaEd0k9iT8pxE+gofY3L9prs6dofG/2f8XqJl0ab2WOEKrh/mdk+\n7v54tM1SM6sntGfpSapa5AN3X2lmq+h4MOsiKn0e6d0PyzCRwvxeQ+Zr8W+Ez248Ie0fJVQjp84N\nfbwWYvuk8n8s/UgBSLAqrZolFysJjZ32IvMXazbhSS0BrAvEn74nZtg+flzo+DEGwMwmEBp1pXdR\nzVfqKWZdOnezm1Kg46f0mscWGlt+BXjG3V+LrU8QnsCXRMtfAGrd/dHUNu5eFxVTpo8fUghJuj4Z\njelph6iu/7+ENhZburtH6/cn/I3ZWk7HD2XctOj/YnSdXU64fqfS+fpNpSPTzagvsrkm6wify4V0\nLvJPSb/x9SSb73B3+71FKArPtF/8Kf4SQprXErrbfzFt20l0tS4939BSvxEnERocp1sB7e0dfg38\n2symR+f+OeFJeptom38C/4yu2/0Igd21Zvaou6cHnssJ10K61HevL9dk6iGtu9Kxdu6eNLOjCG0e\nrjazrdy9KXr7NkKbidGpBphxFhqIf5nQbmx5tPpuYG8zGxk7Ttz/EtryfNwz9w5ZSYagx8KYRSvo\nuCZz+i2JuYHQhuMgQqlKvNSsYNdCpLuH5oJSI9S+e5hwAZW5+wupf4Sn9V8QgrwngAZCQ7m4L/Vw\n3DcJH376D9URhMaCIwlVGH31OOGp5KC09bncJAtlLeGHOv2J9kBCNUuqtfqPgMuiwASA6Mv0MTpX\nHRRKHaF4M273tOVWOt+EtiAEmL9PBR+Rz0f/l8X268nDwMZR3XncNwn51V2350J6OjpXpwaGFnqg\nbEgo5i2kXq/JqJTlBWCLtO/d68CvCMFEtrL5Dne33wbAkrT9Pke4gae6iB9MKC4/ntAW7IAMjf42\nt1idqpmtR2gwfV8P6X6TEKBsmnb+BYT2ENubWaWZuZmdAODuc939ckLQtlF0ruvN7N/R+6vc/V+E\nxtEVZA7oHwZ2jYrx474BLHT3vgSk8wjfifRjZxS1m/oVIUj/SeytswnVNH+Igo10v472iVc/XEAI\nBM9M3zhqf3Qi8Go3wQeE78GmFhqHpvarJPS6O5qO0tfpsfdHAJ/o4U9s5+61hN/+AwntaOIN5Qty\nLcSk0pheVVhQKgHpuzsJF95/zOwMQv3zzoQGQ3d6x8idZwBnmNkawo30AEIjuIzcvc1Ct8ZLovrq\n/xBuar8gdCGsNbOVhJveV8zszrQbXVai+ukrCRHxKMIN/OBY2jI1vusX7r7WzH5DaDi5mJC32xJa\nc9/iUSNRQqPUe4AbzOyPhCfjnxHaFlzYD0m7HfiimV1A+Bx2JwQAcaknkC9En4sTfnBOtdDFtZnw\no5FqkFcd26+nz/BqQg+bW6LrIdWb6UhCt8h+H7DM3VdEn8tpZtZCeLrclPDD/ypRK/wcdVsMn8M1\neQpwh5ldS3iCqyA8Ae4UpS1bWX2HM7gKmAncZ2ZnE6rX9iN08bzI3Vuj9j+XA/9NtauwMNDT78zs\nXg9j/0AISG+z0NuolXDNLyX0TMko+o04FbjCQpfX2whPrj8jdNd+3t0bzex54Odm1kSoStqCcP2k\nqlceAC43s/OivJgQnf8tMgf0FxKCjfvN7JeE792RhKDvqO7Smw13XxO1dfgU4Wk/G78lVLv+xEJX\n9g/d/VXrGGn6o2Z2GeG7My1K42eA/3P3e2LnftrMTiP8Tn+M0KtmKaFk4CRCu61De0jHVYSG8P+J\nvqtLCUHnCOCSqJrnCeCHZjabUJJ0HOHhKtsqyr8RhlEoi16n0l6oayFl9yhNhX646EQlIEEu3U07\nbRs1+tufEEWeTGgQmOrOd1hsu98QLsZDCH3styZ0her2+FF0eiThi30b4WL9NeEHDkKDonsJ0f75\n3aSxty6kEJ7KriBE+LcQLthUl9BchjbvKR+zymN3P4NQF/0Zws3+R4R6zf+JbfNQ9P4UwhfnIkK3\nwE96z+MLdJeO3tJ2JeEp4jDCE8gudC0heo3QzfMHwLVRYPAlwo32BsJNejrhi72KjhKUHj/DqG3K\nHoTP/1eEa2dXQq+SM9K2z7fbdK/7ufsvCZ/L3oTP5TRCu4bd09rPZJuG3rbr9Zr00NPms4R8vZFw\nw2gC9s3QaDfT+VN5nNV3OF1UtL874Uf6HMLN+8uEG1tqIKtLCTeY+KBaM6P//xxb9350vt9G698E\nduuhvUEqDX+J0vhJwudyKaFKbM9YQ9fvEG6OJxKqGU4ldGk+NjpGqsvz5wjX2RWEwHI/7xjaPJ5f\niwjX4POEdgQ3Ej6DL3lsfAu6vyZ7++xvIqoKyWa/qFrheEIPrPh4Fv8kjLb8MuHB7R5CHi8HdvXY\n2Bexfc4mlFImCZ/FHYTv9H8IvVve6i7RUanc7oSGtxcTvh8JYC/v6OF2BOG36k+Ez+R5MndL7i6P\n7iRUpzzjaeP7FOJaiPkcoffk2u7+3kJIJJPFGOpBBqqoQdP+hCe0FbH15xFa60/udmeRfjDcrkkL\nA5Ht6e6bljotA4GFHk7vEAK5a3vbXgor6q0zG9gxrWFqwakKRtYQnmJeNLPfEZ4udyU8pWXqniXS\n33RNDmPu3mBhVOiTzOw679y1XPrfScA/+zv4AFXBDHtREds+hEayVxGK+A4jDALVpTGWSH8bptek\nbrIxUbXQXHruUi8FFjWE/gId1YT9SlUwIiIiUnQqAREREZGiUwAiIiIiRadGqCIDmJndQ+hKuK6H\noeczbfMKsMzd98rymOsT5tQ51jumtX8PeNDdjy5IwrNLx76E7n87E8Ys+JDQffC8VHdq62YK8yKk\nrVPPlCjP/kEYY6SWMJbEHYQulo8UK10iQ4lKQEQGtisJw1J/PtObZrYDsBVhXIFsfZrQzTXuy3SM\ns9HvooHN7iGM2/H/CH/fpYQJHJ+Kbvil9Cs6j8R6PCFQ+ka0/lHCeDAvFD9pIkODSkBEBrabCaOl\nHk4oHUh3BOGJ/F85HLPLKKTu3h9D2GdkZl8nDKZ3nLvHR/p82Mz+S5i+/CJ6mLa9v7l7+mysE4H5\n0TDlKb0NdiYiPVAAIjKARcPT/x042szGeGymWTOrIMwx8ncP036n1n+N0Jd/C8IYGrcAJ0dDQR9B\nKFVJAnOioauPtjD76QPR61S1x6HA1wijjTYTgpzjUiOfRuc/kxAcTQQeIlRT/BXYODb6Y7qfAq+l\nBR+pv3e2mZ1ED1O2m9kehGHYPxFtNw/4azRaa2qbwwhzg2we5cHdhIGtFkTv7wCcS5ipuIww383P\nPJqN2cyuBvZw902j6qkNgUQ0rP4vCfOhPEisCsbMtgZ+Q8cot/cDJ6aCGTPbM9rne1H6xwFfcff7\nu/tbRYYyVcGIDHxXEoaZTh/+/fOEybPah/SO5hL5O2ECxIMJQ1AfAjwYzatyBx2TbcWrXTL1x7+C\njrlnziXMY/Oz2PupIbwvirZZFK3rtm+/ma1LmN/n9u62cfc/uHvGOX3MbAZhgrbFhADpC8AjwOlm\ndmi0zW6Eoe9vJAwpfTywLyFfUjMV3xUd4yBCkFUN3BW9l54fXybMbLyAUO3y5/RtzGxzwiR6kwjz\nBB1NmC/n8Wg+mLifE6Zh+AHhcxIZllQCIjLAufuLZvYSoaThr7G3jgBedvcXAcxsHGFuhyvc/bjU\nRmb2GuEmfZS7X2FmqdlKX+qhlALCXBDt8w6Z2X6EG/6pZvaR6PwnuHtq0rB7o1lD9+vhmKlZTtOr\nOLK1DXC3u38rtcLM7iMEQHsR5t35FGEirXOjeUIws2WEBqQQZk2eRJip+Kno/TcJ87+sQ5irp527\nz4omhFzr7s9G229G56qs06Nz7uvu9dE290d/54/pPFPrpe7+7zz/fpEhQwGIyOBwJfBbM5vq7guj\n+VIOIEwqlbILMBK4Pr6juz9mZu8TbtBX5HDOp9KW59Ixbffe0f83pW3zD3oOQFI9ecpzSEe7aG6Q\na6PSnM2BzYDtCL9lo6LNHiYM2f6amd1EGEn1Xne/O3r/VWAJYSbdGwjVM/e4+8n5pCmyD6F6pdHM\nUn/bakJj1c/QOQApWnsbkYFMVTAig8N1hJv316PlwwjT0l8X22ZC9P/CDPsvJLQ5yMWatOU2On4z\nUtUKi9O2WdTLMT8gVF1s1N0GZjbOzDK2ATGzSjP7M6Hh7YuEWWg3IrRRSQBEpRr7EyY0+xGh9Gee\nmc2M3q8nlJLcTqjG+RewxMwuN7MRvaS/OxMJVTnNsX9NhCBxWmy7JLnNMC0yZCkAERkEollhbwH+\nJ1r1TeDmtOnalxNuwlMzHGIasLSASZob/b9u2vopPe3k7ssJU5CndwOO+wWw1MwyzXr7e0LblkOA\nddx9M3c/gnDDj5/nXnffnzC+yBcIU7JfZGY7Ru+/He03iTDR3VXAdwltWvKxklDytCOhYWvq306E\nRrwikkZVMCKDx5WEhpJ7EMakOCXt/aeBtYTSkUdTK81sd0IvjtS61gKk5XFCichBQLw3S3pD2UzO\nA643s5nufkn8DTP7GGGQr3vcfUnUIyduN8KAabfH9tkRmEz0QGVm5xEGEftE1DvoTjObC7wEbGRm\nGwOXA1u7+2JCvj1tZv9DDyUzGcQbqj5MaFsyy93bYmn7O+CEAEhEYhSAiAwe9xFGC/0j8K67Pxh/\n091XRAN8nWZmLcBthJ4YvyK0e0iNJLqSUFLyFTO7090914S4+3tmdiXw66g9xixCycQXok3aetj3\nRjP7DKFEYmdCO5LVhKDqBEK1zne62f0Z4Ktm9l3gDUL7j1Oj86Wqbe4HfhR1pb2W0Dbk/4BlwANA\nJSFYuTXKrzpC1VYNXdu09CTeCPVXhB4td5jZ5YRA8LvAl+gclHUZg0VkuFIVjMgg4e5J4GpCw8sr\nu9nml4ThzfcmDFx2GvBPYPfU+B2ExpL3AmcD58d2T3bzmm7W/5DQqPVEQvXQ+nR06+2xnYO7/y+h\nV8960TFujZb/AHwiKpnIdM4TCIOznUEIsI6OXv8J+KSZJdz9ruhYWxHad1xHCDL2cveV7r6QUC2y\nktCl9nZCIHNw2rDq6XnQ7bK7v0IY/6ONEOjdQKieOtDdb+3hGCLDViKZ1PdBRHIT9cLZH/hv1D4l\ntf48wrwtmdpviIi0UxWMiORjDaFB6Itm9jtCiceuwExCF1gRkR6pBERE8mJm2xJGVd2F0P7iHeBy\nd7+8pAkTkUFBAYiIiIgUnRqhioiISNEpABEREZGiG3aNUJPJZHL58nra2lT1VAxlZQkmTKhGeV48\nyvPiU54Xn/K8+MrKEkycOKZgY9kMuxKQRCJBWZnGAiqWsrKE8rzIlOfFpzwvPuV58RU6r4ddACIi\nIiKlpwBEREREik4BiIiIiBSdAhAREREpOgUgIiIiUnQKQERERKToBtQ4IGY2CngO+EHatNjxbbYH\nLge2AV4Fvu/uLxQvlSIiItJXA6YEJAo+/gF8rIdtRgN3AA8DOwBPAneYWVVREikiIiIFMSACEDPb\nEngK2KSXTb8OrHH3n3hwPLAK+Gp/p1FEREQKZ0AEIMCewP3AJ4GehlrbGXgsbd3j0X4iIiIySAyI\nNiDufkXqtZn1tOk0QruPuEXAVv2QLBEREeknAyIAycFoYG3aurXAqBKkRUREBqjmljZq69NvF5JJ\nY2sjSxuX9rpdeVmCfcZvX7DzDrYApJGuwcYoYE0uBykvHyg1T0NfKq+V58WjPC++gZLnDWtbWNvU\nWtRz1q1poq6hnvmrF7NqTRPJZJLFtY1Uj+r+9rJqTTMfLFrFohUNjKwoY0zViPb3lq8KQUNW054l\ngAwT4Wpu3OwlylsYtcVzWW+/zzaXF+zcgy0AmQdMTVs3FViQy0FqatRpptiU58U32PN8dUMzra1t\ntCWTLFnR0L6+rr6JNY3NrFy1llVrmhk5ooyX317KtEnVBTv3876Y9SZVF2z2z1aaaCqv5cNFq2lr\nbWOd6pE5H2NxlAcVZZmDnJa2tj6lMV/d3sB6KnwoB9aDyvXCYvwJsrKAaZOBbbAFIE8BP0lbtxtw\nZi4HqatroLW1NF/W4aa8vIyamirleRH1Jc8/WLSKJSs7bvbL6hpZ29TKiIrON736hhbmL6tn/JiO\nAsk5C1eRSMDoHp58U/zDlYwaUU51ZQWrGpqpXd1E5cjy9vcb83iKf+ntJdlvXN5MorK+x02WzMs5\nCRl1ukFvGv6ry+M4qZt1dwbbj7kMPJ+f8lVGlnXfoiGRKGwJ34C/Zs1sXaDW3RuBm4Bfm9lvgT8C\n3yO0C7khl2O2trbR0qKbYTEpz/umYW0LC5evYcWqtZR381SeTMKHS1YzpmoEo0ePZP6iVSyva2T2\nvFqmTx7DC28vYf3YU30yCR8uXs3oURUkElDf2NJ/f0D6Db8cGtpgZfTom6ju/MCcGEFOKsoStLQl\nmVhTSaKXQotkWTP16z2e2wkkK1/f+HAmjlmHsrIEo0aU975DH1SUJ1inpopVdQ20tKrSpa+mVk+m\nqqLnUtOKiqEfgKRfSQuAI4Fr3H2VmX0B+APwv8DLwP7u3oBIkbVGRd61q5toamljaW2GyzAJ85bW\nM2pkOU+S0dLBAAAgAElEQVS/toiysgTLV62ltbWNml6K4d+dX8eokeUFqdNfFBXfz13S9al/zdrs\nAo/0G3sy+qZOHtdRaF5b30RZIsEm02ra17Ulmpg76T+0lTXnmOrcVAA9l2mU3swZx1BZMTQrGbK5\ngRVSRUUZ48dXs6KsXg83g1QimRx2kWNyxQpdsMXS/iMxgPN85eq1tLS00djUyvUPvM06o0dSFt1t\nX3l3GVPGV7WXOrw9t5YxVSNY3dC/N9P+sPkG45i/tJ6Prj+W0ZUdzx4Ll69h600mACGA2H6zSaw/\naUz7+6MrK6jKololrqGlgYX1oUpkQf1CrnvzpgL8BYVXqIAgm6fxYt+gh7rB8Nsy1ER5XpiGUQzM\nEhCRnCWTSerqm1ha18jcxasZWVHOmrUtzJq9lMqR5VSOqmDR8jW8PbeWSWPDDWdpbWNWx04PNgoR\nfEydMJqW1jY+sv7YHrdbXtfIuhNGUzUyVJNs99FJTKjpodd5IsG6E6oYP34MK1fU09La1h5MFUo8\nuMiksaWRS2b9OeN7h29xCNOq09uRl0YhAwI9jYvkTgGIDCrNLW28PXcl78yr5bX3ljNtUjUPvzQ/\np2P0GniUN1M9di1jx4xs337qhNGMqQpflxWr1jJ1fDXNra1Mm1hNWzLJhHUqKSuDcWNGZew5MbZ6\nJIkElJeVkcgpIFgnbXkV9azqcY8P6hKsoH/qxnsKLnpTVVHF9lO2USmAiAAKQGSAW9vcylV3vsHy\nVWuZPbe2y/tvZVjXnemTx9DY1MLS2kY+veN0SMCy2kbWm1TN9MljGFlRxpq2Vfx9/hW0ASui/cqn\nwhLCPwDGwMro5TupWCbVgnJxrn/h0Bav4lAVhIjEKQCRkluxai3PvLGIRcvXMDJqOf/WhyuZs7Dn\nJ/2UqRNGs3D5GvbdcTqbTQ/tGzaeGhpBlpclsm6/0NDSwEmPnJffHzEM9dZ+QgGHiPREAYgURV19\nE3+725lQM4q3P6ylpnokL7yVw7gNwMgRZTQ1t7H9ZpPYf5eN2GDKmD539UtvLBk3WHssFKN7ooIL\nEekrBSDSL1Y3NHPzo+/yzrxaPli0Oqd9J0aNLJfVhXqN3baZyhGf24KKHIe57ktjyZkzjmHLiZvn\ndL6BQg0iRWQwUAAiBTFvaT1/u+vNrNpkjB0zktrVTYytHklTSxvNLW18Y7/N2WbTiYxfJ/95BeMB\nR18bS248doO80yEiIr1TACJ5W93QzAmXPE5LlsN977vjdA7bd7OCza+R0tDSwJzaD/MOOECNJUVE\nik0BiORswbJ6Tv3T0z1uM3pUBQfsuhF7bb8+G64/vt8GC2poaeC0J35DQ0v3g+GqsaSIyMCjAER6\nlUwmeXjWfG599D2mT67mtTkrMm531Oe34FPbTOs0zkWh5w5IN6f2wy7Bh0ozREQGPgUgklFbMsnr\nc5Zz0Y0v09rW0ZOitr6py7Z//PFeOTcQzUaujUgP3+IQDXQlIjJIKACRLn534yxefmdZt+9vuO4Y\nSMJpR36c8rLsAo+G5gbm1i3KOg35NCJV8CEiMngoAJF285fWc/qVz3Qq8UgZWz2SmV/Zho+s1/Pc\nJZmsaWrglEfPZk0P7TT66sxdT1HwISIyiCgAEVasWsuJlz6e8b0fHTqDbTadmNdxG1oaWLp6KStX\nrOhT8KFGpCIiQ48CkGGoqbmV+56fSyIBNz74TsZtDtt3Mz6zU/5jYXTXOyXX2VAVXIiIDE0KQIaB\n+UvreeGtJSxavobHX13Y47aHfXoz9t5+/W4blfbWMDRlQf3CLsGHZkMVEZEUBSBD3F9uf73XoANg\n1Ihyfvf/PtXj3CrZjLmRyfd2+gbjEuOZVDlJwYeIiAAKQIasZDLJ3+99u9vgY/rkan56+A6MrhyR\n9TEX1i/JOfgYXVHFLtN3YG19m+YlERGRdgpAhpi1Ta2c+bfnmLekvtP6MVUj+P1xu+d1zFS1S3y2\n2GzbckyvWZfRI6tYW1/f67YiIjJ8KAAZIp57czGX3fJqxve23Gg8Pz5s+7yO2121y7TqqWwydsNe\n9+/vkVBFRGRwUgAyyM1ZWMevrn4u43vrjq/iG/sZW20yIa9jN7Q08OLiVzI2Jp1aPTmvY4qIiIAC\nkEEvU/Cx/uRqfvbNjzNqZPcNSjPpbTr7VLWLusaKiEhfKQAZxOYt7dyuYtuPTOT4r87I+TjZTGev\nLrQiIlJICkAGsZsenN3++tRv7shH1s99mPRsp7PfeOwGCj5ERKRgFIAMUk+9tpBZsQnjNlmvJut9\n41UtmQYM03T2IiLS3xSADEJ3Pf0BN8RKP/bdYTpliURW+/ZU4qHp7EVEpFgUgAwibW1Jjjn3wU7r\nxlSN4PD9Ns/6GN0NJqY2HiIiUkwKQAaRH/z2kS7rLpy5W97Hiw8mpqoWEREpJgUgg8Q/H3ibtc2t\n7ctf33cz9uvDbLWQ/WBiIiIihaZhKgeBF99awt3PfNi+/IVdN+5z8CEiIlJKCkAGuGQyycX/fqXT\nuoN23yTv4zW2NPY1SSIiIn2mKpgB7qaH3um0fOVP98n5GKlut5lGNxURESkFBSAD2COz5vPfpz9o\nX/7+l7fudZ/4GB+QeUj1FM3nIiIipaIAZIC69h7ngRfmtS9Xjapgpy2m9LjPisaV/OyJs7M6/pm7\nnqJeLyIiUjIKQAagZ95Y1Cn4ALjk+N173KehpaHX4CM1wqm63IqISKkpABlgXn13GVfc+lr78vqT\nqjnjmJ173KehpYEXF3duqBofTh00zoeIiAwsCkAGkA8Xr+bCG2Z1Wverb38i47Y9NSydOeMYtpyY\n/eioIiIixaYAZAA5/cpnOi131+Olp/lcqiqq2HisxggREZGBTQHIAHHipY93Wr78xD273ba7+Vxm\nzjiGjcduoKoWEREZ8BSADACNTS2sWLW2ffn0I3di1Ijy7rePDSaWms9FbTxERGQwUQBSYi2tbRx7\nYcckc5/YcgobTV2n2+0bWho6tfnQfC4iIjIYaSj2EvvRxY91Wv72AR/rcfs5tR92WtZgYiIiMhgp\nACmhV99dRn1jS/vyWd/ZmREV3X8k6aUfM2cco2oXEREZlBSAlFC8y+0Xd92YaROru90201gf6u0i\nIiKDldqAlMjcxas7LR+0x6YZt2toaWBO7YcZx/pQ6YeIiAxWCkBK5InXFra//s4XM7f76G68D431\nISIig50CkBK5KzbL7Se3mppxm0zjfWisDxERGQoGRABiZqOAy4CDgTXABe5+YTfbHgScBWwAvAgc\n5+4vFiuthbBo+Zqc9zl8i0PYfso2CjxERGRIGCiNUM8HdgD2Ao4FTjezg9M3MrOPAdcRApBtgVnA\nHWZWmb7tQHbpza+2v/7Knt23/VhQ31FNM616qoIPEREZMkpeAmJmo4FvA59191nALDM7F5gJ/Dtt\n8/2AV939umjfk4EfAB8DXiheqvPXlkwyd0lHA9QDPrlxl216mutFRERkKBgIJSAzCIHQk7F1jwGZ\n5qBfBmxlZruaWQI4GqgF3un3VBbIwmUd1S97brde5m3S2n5UVVRpwDERERlSSl4CAkwDlrp7S2zd\nIqDSzCa6+7LY+n8CXyIEKK3RvwPcvbZoqe2j393YMfbHrlt3bXyaXvWith8iIjIUDYQAZDSwNm1d\nanlU2vqJwFRCO5Gnge8DV5vZ9u6+tF9TWQDzlqxmaW3HRHKbrlfT6f1MVS9q+yEiIkPRQAhAGuka\naKSW07uLnAO87O5XAJjZd4E3gKOA87I9YXl5aWqeTvvLM+2vP7nVVEaN7Jz9S1cv7RR8jK6oYnrN\nulT0MDz7QJfK61Ll+XCkPC8+5XnxKc+Lr9B5PRACkHnAJDMrc/e2aN1UoMHdV6ZtuyNwUWrB3ZNm\nNgvYKJcT1tQUv0Thw0WrOi2ffNQnSCQSndZ9ECsH+t5O32CX6TsweuTQKP0oRZ4Pd8rz4lOeF5/y\nfPAaCAHIS0AzsAvwRLRud+DZDNvOJ/R4iTPgmQzbdquuroHW1rbeNyygf9z9RvvrYw/ampUrOxfu\nNDQ3cNbDF7cvj0uMZ219G2vr64uWxv5QXl5GTU1VSfJ8uFKeF5/yvPiU58WXyvNCKXkA4u4NZnYN\ncIWZHQ1MB04EjgAws3WBWndvBP4EXGVmzxF6zXwH2BD4ay7nbG1to6WluBfs6++taH+9w+aTu5x/\n9vL3Oy1PqpxU9DT2p1Lk+XCnPC8+5XnxKc8Hr4FSeXYC8DzwAHAxcJq73xq9twA4FMDdbyCMD3IK\nYdyPTwJ7D/QGqMlkkmV1ofHp2DEjKUuremloaeg02ZwmmhMRkaGu5CUgEEpBCA1Jj8rwXlna8lXA\nVUVKWkE88WpHt9qtNp7Q5f2F9Us6LWuiORERGeoGSgnIkPbwrPntrw/d+6Nd3m9s6eiaq9IPEREZ\nDhSA9LPGphZmz+0YJ62memSn99OrXyorBtW0NiIiInlRANLPbnn0vfbXO1rX4dTn1H7YaVlDrouI\nyHCgAKQfJZNJ7nm2I8A45oDOPYjV+FRERIYrBSD96J35de2vR1SUMWpkeaf31fhURESGKwUg/ejS\nm19pf/3zI3fqcVuVfoiIyHCiAKSf1NU3Ubu6qX15/UnVPW6vxqciIjKcKADpJzc99E776y/ttnHp\nEiIiIjIAKQDpJ4+9sqD99YGf2qSEKRERERl4FID0g/cXdsx8O6FmVJdZb0VERIY7BSD94A//ea39\n9bc+ayVMiYiIyMCkAKQfTJ0wuv31th+ZVMKUiIiIDEwKQPrBS7PD5LzbfmRiiVMiIiIyMCkAKbCG\ntS3tr5tb2kqYEhERkYFLAUiBxed++cSWU3rcNj4LroiIyHBSkc9OZjYDOA7YAvgqcCDwurs/VLik\nDT7JZJJ7n+uY+2WrTSZ0u236PDAiIiLDSc4lIGa2I/AUsCmwIzAK2B64x8w+X9jkDS5Pvraw0/Kk\nsd0PrZ4+D4xmwRURkeEknyqYc4AL3H0voAnA3b8DXAL8omApG4SuuvPN9tdn/+8uPW4br37RPDAi\nIjLc5BOAfBy4JsP6S4GPZVg/LCSTSVrbku3L8a646dKrXzQPjIiIDDf5BCBNQE2G9RsA9X1LzuD1\n7oK69tef3nF6j9uq+kVERIa7fAKQW4CzzGxctJw0sy2Ai4DbC5ayQWbxiob213vMWC/r/VT9IiIi\nw1E+AchJwBhgKVANvAC8BrQCPy5c0gaXe5/t6P0ycWzPVSrx9h+qfhERkeEo52647l4H7GZm+xJ6\nv5QBrwJ3ufuwHXlrTmwCuqpR3Werut+KiIjkEYCY2QPAwe5+P3B/bP0UM7vb3bcvZAIHg6UrO6pf\neht+Xe0/REREsgxAovE9Ph4t7gmcYmar0zbbDNi4cEkbPB57ZUH7654GHwN1vxUREYHsS0DmEMb5\nSETLXye0+UhJAqsZpm1AXnl3efvrfXvoAaPutyIiIkFWAYi7v04Y+RQzew/Yyd2X9mfCBpP3Yl1w\nyxKJbrdT9YuIiEiQTyPUTbp7z8wq3X1YzbA2b2nH0CebTR/b6b2GloZOQceC+o6h2lX9IiIiw1k+\njVAnAqcC2wDl0eoEYU6YjwHjutl1SPrzba+3vz7gkxu3v17RuJKfPXF2t/up+kVERIazfMYBuQz4\nFmEckD2AecA6wC7ArwuXtMHh/UUd3W+32TQ0QG1oaegx+KiqqFL1i4iIDGs5l4AAnwa+5e53mNm2\nwHnu/rKZ/RHYqrDJG9hmz6ttf731JhNIRO0/0tt6zJxxTKcSj6nVk1X9IiIiw1o+AcgY4OXo9ZvA\ndtHyxcCdBUrXoPCX2zuqXw7aY9OM28yccQxbTty8WEkSEREZFPKpgpkHbBS9fgvYNnq9Buh5EIwh\nZkzViPbXm0zLND+f2nqIiIhkkk8JyL+Aq83sCOA+4Hozewr4MvB2IRM3kCWTSd6ZH7rfpo9+Gh9s\nTERERLrKJwA5FRgBbOTufzezfwE3ALXAVwuZuIHsxbc7hkEZWdFRkLSicaXmehEREelFPuOANAHH\nx5a/Z2anAHV0Hh11SFu8omP+l8M+Hdp4ZOr9ot4uIiIiXeXUBsTMtjYzS1/v7ssJPWCeKVTCBrqX\nZocSkNGjKhi/ziiga++XM3c9Rb1dREREMsh2MrpNgP8QBhrDzJ4BDnD35WY2AvglcBKwvPujDC1v\nfbgSgDVrWzK+P3PGMYyvHFZjsomIiGQt2xKQC4Ea4EjgMEJX3HPNbArwFPBT4HqiAGWoW17X0ch0\n6oTRGbdR7xcREZHuZdsGZDfgaHe/HcDM3gAeBDYHphFKQ/7bP0kceP7z+Hvtr7+8e7dT44iIiEg3\nsi0BGQ+8lFpw91cIJSJjgO2GU/ABMH/ZmvbXn9hy3RKmREREZHDKNgApB5rS1q0FTnD3xYVN0sCW\nTCaZPTcMwZ5qfJqi8T9ERESyk89IqHEfFCQVg8iqhub21/H2Hw0tDRr/Q0REJEvZBiDJ6F+m9cPK\nnAV17a8/8/EN2l+nd8HV+B8iIiLdy7YRagJ4zsziA42NBh42s079UN0986xsQ8SSlbEeMBMz94CZ\nOeMYjf8hIiLSg2wDkF/2ayoGkYdemtf+ekJaG5AUdcEVERHpWVYBiLsrAInMW1Lf/nrkiPISpkRE\nRGTwymcyuoIzs1HAZcDBwBrgAne/sJttt4m23ZEw++5x7v5QkZLarmb0iGKfUkREZMjoay+YQjkf\n2AHYCzgWON3MDk7fyMxqgHuAV4GtgZuBm81sUjESWVvf0RP5i7uFAcgaWhp4r/YDFtQvLEYSRERE\nhoSSl4CY2Wjg28Bn3X0WMMvMzgVmAv9O2/xIYJW7fz9a/oWZ7Q98HLirv9P6k8ufaH89eVwlDS0N\nnPbEb2hoaehhLxEREUlX8gAEmEFIx5OxdY8Bp2TYdk/g1vgKd9+5/5LW2fh1RrFoRQg2ttl0InPq\nPuwSfFRVVKkLroiISC/yDkDMbENgS+ARYJ0+jIg6DVjq7vHuvIuASjOb6O7LYus3BZ4xsz8AXwLe\nA05y9ycoglTwscPmk0kkEp3eO3yLQ5hWPZWp1ZPVBVdERKQXObcBMbORZnY9MAe4gxBAXGFm90Zt\nNHI1mjCse1xqOb2f6xjgJ8B84HOE4OceM1s/j/PmZOXqjiRm6n47rXoqm4zdUMGHiIhIFvIpAfkZ\nodpkH+D2aN3vgauA3xAakeaika6BRmp5Tdr6FuDFWLfgWWa2H/DN6NxZKS/Pve3t/GUd3W+3/shE\nKirKqCjvKAWpKE9QUTFQ2vQOHKm8zifPJT/K8+JTnhef8rz4Cp3X+QQghwHfd/eHzCwJEL0+BriG\n3AOQecAkMytz97Zo3VSgwd1Xpm27AHgzbd1bwAbkoKYm91KK9xe/3/56+y2nMr6mkg9i5Tbr1FQx\nfnx1zscdLvLJc+kb5XnxKc+LT3k+eOUTgKwPzM6w/gNgQh7HewloBnYBUm05dgeezbDtU8Aeaeu2\nAK7L5YR1dQ20trb1vmE8kbEmLonWVt5ZMI+zHrm4fd2qugZWlNVn2nVYKy8vo6amKq88l/woz4tP\neV58yvPiS+V5oeQTgLwOfBpIn/r169F7OXH3BjO7htCO5GhgOnAicASAma0L1Lp7I3AFMNPMfk4I\nOo4ANgGuzeWcra1ttLTkdsFWV3YMPLaqsZ6THzmz0/uTKiflfMzhJJ88l75Rnhef8rz4lOeDVz4V\nOr8ALjKzCwkBzBFRo9TTgbPzTMcJwPPAA8DFwGnunupuuwA4FMDdPwA+S+gB8wpwAPB5d1+Q53mz\ntqaxGYCPrj+2y8y3Z+56ihqfioiI5CDnEhB3v93MvkIYp6MV+DFhZNKvufu/8kmEuzcAR0X/0t8r\nS1t+kjDwWFG9NbcWgHHrjKKxpWNG3JkzjmF85bhiJ0dERGRQyzkAMbNN3f0uijDy6ECxtrm1/XVD\nSwOXzLqmfVkz34qIiOQunyqY2Wb2iJkdZWbDotvH3CWr219vtGHnAcg06qmIiEju8glA9gLeIEwg\nt9DMrjGzfQqaqgHm7/e+1f56gylj2l/PnHGM2n6IiIjkIecAxN0fcffvEsbq+BZQBdxuZnPM7Jc9\n7z04jRvTMU7alHEdAYeqX0RERPKT97Bm7t7s7jcTBh47DRhP5gnkBr2W1iQAtsE4SJsDRkRERHKX\n12R0UduPg4DDgX0J88KcB/y1YCkbQF59N8yHVzVqIEweLCIiMvjl0wvmeuALQBtwI7Cvuz9a6IQN\nFMlkkmT0ujXRxIL6hSVNj4iIyFCQzyP9uoRql5vcPX2yuCHn7mc+DC/Km3lv3C3MfrOptAkSEREZ\nAvIZiGzv/kjIQHXDg2Ham0RlPa2JjuCjqqJKXXBFRETylFUAYmbvAju5+zIzew/aayW6cPdNC5W4\ngWCd0SNYtaa507rDtziE7adsoy64IiIiecq2BOSvQEP0+ur+ScrA09rW1h587DljPZ5uCeunVU9V\n8CEiItIHWQUg7h4f3+NB4El371QsYGaVhMnhhoy3PljZsVDeDC2lS4uIiMhQks84IA8CmWZf+xhw\nbd+SM7CsrI/afJQ38/Ta20qbGBERkSEk2zYgxwMXRIsJwhDsmTZ9pkDpGhCefn0REBqgxqnxqYiI\nSN9k2wbkEmA5ocTkSuBHQG3s/SSwGnigoKkrsUwDj2n+FxERkb7Ltg1IC3ANgJklgevdfW1/Jmwg\naG5pA2CDqaNYEq3T/C8iIiJ9l20VzLeAf0ZBRxL4WjdVMLj7NYVLXmm9+NYSEiMbWDLx4VInRURE\nZEjJtgrmauAuYDE9d8NNEpWUDAXjxpXRuHnn4EPtP0RERPou2yqYskyvh7qVzcuJV7icuespav8h\nIiJSAH2e3tXMJgN7As+5+5w+p2iAWFbb2Gl55oxjGF+ZqfexiIiI5Cqf2XC3Bv4NHAO8DMwCpgJr\nzezz7v5gYZNYGg+9NK/TshqfioiIFE4+1SnnA28DbwKHASOA6cB5wJmFS1ppPfzS/FInQUREZMjK\nJwDZFTjR3RcDnwPudPf5hMap2xUwbSW1uqG5941EREQkL/kEIG1Ak5lVAHsB90fr1wHWFChdJTdq\nRHmpkyAiIjJk5dMI9UngZGAJUAXcaWbrA2cDTxUwbSXV3NIGI0udChERkaEpnxKQHwI7AN8HjnP3\npcBPgS2BkwqYtpJpaW2jLZksdTJERESGrJxLQNx9NrBj2upfAce7e2tBUlViS1Y2lDoJIiIiQ1pe\n44CY2RjgG8A2QDPwGvBPoK5wSSudtc1DIo4SEREZsHKugjGzDYFXgQsJPWL2Bi4CXjaz6YVNXmms\nqBvy8+yJiIiUVD5tQC4APgQ2cfft3X0GsAnwPnBuIRNXKkvrGnvfSERERPKWTwDyGeAEd1+UWhG9\n/jHw2UIlrJTefH9FqZMgIiIypOUTgLSQebyPBmBU35IzMFRXjSh1EkRERIa0fAKQx4HTzKz9Lh29\nPjV6b9BbGvWCWW+KBgIRERHpD/n0gvkp8ATwjpk9F63biTAS6p6FSlgpvTu/DsqbWT75kVInRURE\nZEjKuQTE3d8gzPnyD0KVSyVwHTDD3WcVNnml0dTSRqKyvtO6qdWTS5QaERGRoSenEhAzqwGa3P19\n4Cf9k6TSqq1v6rJu5oxjqKqoKkFqREREhqasSkDMbJyZ/QdYDqwys5vNbFL/Jq00Fiyt77KusqKy\nBCkREREZurKtgjkP2Bk4jdDYdCfgiv5KVCm1tLaVOgkiIiJDXrZVMPsD33L3uwHM7AngPjOrcPeW\nfktdCTQrABEREel32ZaATAFeiS0/SQhe1i14ikps1ZpmABLlQyquEhERGVCyDUAqCAOQARDNejtk\nBh6LW7h8DZQ3M2qL53rfWERERPKSz0BkQ9rTry9SF1wREZF+lks33Olmlt4dZD0z61RX4e4f9D1Z\npTNuzEhW1nUsqwuuiIhI4eUSgDybtpwAHk5bTgLlfU1UKb23YBWJ6o5ldcEVEREpvGwDkL37NRUD\nyMiKMppLnQgREZEhLqsAxN0f7n2rwa+ltS0Mwz7kmtaKiIgMLGqEGrNw2ZpSJ0FERGRYyGc23IIz\ns1HAZcDBwBrgAne/sJd9NiaMTXKAuxdk2tr7X5hbiMOIiIhILwZKCcj5wA7AXsCxwOlmdnAv+1wO\njC5kIuYuXg1oEDIREZH+VvIAxMxGA98G/p+7z3L3W4FzgZk97HM4MKbQaXlnfp0GIRMRESmCvKpg\nzGwa8B1gS+A4YA/gFXf3PA43I0rHk7F1jwGndHPuicBvgP2A1/I4X480CJmIiEj/y7kExMw+CrwK\nHAl8hVAS8TXgOTPbOY80TAOWpk1qtwiojIKNdBcCV7v7G3mcq1vNLa1d1mkQMhERkf6RTxXMBcDN\nwEeAtdG6w4DbCCUTuRodO05KarlTh1gz+zSwK3BGHufp0fJV6UnQIGQiIiL9JZ8qmN2APdw9aWYA\nuHuLmf0KeDqP4zXSdVK71HJ7v9hoGPgrgO+7e1Me52lXXt417lq0oqHLuoryBBUVJW8mM6il8jpT\nnkv/UJ4Xn/K8+JTnxVfovM4nACknc8lJDdC1HqN384BJZlbm7m3RuqlAg7uvjG33CWAT4F9mloit\n/6+Z/dXdj832hDU1XatVRo5a2WXdOjVVjB9f3WW95C5Tnkv/Up4Xn/K8+JTng1c+AcjdwMlm9s1o\nOWlmE4BzgPvzON5LQDOwC/BEtG53us498zSwWdq62YQeNPflcsK6ugZaW9s6raut61oCsqqugRVl\n9V3WS/bKy8uoqanKmOfSP5Tnxac8Lz7lefGl8rxQ8glATgAeAhYAVYS2HxsBywkNU3Pi7g1mdg1w\nhZkdDUwHTgSOADCzdYFad28E3o3vG1UBzXf3pbmcs7W1jZaWzhdsU3PXwpuW1mSX7SQ/mfJc+pfy\nvPiU58WnPB+8cg5A3H2+mW1HaHi6PaE65lXgWnev63Hn7p1AGAn1AaAWOC0aDwRCoHMkcE2G/ZJ5\nnuXaTe0AACAASURBVK+L1Q2agk5ERKRY8hoHxN3XAH8pVCLcvQE4KvqX/l63rV7cvbxQaZi7WFUt\nIiIixZJzAGJmD/T0vrvvk39ySmd0ZcgKDcMuIiLS//IpAXk/wzE2A7YBftvnFJWIf7BSw7CLiIgU\nST5tQLpUkwCY2WnABn1OUYmUlWkYdhERkWIp5KgifwMOLeDxiqoskei0rGHYRURE+k8hA5BdgUHb\ngGLOwlWdljUMu4iISP/JpxHqg3Tt/lpDmNX20kIkqtjakgXrzSsiIiJZyKcR6pwM65qAS4Br+5Sa\nElmysusoqCIiItJ/8glA7gHudvflhU5Mqbz67pD5U0RERAaFfNqAXEqYLG7IaNYwviIiIkWVTwDy\nFmHMjyHjpdlhKpnKkZrWWUREpBjyqYKZBVxnZj8G3gY6NaBw96MLkbBimr80jP/R2NSG+r6IiIj0\nv3wCkM2BR6PXQ6IqZtSIclY3NDNt4mhWlDoxIiIiw0A+I6Hu3R8JKaVldY0A1KxTpgBERESkCLJq\n9GBmrWY2pb8TUwotrVED1PJm3q++r7SJERERGSaybXWZ6H2TwamuvgnQPDAiIiLFNOy7fcxdEgKP\nRHnHKPKaB0ZERKR/5dIG5FAzq+ttI3e/pg/pKbrmljYob2bUFs+1r9M8MCIiIv0rlwDk91lskwQG\nVQDS2NSi6hcREZEiyyUAmerui/stJSXy7vzOhTqqfhEREel/2bYBGbLTxY6u7ByDqfpFRESk/w37\nXjDt3XBFRESkaLINQP5K2pDrQ4UmohMRESm+rNqAuPtR/Z2QUnnghXkkqkudChERkeFl2I8DMnXC\n6FInQUREZNgZ9gFIc0trqZMgIiIy7Az7AGRZ3dpSJ0FERGTYGdYByNomlX6IiIiUwvAOQFT9IiIi\nUhLDOgBpXNvS+0YiIiJScMM6APn3I++WOgkiIiLD0rAOQEaUD+s/X0REpGR0BwZGVCgbREREimlY\n33lb2pJQ3sz4yU2lToqIiMiwktVQ7EPVnMXLqZzxMHUVaowqIiJSTMO6BGRxwxISseCjqqKKqdWT\nS5giERGR4WHYloCsbmjutHz4Foew/ZRtqKqoKlGKREREho9hWwLywaJVnZanVU9V8CEiIlIkwzYA\nWdPYQqJcbT9ERERKYdgGIM++NY9RWzxX6mSIiIgMS8M2AFnRvKzTshqfioiIFM+wDUAWLl/T/nrm\njGPU/kNERKSIhm0Asqa5sf11ZUVlCVMiIiIy/AzLAKS+aY3af4iIiJTQsAxA3lo8t9Oy2n+IiIgU\n17AMQGrrO+Z++dzkQ9T+Q0REpMiGZQDS1pZsfz1lnZoSpkRERGR4GpYBSGssACkrS5QwJSIiIsPT\ngJgLxsxGAZcBBwNrgAvc/cJutj0AOBP4KPAOcJq735bL+ZId8YcCEBERkRIYKCUg5wM7AHsBxwKn\nm9nB6RuZ2bbAv4A/AzOAPwI3mdk2uZysta2t/XV5QgGIiIhIsZW8BMTMRgPfBj7r7rOAWWZ2LjAT\n+Hfa5ocB97v7pdHyZWb2JeBQ4JVsz7li1dr21yoBERERKb6SByCEkowK4MnYuseAUzJsezUwMsP6\nsbmcsLmlowSkcmR5LruKiIhIAQyEKphpwFJ3j09NuwioNLOJ8Q09aC/pMLOtgH2B+3I5YbzWZUSF\nAhAREZFiGwgByGhgbdq61PKo7nYys0mE9iCPuvt/cjlhrAmIiIiIlMBAqIJppGugkVpeQwZmti5w\nL5AEvprrCWO9cKkoT1BRMRDisKGpvLys0//S/5Tnxac8Lz7lefEVOq8HQgAyD5hkZmXuniqbmAo0\nuPvK9I3NbH3gAaAV2Mvdl+V6wvLyBDSH1+vUVDF+fHW+aZcs1dRotNliU54Xn/K8+JTng9dACEBe\nIoQDuwBPROt2B55N3zDqMXNXtP3e7r4knxO++u4yWC+8XlXXwIqy+nwOI1koLy+jpqaKuroGWltV\n91UMyvPiU54Xn/K8+FJ5XiglD0DcvcHMrgGuMLOjgenAicAR0F7dUuvujcCpwCaE8ULKovcglJbU\nZXvOsTVlpDZuaU3S0qKLt7+1trYpn4tMeV58yvPiU54PXgOl8uwE4HlC1crFhNFNb43eW0AY5wPC\nSKlVwNPA/2/vvuOqrP4Ajn9ABAUEwb3F0XHmyG1AuVN/5t6KIysbrsRVaVaae5ZaZo7MWaamiXtl\nlg33OE4c4EJFUBFl/P54LlcuQyHggvB9v173Jfc853me8xzv6z7fe855zgmM9ZqR1BM9eBTGZeft\nqVRsIYQQQvwX6d4CAkYrCNDb9Iq7zTbW3+VTeq6A0GsW7ws65UvpIYUQQgiRTBmlBSRduN7wJKed\nDGASQgghrC1LByCqUN70LoIQQgiRJWW5AOTBw8fmv21kITohhBAiXWTBAOTJjO9uuRKdaFUIIYQQ\naShLByDOObOnY0mEEEKIrCvLBSA7/7ls/ttBVsIVQggh0kWWC0DcXJ50uxRyd0zHkgghhBBZV5YL\nQCxWwpVBqEKINDR+/Fg8PWvi5VULT8+aFi8vr1ocOvRvso958OA/eHnVSlLeTZs20KHD68k+R3K8\n//5bXLp00SJtwYKv8fSsyb///p1g/oUL58dLP3jwHzw9a5rfv/fem/HqrGlTbwYO7M/58+cs9n38\n+DGLFn1Lly5tadCgPh06tGLGjCkEB8dbTozQ0FBmz55Ohw6v06jRy3Tv3pFVq5YTHR0dL+9/FRBw\nhUGD3qFJE298fLqwf/9vFttHjBhi8bnw8qoVL09sq1Yto02b5jRt6s2ECZ8RHv5kAfmfflpFy5aN\n6NatPSdOHDOnP378mM6d23L7tuVyad98M4dfflmbSleaMhliIjJrioySKXuFENYxaNBQ+vd/H4Bt\n27awYsVSvv32e4yFvCFXLpdkH7Ny5SqsW+eXpLwNGzahXr2Xk32OpPr1118oVKgwxYuXsEjfvn0L\nRYoUw89vI9Wr10jy8WI/mWhjY0OXLt3p0qUHANHR0QQGBjBjxhQ+/NCX1auNm2hkZCS+vgO5du0a\n77wzAKXKERgYwIIFX/Pmmz7MmbOAvHmNKRdCQu7y5pu9yJcvP6NGjaZQocKcOHGc6dMnERh4hUGD\nfFNaJTx69IhBg96lTJmyzJ+/mFOnTjB69Chmz55HuXIVAPD392fMmM956aUnAVdin4Vdu7azcOG3\njB79GW5u7owbN4a5c2cxaJAvwcHBzJkzk6lTZ3P06BGmTJnAd98tBWDDhnXUr/8y7u55LI7XtWtP\n+vTphrd3A1xckv/5S01ZsAUk9aJcIYR4GkdHJ9zc3HFzc8fZ2Rlb22y4ubmZ0+zskv8b0M7ODjc3\n9yTltbe3x9U1d7LPkVRLlnxHmzbtLdK0PkVAwBV8fPqwc+d2Hj58+J+PnzOno7mu3N3zUKnSiwwc\n+AEBAVc4e/YMAKtXr+DcubPMnbsAL69XKFCgINWqvcSMGXNwdXVl1qyp5uPNnTsbBwcHpk//imrV\nXqJgwUI0aNCIESM+5ueff+TKlcuJFSXJ9u3bQ2joXT7++FNKlChJ06bNadq0OStXLgOMlomrVwMo\nV66C+dqe9ln48ceVdOrUlbp161OuXHl8fUexYcM6wsPDCQy8gouLK1WrVsfb+1UuXzZaoiIiIli1\nahnduvnEO56zszO1a9djzZpVKb7WlMpyAUh4ZPizMwkhhJWMHz+W8ePH0qtXV1q1akpAwBUuXDjP\nkCHv06SJNw0a1Ofdd/tx6ZI/YNlVce3aVTw9a7J79046dWpNgwb1GTZsMKGhoUBMF0wr834dOrRi\n7dofadOmOY0be/LZZ6OJiHjyZOCWLZvo1Kk1jRt7MnbsR3zyyYcJdpcA/PnnfsLDwylfvqJF+rZt\nmylT5gVeeaUhkZER7NqVumtvZc9uPL2YLZvxEMH69Wtp0aIVbm5uFvns7Ozo3r0Xe/bsJCQkhMeP\nH7N9+1batesU72Zfv74nM2bMoWDBQvHOF1PfcbvREutCu3o1kOLFS+Lo+GSMYZkyZTh27CgAFy/6\nY2trS+HCRZ55rVFRUZw8eZwXX6xqTqtYsTKPHz/m7Nkz5M9fkJCQu1y/fo1Tp05SoEBBADZsWEvd\nuvXjtX7Evt71639+5vnTWpbrgjlpuym9iyCESCUPHkZw9fZ9q52vkLsTjjlS/2tz8+ZfmTBhKm5u\neShcuAidO7ehVq26+PqO5N69UKZNm8jcubP54gvj13zcSRSXLl3I2LFfEB0dxfDhQ1ixYin9+vU3\nbX2SNyjoJrt27WDatC8JCrrByJFDqVatOi1btubw4UNMmPAZgwcPo0qVaixfvpSNG9fRu3e/BMt8\n4MB+iy6EGDt2bKVly9fJmTMnL71Uk02bNtKsWYtUqaegoCDmz5+Hh0dpSpb0ICwsDH//C/Tp82aC\n+V98sSqRkZFofZJ8+fITFvaAcuUSXlKsWrWXEkyvXLkK69dvTnBbQt0mbm7u3LoVZJF2/fp17t41\nxqNcvHgBJycnPv30Yw4e/If8+QvQt+9b1KlTL96x7t0L5dGjR+TN+2TNsmzZsuHqmpubN69TsWIl\n2rfvTMeOr+PgkIOxY8cTERHB6tUrmD376wTLDFC9eg1u3Qri/PmzlCpVJtF8aS3LBSCxyUJ0Qjy/\nHjyMYNjc33kQHvHszKnE0cGOSf3rpXoQUr58RerWNcZqPHz4kNat29O2bXscHHIA0KxZS5Yv/z7R\n/fv2fdt8Y23cuBknT55IMF9kZCSDBw+jRImSeHiUonbtupw8eYKWLVuzdu2PNGzYhP/9rzUAQ4eO\n4MCB/YmeU+tT1K5tedM8fPgQN2/ewNPzFQC8vV9l8uQvuH79mvnXeXIsWfIdy5YZ1x0VFQlArVp1\nmTRpOjY2NoSEhBAdHZ3o+ImY9JCQu+TMmRMbGxucnJyTVYbkdHkB1KlTn5kzp7Bgwdf4+PTl7NnT\nbNy4nogIYxbuS5cuEh4eTp069ejRoze7d+9g+PDBfPPNYpQqZ3Gshw8fYmNjg729vUV69uzZefTI\nOF7//u/To0dvHBwcyJ49O+vX/0zt2nWxsbFl8OB3uXLlCm3atKNr157m/e3t7SlcuAhan5IAJD2U\nuN9IFqITQmQIsZv+c+TIQevW7di0aQOnTp3k4kV/Tp8+hbt7wmtX2djYULRoMfN7JycnIiMTD8qK\nFCkaK6+zuQvm3LkzvP56O/O2bNmyJdpaABAcHEzu3JbjS7Zt20yBAoUoU6YsAPXrezN58hds3vwr\nPXv2AYwbelQCDwNER0ebu1VitG7dnvbtO/H48WNWrVrGX38doF+//uZgJub8t27dinc8MFp8AFxc\nXHFxcSU6OtrcPZVUhw8fYujQAfHSbWxsmDJlpkX3CICbmxuffDKeceM+YcmS7yhUqAjt23di1arl\nAPTu3Y8OHbrg7GwEQqVLl0Hrk6xfvwZf31EWx7K3dyA6OppHjx5ZpD9+/JgcOXKY38ccK2bsx8yZ\nc1mw4GtKlSrN559PpGfPztSoUYsXXngS4Li65ubOnTvJqovUlmUDEDtkFlQhnmeOOYzWiMzQBRP7\nF25YWBhvvNEDNzd36tf3onHjZvj7X2DFih8S3d/OzvL77GmPlMYd/xCT17j5R8fZlniZbWyMFpUY\nUVFR7Nq1nZCQu3h717Y4vp/fRnMA4uyci/v378U7XmhoKM7OuSzSXFxczAHTsGEfMnToAHx9B/L9\n9ytxccmFg4OD+QbepEmzeMc8efI42bJlQ6lyODk54+TkjNYnEwysRo78gPbtO8frVipfvgKLFi1L\nsA7y5cufYHqdOvX45Zct3L59C3f3PPz8848UKvQkyIwJGGKUKOGBv/+FeMdxdXXF3t6e27dvmZ80\nioyM5O7dYPLkiR+Qbtq0gZo165AnT16OHj3MO+8MwMnJmUqVKnPkyCGLACQqKgpb2/SdiiLLBiCy\nEJ0Qzz/HHHaULuya3sVIVQcP/sOtW7dYunS1+Xvqzz9/J25wkNo8PEqj9Snz+6ioKM6cOU3Zsi8k\nmN/dPQ8hIXfN7//++wB37wYzbtwkihYtbk4/cGA/X301k2PHjlKpUmVKly7D77/Hn/Pi+PGjlC2r\nnlpGX99RdO/ekXnzvmTYsJEAtG7djjlzZtOlSw/z47ZgtAYsWfIdXl6v4uJifEYaNWrCmjWraNGi\nlUUg9ttve9i3by9vv/1+vHPa29tbtBo9y8WL/kybNomZM+eYB4Hu3/8b1asbgc348WOxsbFh5MjR\n5n3Onj1N6dJl4x3LxsaG8uUrcuTIIapWrQ7AsWNHyJ49u7mVKUZkZCQrVy5j1qy5ANja2phbmiIj\nI+MFk3fvBifaqmYtWe4pmBgSfwghMiIXF1fCwh6we/cOrl27yi+/rGXNmtXxmuFjpNYEWm3bdmTb\nti1s2LCOS5cuMnPmFK5fv5roj7WyZRXnzp0xv9+2bTMeHqXw9HwFD49S5lebNh3IlSsXfn4bAGjR\nohUXL15g1qypXLzoz6VL/qxevYK1a3+ic+duTy1jgQIF6dmzN+vWreHMmdMAtGvXgapVq/P++2+y\nZ88url+/xuHDh/D1Hcj9+/cZOPAD8/59+rzJ/fv3+eCD9zl06F8CAq6wYcNaxo8fS4cOXShRomQK\na9HoTrt48QILFnzN1auBLFr0LUeOHKZdu44A1K/vxdatfvj5bSQg4AoLF87n6NHDtGvXCYDw8HCL\nycPatGnPsmXfs3fvLk6ePM7UqRNo1aoNDg6Wi6lu2rSBGjVqmYOecuUqsnWrH6dPn+LgwX+oWLGS\nOe+DBw+4du1qvDEn1paFAxCJQIQQGU+lSpXp3bsf06ZNolevLvj5beSDD0YQHHyHoKCgePlT67us\nUqXKDBkyjIUL59O3b3fCwsKoWLFyovNT1K5dl6NHjwDGmIS9e3fTsmXrePns7e1p3rwVO3Zs4/Hj\nx+TLl5/Zs7/m0qWL9O/fl759e7JlyyZGj/6UWrXqPPO6OnfuTqFCRZg2bZI534QJU2nVqi3z58+h\nW7f2fPbZx3h4lGL+/MUWXRXu7nmYO3cBhQsX4dNPP8bHpzOrV6+gX7/+vPfeoP9cd7E5ODgwfvxk\n9u/fR8+endm/fx/Tps0mf/4CgDEwd8iQ4SxevICePTuxb99epk6dTcGCxriWHTu20rr1a+bjNWzY\nhB49ejF58hcMGfI+FSu+SP/+lmNSIiMjWbVqGd279zKn9enTj6tXAxg06F3at+9MhQpPApBjx46Q\nP3+BVAm4UsImNaeffR50XNk/GkA9bMGA5t7pXZxMz87OFjc3J+7cuU9EhMxCaw1S59aXGer85Mnj\nODk5W8xq2qNHR7p27clrr7WMlz8qKoquXdsxcuQYqlSpGm97WssMdZ5exo8fS9GixczjcpLKVOep\n9utdWkCEEEJw7NhRhg0bxLFjRwgMDGDJku+4efNGgvNTANja2tK9uw/r1v1k5ZKKlLh7N5i//z5A\n69btn505jWXhQajpXQIhhMg42rbtwLVrgXz44TDu379H2bIvMGXK7KfOgdGixets2rSRS5f8KV68\npPUKK/6zFSt+wMenb7qvAwNZuAum4uOWvNPUK72Lk+lJM6n1SZ1bn9S59UmdW590waQWaQIRQggh\n0k2WDUAk/BBCCCHST9YNQKQFRAghhEg3WTYACX2Q8KQ+QgghhEh7WTYAKVEg17MzCSGEECJNZNkA\nxDZblr10IYQQIt1l2btwNhkCIoRIY+PHj8XTsyZeXrXw9Kxp8fLyqsWhQ/+m6PgBAVc4cOAP89+e\nnjXNS9CnhTlzZrFp0waLtL/++hNPz5osWvRtvPzz589l0KB34qVHRkbi6VmTo0cPm/PFradGjV6m\nV6+u7N27K97+W7Zsok+fnlStWpXmzRvz8ccjOH/+bLx8UVFRrFz5Az4+XWjU6GU6dGjFrFlTuXcv\n/mq8/9WDBw8YP34sLVs2ol27lixfvtRi+/Hjx3j77T40avQy3bt3YMsWv6ceb9myJbRr15JGjV7G\n13cgAQFXzNsOHfqXjh1fp1WrpmzcuN5iv1GjfNm/33KRvz/++J1x4z5J2QWmoawbgEgEIoRIY4MG\nDWX9+s2sW+fHgAEfkD9/Adav32JOq1TpxRQdf/z4sZw6dQKAQoUKs379ZvLmzZcaRY/H3/8Cf/yx\nj2bNWlikb9++hSJFiuHn92uC+yV1wH+VKtVYt24z69cbr2++WYyHRynGjPmQa9eumvN9880cpk2b\nSPPmLfnll1+YOfMrnJ2deeutPvECulGjhrJmzWp6936D779fxahRYzh06CAffPA+ERERyayBhI0f\nP5YTJ44xceIMRo/+jB9/XMFPP60EICQkhGHDBlK9eg2WLFlJ9+69+OKLsZw8eTzBY23atIEffljM\n8OEfsXjxChwdnRgxYoh5+/Tpk2jXriOjR3/G9OmTzIHUmTOnCQq6Sd26L1scr06degQGBnDkyKFU\nudbUlmUDkKjIrDUBmxDC+hwdnXBzc8fNzR1nZ2dsbbPh5uZmTktsobekij2RpK2t7VNnLU2ppUsX\n0bz5/ywCioiICHbv3kmvXn25ejXA3KLxX2TPnt2ibkqVKs2oUWMA2L9/HwAnThxj6dJFTJgwjfbt\nO1KsWDHKln2B4cM/olmzFowb94k5sNi0aQN//32AmTPn8corDSlUqDDVqr3E5MkzOHfuDFu3Pr0l\nIilu377F7t07GD78IypWrESVKtV46633WLbsewBu3LhO/fpevPnmOxQuXIRmzVpQvHjJROvpwYMH\n9O8/gFq16lCkSFG6devJxYv+hIaGAnDxoj/e3g2oUaMWOXLk5OrVAAAWL/6W3r3fSPCYr7/ejkWL\nFqT4WtNClg1A8uTOmd5FEEIIANasWU2HDq1o0sSbgQPf4cKF8+Ztf/31B716daVBg/p07tyGDRvW\nAvDZZx9z9Ohhvv12HoMHv2vRBRPTxbFlix89enSkQYP6vPfem1y/fs183JMnj9Ovnw8NG9bnnXfe\nSLS7BIxf8jt2bMPT8xWL9P37f+PhwzC8vF5FqfLxumdSysbGBjs7O3OgtnHjeipWrEzVqtXj5e3d\n+w2uX7/GX38ZXVKbNm3A27uBeZXZGHny5GXWrHnxrgWedA3F7TLz8qrFkiXfxcsfGBiAjY0N5ctX\nNKeVKVOGmzdvEBR0kzJlypqDqOjoaPbs2UVg4BWqVIlffoB27TrSsuXrAISGhrJmzWrKlHmBXLmM\nhyYKFiyE1icJCLjCgwcPyJevAOfOneXGjRvxWj9i1K1bn4MH/yYwMCDB7ekpy64FY2ebZWMvITKN\nsIgwrt1PuzEPcRV0ykdOu9T98bJ7906+/34hw4d/RNGixdi4cT0DB/ZnxYo12Ns78PHHI+nZszeN\nGjXl0KF/GTfuE6pUqc6QIcO5fPkyL71Uk27dfLh7Nzhed8fChd8wfPhHuLi48uGHvixY8DWjRo0h\nNDSUoUMH0KxZC0aP/ow///yd2bOnU716jQTLePDg3+TNm5ciRYpapG/fvpUqVarh6OiIp6c3P/yw\nhEGDfLG3t09xvYSFhbFw4Xyio6OoW7c+AKdOnUx05V139zwULlyUEyeOU7fuy5w9ewYvr1cSzBt7\nafrYsmXLxvr1mxPc5ujoGC8tpsUpKOgmBQsWAjAHecHBwebusPDwcJo29SYqKoq2bTuiVLlErtqw\nfv3PTJ48HgcHB6ZP/8qc/tZb7/Lppx8TGRlJ7979yJ07N1OnTki09QMgV65cvPBCOQ4c2J8hFqCL\nLcsGIBJ/CPF8C4sI4+PfJxAWEWa1c+a0y8ln9UakahCyfPn3+Pj0Na86+9Zb77J//z62bPHD27sB\n9+/fw83Nnfz5C9CkyWvky5cfd3d3nJycsbOzI2fOnDg7O3P3bnC8Y3ft2tPcWtC6dTs2bFgHwNat\nfuTK5cr77xvjC4oVK87hw4e4dy80wTJqfYqSJT0s0h4+fMi+fXvo338AAN7erzJ//lz27t1Fw4ZN\nkl0P//77N40bx6zPFc2jR48oV64CU6fONt/IQ0JCyJUr8UXUcuXKRUjIXQDu37+Hk5NzssuRnG6s\nIkWKolQ5pk+fxEcffUp4eLi5uyMi4rE5n42NDfPnL8bf/wJTp06gWLFitGvXKdHj1q5dl+++W8ov\nv6xl2LDBLF68nPz5C/Dqq42oV8+TyMgIHB2dOH/+LNeuXaVWrbpMnDiOP//8nZo1a+PrO8qie69k\nSQ+01smui7SWZW/D2WxlEKoQIv35+1/gyy+n07ixl/nl73+eK1cu4+bmRqtWbRg/fiwdOrRixowp\nODvnSvKNNXaLhZOTk3l8xPnzZ+P9Cq9UqXKixwkOvoOra26LtL17dxEeHo6npzcAxYuXpHjxkhbd\nMHZ2dkRFxR9vFzN2JfZNsmLFyixevJyFC3/gzTffxdHRic6du/Hii09aPFxcXLh161ai5bx1KwgX\nF1cAcuVyMY+dSKqoqCgaN/aiSRNvi/+PJk28zeM64hozZhzXr1+nRYuG+Ph04rXXWgLG+J8Y9vb2\nlC2raNy4Gd2792L16pVPLUeBAgUpW1YxZMhw8uTJg5/fRvM2BwcH87EXL15Ar15vsH37Vvz9z7Ny\n5VqCg++wdu2PFsdzdXUlOPh2surCGrJwC4gEIEI8z2JaI573LpjIyEiGDBlOlSrVLNKdnY0gw9d3\nFO3bd2bv3l3s3buL9evXMGnSDGrUqPXMY2fPnt3ifcyY1WzZsgHRcbYlPjDfxsaGqKhIi7Tt27cA\n0L79/yzSr1y5xK1bQeTJkxdn51zcvx//kdeYwMDZ+cmEkA4ODhQuXASADh068+DBfT799GMKFy5q\nDpYqVKiE1icTLGNQ0E2Cgm5SoYIxHkOp8onmnTt3NgUKFKRt2w4W6ba2tixatCzBfeIGYDGKFi3G\nokXLCA4OxtnZmYsX/bG1taVAgQIEBgYQEHCZmjXrmPOXLFkqwdYqMFqB8ucvQNGixcxpJUqUOBgd\nXwAAFDRJREFUTDD/hQvnCQwMpH59T6ZOnUj16jXInj07tWrV4fDhQ7Rv39mcNyoqGhubjNfekPFK\nZCWuzinvoxRCpK+cdjnxcC1utVdqBx8AxYuX4MaN6xQpUtT8WrToW06cOE5QUBDTpk2kePES9OzZ\nh/nzl/Dii1X57bc9wH9f08rDoxSnT1s2yWt9KtH87u55uHv3rvn9vXv3OHDgD3x8+rJo0XLza/r0\nr4iKimLz5k0AlC5dhosXL/DgwX2L4x0/fhRHR0eLG21c3bv3onjxkkyc+Lk57X//ex2tT8ab7wJg\n4cL55M9fwHyzb9r0NXbv3mEx8BaMMRo///xjvOAsRuz/h9ivmIAwtqioKAYNeodLl/zJnTs3dnZ2\n/P77XsqXr4CDQw6OHTvCJ598aPHIr9YnKVmyZILnXrLkO1atehIARUZGcvbsGUqU8IiXd/HiBfTu\n3Q8wflBHRUWZ94kbTN69G4y7e54Ez5mesmwAYivr4QohMoBOnbqxfPn3bNniR0DAFb78cga7d++k\nZEkPXF1d2bVrB7NnTycg4Ar//vs358496T7JkSMnV65c5s6dO8DTWzFia9LkNUJC7vLllzO4fPkS\na9f+xM6d2xINaMqWVZw/f878fteubQC0a9cJD49S5lf16jWoUaM2fn5GN0zVqtUpVqw4H300gpMn\njxMYGMCuXduZMWMyHTt2fWoAlS1bNgYP9uXMGW3uUnjhhXL07t2PsWM/4scfV3H58mXOnTvLtGkT\n2bLFj48+Gmvu1mncuBmVK1dhwIC32b17B4GBAezf/xsffDCAsmVfMHeVpIStrS329g7MnTubK1cu\ns3v3DpYsWUjPnn0AePllL3LkyMnkyeO5fPkSmzf/ysqVy/DxMQaNRkVFcfv2LXOA0qZNBzZuXM/2\n7Vu4dMmfSZPGERUVRdOmzS3Oe/GiPwEBV6hXz3jypVy5Cuzbtwd//wvs3LktXnfauXNnnjnwNT1k\n2S4YZDVcIUQG0KRJM4KD7zB//hzu3LmNh0dpJk+eSaFChQGYOHEas2ZNpVevrjg5OdG6dTvzzbNV\nq9ZMnDgOf/8LjBnzucUN/Wk3d0dHJyZOnM7UqRNYs2Y1FSpUpEmT1wgOTrhroEaNmgQH3+Hq1UAK\nFSrMtm1bqF/fi9y543dLtGnTjg8/HIbWp1CqHFOnfsncubMYMeID7t0LNXV9dKRr1x7PrJuqVavT\nsGETvv12Hg0aNMHFxYVevd7Aw6M0K1f+wLx5X5I9uz3Vqr3EN98swsOjlMX1T5w4ne+/X8jXX3/F\njRvXcXfPwyuvNKBXrzdSPAdLjOHDP2TSpHH07dsdN7c8+PqOND8S6+joxLRpXzJ9+iT69u2Bm5sb\ngwf7mgccX70aSJcubfnqq/lUrlwFb+9XGTzYl/nz5xEUdINKlV5k2rQvcXBwsDjn4sUL8PHpa37f\nuHEz/vrrT95+uw+1a9exeNrl/v17nD9/jtq166bK9aYmm6RGzJlFx5X9owGGvvQeHq7F07s4mZ6d\nnS1ubk7cuXOfiIio9C5OliB1bn3PW50HBgZw+/Yti5lYJ08eT1RUNMOHf5jgPp99NpqSJUvRo0cv\nK5Xy6Z63Ok8vGzasZdeuHUyZMivFxzLVear9es+yXTBCCJFVhYSEMHBgf3bv3sm1a9fYuXMb27Zt\npkGDRonu061bT/z8NpjHGojnw/r1a+nevVd6FyNBWbcLRgghsqhy5cozcOBQ5s6dxc2bNyhYsBCD\nBvlSs2btRPcpVaoM9ep54ue3kebN/5doPpFx7N//G8WKFU9w5tiMQLpgRJqSZlLrkzq3Pqlz65M6\ntz7pghFCCCHEc08CECGEEEJYnQQgQgghhLA6CUCEEEIIYXUSgAghhBDC6jLEY7hKKQdgDtAWeABM\n1VpPSyRvNWAuUBk4BvTXWv9rrbIKIYQQIuUySgvIFKA68ArwDjBGKdU2biallCOwEdhtyr8f2KiU\nSv0VooQQQgiRZtI9ADEFFX2BAVrrw1rrdcAk4L0EsncGHmith2vDICAU6JBAXiGEEEJkUOkegABV\nMLqC9sdK+w1IaEq+2qZtse0DMt4qO0IIIYRIVEYIQAoBQVrriFhp14EcSqk8CeQNjJN2HSiahuUT\nQgghRCrLCINQHYHwOGkx7x2SmDduvqeyw4GiLgWws8sI8Vfmli2brcW/Iu1JnVuf1Ln1SZ1bX2rX\ndUYIQB4SP4CIef8giXnj5kvUqk5zU20ee5F0Li4yTtjapM6tT+rc+qTOn18ZIXQMAPIqpWKXpSAQ\nprUOTiBvwThpBYGraVg+IYQQQqSyjBCAHAIeA3VipXkCfyWQ9w+gXpy0+qZ0IYQQQjwnbKKjo9O7\nDCil5mIEEn0wBpQuAny01uuUUgWAu1rrh0qpXMAZYDnwDfA20B4oo7UOS5fCCyGEECLZMkILCMAQ\n4B9gBzAb+Ng0HwgY3SsdAbTWoUBLwAv4G6gFvCbBhxBCCPF8yRAtIEIIIYTIWjJKC4gQQgghshAJ\nQIQQQghhdRKACCGEEMLqJAARQgghhNVlhJlQU5VSygGYA7TFmCF1qtZ6WiJ5qwFzgcrAMaC/1vpf\na5U1s0hmnbcAPgfKAOcwnnj6xVplzSySU+ex9ikJHAVaaK33pHkhM5lkfs4rm/K+hDF1wECt9S4r\nFTXTSGadtwHGAcWAgxh1ftBaZc1sTHX/N/BuYt8XKb2HZsYWkClAdeAV4B1gjFKqbdxMSilHYCOw\n25R/P7BRKSXz+iZfUuv8ReAn4FuMVZC/AX40fVmL5ElSnccxF2M9JfHfJPVz7gJswfhCrgT8DPys\nlMprvaJmGkmt8wrADxgByIvAYYzv8xzWK2rmYQo+lgMVnpInxffQTBWAmCqkLzBAa33YNJfIJOC9\nBLJ3Bh5orYdrwyAgFOhgvRI//5JZ512A7Vrrr7TW57XWc4CdmOZ5EUmTzDqP2acb4GylImY6yazz\nXkCo1rq/6XP+CXAaqGGt8mYGyazzJsAxrfUPWusLwEiMZToSvYGKhCmlymPMLu7xjKwpvodmqgAE\n41e1HUYkFuM3oHYCeWubtsW2D6ibNkXLtJJT54uAEQmku6Z+sTK15NQ5Sqk8wATgTUAWY/xvklPn\n3sC62Ala69paa7+0K16mlJw6vwVUVErVU0rZYMyqfRejm1ckjzewHeNe+LTvixTfQzNbAFIICNJa\nR8RKuw7kMH0Jx80bGCftOsZU8CLpklznpij5aMx7pVRFoCGwzSolzTyS8zkHmAYs0lqftErpMqfk\n1HkpIEgp9bVS6qpS6nelVNw1rMSzJafOVwK/YtwQH2G0lLTXWt+1SkkzEa31PK31UK31w2dkTfE9\nNLMFII5AeJy0mPcOScwbN594uuTUuZmpP/wnYK/Wen0alS2zSnKdK6UaYSzg+JkVypWZJedz7gwM\nx/hybgbsAbYopYqkaQkzn+TUeR6MLpd3MJboWAIsknE3aSrF99DMFoA8JP7Fx7x/kMS8cfOJp0tO\nnQNgWmBwBxCNjLn5L5JU56YBePOAd7TWj6xUtswqOZ/zCOCg1nqsaezCCIwxID3SuIyZTXLqfCJw\nxPTr/SDwFnAf6J22RczSUnwPzWwBSACQVykV+7oKAmFa6+AE8haMk1YQY/E7kXTJqXNMvwL3YPTt\nvqK1vmWdYmYqSa3zWhgDyX5SSoUqpUJN6ZuUUnOsVNbMIjmf86vAqThppzEeDxVJl5w6fwnjyRcA\ntNbRpvcl0ryUWVeK76GZLQA5BDwG6sRK8wT+SiDvHxhN07HVN6WLpEtynZtGtfuZ8ntrra9bpYSZ\nT1Lr/E+gLFAVY0BfFVN6X2B0Gpcxs0nud0uVOGnlAP80KVnmlZw6DyT+Ey8KuJA2RROkwj00U01E\nprUOU0otAeYppfpgDIb5APABc9P/XdPgmh+BL5RS0zHmo3gbo09rVboU/jmVzDr/EOMX+SuArWkb\nGL9oQqxe+OdUMuv8fOx9lVIAgVrrIOuW+vmWzDqfB7ynlBqNMTeFD8bnfmm6FP45lcw6nw8sVEr9\njfHUTD+gOLA4XQqfSaX2PTSztYAADAH+wRhjMBtjps2YR+KuYppzQmsdCrQEvDBme6sFvKa1DrN6\niZ9/SapzjNkMc2L8Mg+M9Zph1dJmDkmt87iirVC2zCqp3y2XgKZAK0wzzwLNtdbSvZt8Sa3zVRjz\ng4wC/sV4FPRVCbRTLO73RareQ22io+X7SAghhBDWlRlbQIQQQgiRwUkAIoQQQgirkwBECCGEEFYn\nAYgQQgghrE4CECGEEEJYnQQgQgghhLA6CUCEEEIIYXUSgAghhBDC6iQAEUIIIYTVZaq1YIR43iml\ndmFMbRxXNDBVaz0sCcfwBnYCJU3TgqcqpVQJ4i/yFQncNp3XV2t9OZXOdQFYqLX+1PS+J/Cr1jpI\nKeUDfKe1zpYa50rg3D7AQoy6tzElRwEhGFNPD9NaH0rG8YoB9bTWK1O7rEI8j6QFRIiMJRpYCRTA\nWNo65lUIGJvM46SlaKANT8pXHGOtn2rAL6l4nhrAFACllBewCGPBK4AVGPWSlqKx/H8oDrTD+P/x\nM63wnFSLMdaIEUIgLSBCZERhWuub6V2IZ7AB7mitb8RKu6qU+gRYqpSqrLU+mtKTaK1vxXprS6zA\nSmsdDtyIt1MqS+D/IlAp9R6wC2gAbEjioWyenUWIrEMCECGeM0qp3MBk4DUgP3AHWAcMMC2THTd/\nGYyVROti3MR/B4ZqrY+ZtrtgtDK0BuwxuheGa63/+Q/FizT9G246dlFgAtAQyAX8htFFc9S0PR/w\nFfAq4ISxkukorfUe0/YLGN0guzFWRAW4oJTqjXFDX6i1tlVKLQTKa63rxLru4hhdRY211juUUvWA\nL4CawE2MlpqRplU9kyvcdP7HpnPZACMwloovadq+D3hXa31BKbUT8Aa8lVKvaK1LKaWyA58D3QBX\njJVzx2itt/6H8gjx3JEuGCGeP4uAKhgBQxlgENATeDOR/CuBK0B1jCWzI4E1sbZvAkoAzU3b/wB+\nU0pVSWqBlFI2SqmqwEfAIa31aaWUM0awUxhj2e66wANgj2k8BMA8IAfgCVQCTgNrlVI545xiH0bX\nRzRGABEzjiKmRWQhUFMp5RFrn+7AZVPw8SKwFfjVdJ4upvrYnNRrjHWtHsBEwB/YY0oeCHwADAbK\nAq8DLwBTTdvbAvtN5a5hSlsMNDKVpSqwCvhFKfVacsskxPNIWkCEyHi6K6U6xEnbo7VuYfp7C7Bb\na33c9P6SUmoAUDmR45XCuNFe0lpHmFoPygEopRoCtYG8WutgU/6PlFIvY9xU+zylnJuUUlGmvx1M\n/+4G3jL93QNwB9prrW+bztcVOAe8i9FiUAo4AvhrrR8qpQYCS3nSkgKAqdy3TW+DtNbhSqnY2/eY\nWku6YbQqAHTFuMkDDAU2a60nmt6fV0p1A84ppbxiWlwSYKOUCuFJ90l24BHgB/horcNM6WeAnlrr\nTab3l5VSq4H2pvLdUUo9wuheu21qleoMVNVaHzHtM8MUxA3DCAqFyNQkABEi41mHcROKPWYgLNbf\nc4FWpkCiLFARo9n/ZCLHGwXMBN41PWXjByw3bauG0RJ6OfYNHaMrxv4Z5ewLHDD9/Ri4YRqXEaMS\ncDom+AAwBRkHeBIsjcUIODoopX7DCJSWaa0fPePcCVmMKQBRSlUDymO0FoHR2lFGKRW3uyXalC+x\nACQao7XJBqO763OMAagfxX7CSGu9USlVSyk1FlCmV0WMlqeEVDX9+5up+yaGHUaXmhCZngQgQmQ8\noVrruI+5AuaxBhuBCsAyjCdB/gXmJ3YwrfVc06/x5hhjMT7FaOWoihF83MW4QccdJBnO0wVqrc8/\nZXtigy5tMY2d0FqvVUoVApphdEcMBsYopWprrRMLqBKz2LRvdYxujX2x6tEW+AEjgIhbrqcO+I11\njPNKqf9hBF1blVJVtdZ3AJRSI4CPMbqCtgHTMLrIOidy2JgBtS8D9+Jsi4yfXYjMR8aACPF8qYpx\ns26vtR6ltV4OnMcYCxLvhq+UyqeUmg04aK2XaK19MH7RF8IYFHkMcDFtPx/zAkZijGNIiSPAC0qp\nvLHKkwNjDMRxpZS9UmoqUFprvVpr/ZbpOqKAFgkc76mPFptaJHYCHYCOPGn9AOM6K2itL8S6Rntg\nBlAs7rGeco4wjFaWghiDZ2OMBD7RWr+ntf5Wa30AoxUk9v9J7PIfM20rHKfe+wK9k1oeIZ5n0gIi\nxPPlGkbrQSelVBCQF6OLpQBPxmHAkxvfbYybeSml1CggFOiF0brxN3AJOAysNI2/uIwxPsMHo8Ug\nJZZh3JhXKaWGYYydGIPxtMvXWutHSqmawMumMSzXMFppnDAGr8Z1z3RdVZVStxLYDkYryFcYP65W\nxUqfijH49UvgS8DNlM8BY+BrkmmtjyilJmK0Iv2gtd6IUW9NlFIbMFowemLMk3ItTvlLKqWKaK1P\nmPLOMz3SexwjcBqO8f8jRKYnLSBCPEe01lcxgoNWwAmMm+wVYDpPnq4A069trXUkxuO6URhdA0cx\numGaa639tdZRGF0ff2M8oXEYo1ugtdZ611OK8syJzrTWIRitLHdM596DccOvH2v8REeMFpx1wCmM\nJ3m6aq1jApDY5zmK8RTLShJ/4ucn0z5rtNbmrg2t9Z8Yk4BVAf4B1mKMmWmstY541rUk4HPT/nOU\nUk4YA24dgb8wBuJWxBiMm9/0KDIYT/xUBg6butI6mco7DyMA6QH00Vov/Q/lEeK5YxMdndYTJgoh\nhBBCWJIWECGEEEJYnQQgQgghhLA6CUCEEEIIYXUSgAghhBDC6iQAEUIIIYTVSQAihBBCCKuTAEQI\nIYQQVicBiBBCCCGsTgIQIYQQQlidBCBCCCGEsDoJQIQQQghhdRKACCGEEMLq/g8EDM8u7hmM7AAA\nAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x1554a5c18>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Plot ROC\n",
+    "plt.figure()\n",
+    "for label, metrics in ('Training', metrics_train), ('Testing', metrics_test):\n",
+    "    roc_df = metrics['roc_df']\n",
+    "    plt.plot(roc_df.fpr, roc_df.tpr,\n",
+    "        label='{} (AUROC = {:.1%})'.format(label, metrics['auroc']))\n",
+    "plt.xlim([0.0, 1.0])\n",
+    "plt.ylim([0.0, 1.05])\n",
+    "plt.xlabel('False Positive Rate')\n",
+    "plt.ylabel('True Positive Rate')\n",
+    "plt.title('Predicting TP53 mutation from gene expression (ROC curves)\\nVoting Classifier')\n",
+    "plt.legend(loc='lower right');"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Compare with Simple Classifiers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAiAAAAGbCAYAAAD9bCs3AAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAAPYQAAD2EBqD+naQAAIABJREFUeJzs3XecXFX9//HX7myS3WyypJPEUAU+oYZQlCLVgthFLIhK\nteMPBPyiFEFABAQUKaKiFEERpUnvPRQJGPoHgYQQSG+bbHY3W+b3x7kze3d2ts3Ozszuvp+PRx65\n984tZ8/cufdzT7tlyWQSERERkUIqL3YCREREZOhRACIiIiIFpwBERERECk4BiIiIiBScAhAREREp\nOAUgIiIiUnAKQERERKTgFICIiIhIwSkAERERkYKrKHYCis3MHgH2zljcBCwCbgdOdfdV/XTsw4G/\nAJu6+3wzOx34ubsnerj9B4A/AD9w9/nRsrnAw+5+ZH+kOXbsh4F9ulntanc/srd5bGYLgKkZ6yeB\nie6+Ilpnd+AcYGdgLfBP4BR3X5vbX9Q3ZrYB8DvgT+7+RC+2K9p3GB1rO+CvwNbAm+6+XX8fUwYe\nM2sFznD3Mwt4zNuA29z9L9G18fQsq60DFgD/Ak5395aMfWwP/ATYD5gILAaeBH7r7s92ctxdgP9H\nuL5NBN4HHgR+5e7z8vCnlSwz2wq4B9jR3Wv7+3hDPgAh3NieB74PlEXLhhNubL8CdgQ+0o/Hjo+F\n/yfg7l5s/zHgwIxlXwD6/cQh5FdNbP73hL8lno9Lo/97nMdmNp4QfJxAuFDErYrW2QF4ALgfOCha\n/zxgKzrmR6HsCHwT+HMvtyvmdwjhor4R8Hnavi+RTLsRbvQFET2cfcDd/xJbnIzSURZbNgE4BDgZ\nSAA/i+3jG4Tf4+zo83nANOAo4Ekz+4m7/zbjuD8EfgM8BJxECD62BP4P+JKZ7efuL+XtDy0x7v6G\nmd0KXAIc1t/HUwAS1Lr7fzKWPWFmo4FfmNmHOouW88nd3yec8D1VlrnA3efkL0Wdc/fX4/NmVgsk\ns+RjSk/zeEfCheaWLp42jgOWAQe7e3N0/DLgL2a2pbv/L7e/qk/KaB9M9ma7dgr1HUbGAy+5+70F\nPKYMMIW4/qWYWSVwLvC9LOnIdn25y8w+CBxBFICY2UxC8HG1u383Y/2/m9lvgAvN7EV3fyjaZk/g\nt8Dv3P2E2PqPRaUxLxBKrHft0x9Y+s4D3jWz37j7f/vzQApAuvYc4QaxCfBsVO2wAKgkPLU+6e4H\nmNkI4Czga8AkwIFfuvuNqR1FN8hTgG8Tovb7gMfiBzOzMwhVMOWxZd8k3HCnE2661xOeWr9O+DEk\ngXlmlqrumAc8FE1vAswFvgJ8FTiAUPVxE3Csu9dHx6gAzgYOJdyQHgH+DlxDVD3Ul0zsRrs8JgQg\na7op6jwFuCgVfESaov8rO9vIzK4CJgM3E55uphJKZo4AjFCl80HgJeC7qUAgqkJqdff9Y/vaB3gY\n2DdK/0OE7+IRM3vE3fc3s3JC8e83ov22AnMIVUWPmNlhdPMdRseqAc4APgd8AHgz+vuviqVnLuH7\nGgl8i1A69SjwI3d/s5P8aI2OXWZmLVE+lAFXEi7+ZwPDgI+4++tm9lXgRMK5uBa4FfhZqvosKib/\nGuEmcBawBfA6oeQLwsV9B+Atwvn3UPZvqufnpJntFR1rV6CBUKV3orsviz4/LPp7UjeXmYRi+Evc\n/cLY8br9DXeSzrGEm+XngQ2A/xK+39RN7UfAxcDh7n5ttGw/Qgnez939l9F5uSnht30aMA54Bjje\n3V/M+DuyfS+fB04FtiOUEv4DONnd10XbVgIXAZ8lVCnMBa7M+PuPjfa9KbAcuA34qbuviT5vVwVj\nZpMJv5ePEa5nLwFnu/vtsX22Aj8EdiKUVA4jlPAe4+5dlbYdBYwA7uwq7zOspv0DwMnAGuDYTtb/\nP+CLwM8Jv10Iv9WVhOtLO+6+zMx+DJiZVaWunZmifDkP+CRQRbi+/NTdn45dj9PnQrTN1cA+7r5Z\nNJ95n5kFbEx4UPhyxvH+C8x19y9G830+F9x9sZk9RPgdf7WT/MsLNULt2nTCSR2/gH+VUDz+WeD8\naNmtwHeAC6LlTwI3REWAKb8mXFz+SChiX0a4cMW1q5KJigOvAf4TbXMOoW7yd8AdhAsR0WdnxfaR\n6QrCifb5KM1HEU7SlD9G+704WmdxtKwQr0rOzOMdgZVm9i8zW2Vma8zshuiHDYC7L3T3lwHMbKSZ\nfQz4JfBED4pH9yBcFI8DDge2Ae4CLiTk51cJP/brYtt0lg+p5bOjfUK42f4gmj6PkM+/JwR/RxNu\nLv+MLgR30s13GK33JKGY+VxCEPIY8Gcz+2lGeo4l5OdhhO94F8L505ndCDfM56Pp1AU/ARwPHAn8\nOLrJnQr8jXAxPIgQEB0MPBzdvFM2IvwOzoo+H0uon7+ecE59nhDk/D1ju0zdnpNmtjfhRr4W+HL0\n9+8LPJSx73LChfhvhAv648CvzezjsXV68htuJzrGw9H6PyPc0N4F7jGzfQHc/RLC93WBmY2LSvyu\nivZ/Tmx3O0Z5dhoh6JpACGY3jK2T7Xv5OnAL8GqUT6cTqgJvjW13MeH8Ox74RPTZ+VFQg5kdQjhX\nL4k+/0W0j9918ndPIjw4fAT4KeF8mAvcGu0r7peE/E8Fr58lBIJdORS4092bMj8ws0Ts3zAzm2pm\nJ0XpviZapwz4OPCAuzdkO0C071uAj0RBJNE+Huxim3+5+y+7CD6qCb+PfaK/9YuENir3RSU0ncms\niof295nzCNejA6NjpI63NSGgTwW2fT4XYv4JfN7MRnaR7j5TCUhQZmbxhp/jCBeyU4BZ7v5C7LNG\n4HupH0d0ETsA+Iq7/yta534zGwWca2Z/A0YDPwIucPdfxtb5QLRtB9GP6DTgZnf/Xmz5SELpxyrC\nkyTAf7sppbjD3f8vmn7YzD4BfAY4JfphHEZ42ro4lrbJhBM0X3qaxzsSSiauINTFbk24MD9iZjOz\n/PiXEZ6WlhNuWN0ZBXw5VU0T3Si+C+zv7o9Gyy4g3KBqetIQy93Xmtmr0exrseqpyYQSgstT65pZ\nI+GGvIO7P2tm3X2HRxCCpN1jxeD3m9lw4DQzuyLWgHcF8Hl3T0bH2gI4w8zGuvvKLOl+1jKqzswM\nwsXwbHe/O1o2hvA9XeHu6SdKM3uFcHM9gvB9QXjq+7673x+tsy2hnc+R7p66QfyccIEz4MXMdJnZ\n5vTsnPwVIb8/E9v2aeA1wk3699HiMuAX7n51tM4s4EuE38D9PfkNu3trZjoJJU3bAx929+eiZfdE\nJWbnAR+Olh1BKPn6NdACjCE88cZvOjXAp919VpTGZ4G3CUHVydE67b6XyLnAXe6evoGY2f+AB83s\nwGjdvYH73f2f0SqPmdlaYEk0vzfwduw8fTz6fFyWvxlC+6zxwG7unmoXco+F9lsXEEqqUl5096Ni\nafswITDNKsrzXYEbsnxcRltJZ9w7hGvledH8OEJ+zuvsOJE3o31uHF2bKgmBVK6OIDy8zEw9CJnZ\nk4Sqm30IDVl7KvM+8xYhMPwCIZiH8FCykvAwCvk5F1L+Q2intxfQb9WzCkCCfeh4YrcQGjlm1h++\nlhGZ708oWr8r4wZ7OyGS3w6YQsjrO2jvRjoJQAgNKicRIto0d/8N4caculn0xNMZ8wsIVR4QWodD\nuCnG/Z38BiA9zeOjgWZ3nx3NPxnd3J8gXPD/kFoxKqb/LOHC8TPChXPPbkpBVma0EVkc/R+v414e\n/T+GPjQGdfdvRumcQLjZbhmlF0LQ1BP7APOy1MFfRyjl2I3Qah3gPxk3tdTNoZpwoeqNeDuU3QgX\no3Y3BXd/wszeIQSSV8Q+eio23V3+ZtPtOWlmVYQb/PkZv7t5hADk47QFIElivwF3X29mSwn5AvBR\nOv8Nf4PwG+4QKBF++4uAF2LblRF+5+eZ2Qbuvtrd50ZP6ZdG6xzu7u9k7GtuKviI0rgoCpQye5ql\nvxcLF4BpwC8z0v044bz9OKHK42Hge2a2EaG0787YgxDR5981s+cJ15u73D0eRGTah/DQkNko9TpC\nO6zpsSA827Wnms5tTCjpyRYIJAmlemXRPn5MOFd+5O7xa2uqXVW2YCUuVYVbFpvuUQ/ETuxJ+B7T\n15+oNGVrgKgKpqfa3WfcfV4UzHyNtgDka8CN7t6Ux3MhZV70/2a9SHOvKQAJZhOKX1MNCRuA+e5e\nl2XdzG6e4wlFjNm6f7YSnuZTRXzLMj5f2EWaxkf/Z0amuViXJV2p6rcJnRxnMfnVozx292cyN3T3\nWWa2GpiRsbyZ6KnCzB4n/GiOJQQxnckaUHRWrNoXFrrzXU64aNYBrwCpUo4OjU87MY5wk8uUWha/\niWf7niG3qtb4+Zx6Eu4sHe0CCc/eFTrbb6kzE6P/uzonxxL+rpMI1QBxySzH6+o3MI7uf8PZApDx\nhIeLzBtdqkh9CqFtAoQqoIui5fdn2dd7WZYtIbRZiYunMXWNuJy2YCuehlRX9mMJVUPfIFSrXGJm\nTxFKql509xujEtcfEEoSfmGhHdJJsSfluHG0lb7G9fSc7Orc3yD6P+v5Ei+NNrMnCFVwN5nZ/u7+\nZLTOMjOrI7Rn6UqqWmS+u68yszW0PZh1EJU+D/fOh2UYT36u15D9XPwr4bsbS0j7FoRq5NSxoY/n\nQmybVP5vQD9SABKsyahm6Y1VhMZO+5L9h/Um4UmtDNgQiD99j8+yfny/0HYxBsDMxhEadWV2Uc1V\n6ilmQ9p3s5uUp/2ndJvHFhpbfgl41t1fiS0vIzyBL43mPwOsdvfHU+u4e21UTJk5fkg+JOn4ZDSq\nqw2iuv67CW0stnZ3j5YfSPgbe2oFbRfKuCnR/4XoOruCcP5Opv35m0pHtptRX/TknKwlfC8X0b7I\nPyXzxteVnvyGO9vuDUJReLbt4k/xlxLS3Ejobv/ZjHUn0NGGdH1DS10jTiQ0OM60EtLtHX4F/MrM\npkXH/jnhSXr7aJ1/AP+IzttPEAK768zscXfPDDxXEM6FTKnfXl/OydRDWmelY2nunjSzIwhtHq42\ns23dfX308e2ENhMjUw0w4yw0EP8Cod3YimjxvcB+ZjY8tp+47xDa8uzi2XuHrCJL0GNhzKKVtJ2T\nvbqWxNxIaMPxRUKpSrzULG/nQqSzh+a8UiPUvnuUcAKVu/vzqX+Ep/UzCEHeLKCe0FAu7nNd7Pd1\nwpefeaE6jNBYcDihCqOvniQ8lXwxY3lvbpL50ki4UGc+0X6eUM2Saq3+Y+DyKDABIPoxbUP7qoN8\nqSUUb8btlTHfQvub0HRCgPm7VPAR+VT0f3lsu648Cmwa1Z3HfZOQX511e86nZ6JjtWtgaKEHysaE\nYt586vacjEpZngemZ/zuXgXOJAQTPdWT33Bn220ELM3Y7pOEG3iqi/hBhOLy4whtwT6dpdHfVhar\nUzWzqYQG0w90ke7XCQHK5hnHX0hoDzHTzCrNzM3seAB3X+DuvycEbZtEx7rBzG6OPl/j7jcRGkdX\nkD2gfxTYIyrGj/sGsMjd+xKQvkf4TWTuO6uo3dSZhCD9pNhH5xCqaf4QBRuZfhVtE69+uJAQCJ6d\nuXLU/ugE4OVOgg8Iv4PNLTQOTW1XSeh1dyRtpa/TYp8PAz7UxZ+Y5u6rCdf+zxPa0cQbyuflXIhJ\npTGzqjCvVALSd3cRTrx/m9lZhPrnDxMaDN3lbSN3ngWcZWbrCDfSTxMawWXl7q0WujVeGtVX/5tw\nUzuD0IVwtZmtItz0vmRmd2Xc6Hokqp/+CyEiHkG4gR8US1u2xnf9wt0bzexcQsPJJYS83YHQmvtW\njxqJEhql3gfcaGZ/JDwZn0poW3BRPyTtDuCzZnYh4XvYixAAxKWeQD4TfS9OuOCcYqGLaxPhopFq\nkFcd266r7/BqQg+bW6PzIdWb6XBCt8h+H7DM3VdG38tpZtZMeLrcnHDhf5moFX4vdVoM34tz8mTg\nTjO7jvAEV0F4Atw1SltP9eg3nMVVwDHAA2Z2DqF67ROELp4Xu3tL1P7n98DdqXYVFgZ6+q2Z3e9h\n7B8IAentFnobtRDO+WWEnilZRdeIU4ArLHR5vZ3w5Hoqobv2bHdvMLPZwM/NbD2hKmk64fxJVa88\nBPzezH4d5cW46PhvkD2gv4gQbDxoZr8g/O4OJwR9R3SW3p5w93VRW4ePEJ72e+I3hGrXkyx0ZX/X\n3V+2tpGmtzCzywm/nSlRGj8O/J+73xc79jNmdhrhOr0NoVfNMkLJwImEdltf6SIdVxEawv87+q0u\nIwSdw4BLo2qeWcCPzOxNQknSsYSHq55WUf6VMIxCeTSdSnu+zoWUvaI05fvhoh2VgAS96W7abt2o\n0d+BhCjyZ4QGganufIfE1juXcDIeTOhjvx2hK1Sn+4+i08MJP+zbCSfrrwgXOAgNiu4nRPsXdJLG\n7rqQQngqu4IQ4d9KOGFTXUJ7M7R5V/nYozx297MIddEfJ9zsf0yo1/x6bJ1Hos8nEX44FxO6Be7u\nXY8v0Fk6ukvbXwhPEYcQnkB2o2MJ0SuEbp4/BK6LAoPPEW60NxJu0tMIP+w1tJWgdPkdRm1T9iZ8\n/2cSzp09CL1KzspYP9du091u5+6/IHwv+xG+l9MI7Rr2ymg/09M0dLdet+ekh542BxDy9Z+EG8Z6\n4KNZGu1mO34qj3v0G84UFe3vRbhIn0e4eX+BcGNLDWR1GeEGEx9U65jo/ytjy96JjvebaPnrwJ5d\ntDdIpeHPURp3J3wvlxGqxPaJNXT9NuHmeAKhmuEUQpfmH0T7SHV5/iThPLuCEFh+wtuGNo/n12LC\nOTib0I7gn4Tv4HMeG9+Czs/J7r77fxFVhfRku6ha4ThCD6z4eBb/IIy2/CLhwe0+Qh6vAPbw2NgX\nsW3OIZRSJgnfxZ2E3/S/Cb1b3ugs0VGp3F6EhreXEH4fZcC+3tbD7TDCtepPhO9kNtm7JXeWR3cR\nqlOe9YzxffJxLsR8ktB7srGzvzcfypLJQgz1IKUqatB0IOEJbWVs+a8JrfUndrqxSD8YauekhYHI\n9nH3zYudllJgoYfTW4RA7rru1pf8inrrvAnsnNEwNe9UBSPrCE8xL5jZbwlPl3sQntKydc8S6W86\nJ4cwd6+3MCr0iWZ2vbfvWi7970TgH/0dfICqYIa8qIhtf0Ij2asIRXyHEAaB6tAYS6S/DdFzUjfZ\nmKhaaAFdd6mXPIsaQn+GtmrCfqUqGBERESk4lYCIiIhIwSkAEZEOzOx6M2u18AbQnqy/T7T+3r04\nxibRNt/KPaX5ZWanmNkJ3a8pIn2lAERE2olGpP0Cofvid3qx6WCozz2Lrt9VIiJ5ogBERDJ9nRBM\nHEtol7ZfN+uLiPSauuGKSKYjgAfc/dFoxMbvEgZMSzOz7xIG0tuIMFT7VZk7iapjTiYMNV1NGGb7\nmmhQs7hpZnY74a20ywgDv53p7q3RfsoJA3l9j/ACrqWEQd/OiA+UZGYfJwyQtgNhGPR7CS9UWxB9\nXkYo4fg6YYjx9wlv+D0tGrW0lRB4nWFmp7t7X96MKiLdUAmIiKSZ2baEocyviRZdA3zBzCbG1jmG\nMLz47YTRXp8mjKYY388OhPeYLCEMX/0Z4DHgdDPLHM76DMKbVD8P/JkwOuOvY5//kTD8902EdyNd\nQhgp9dbY8b5JCDjeoe29K7sDT0XDoUN4x9D3ouN9nDDC7k8Iw1UTrV9GGIl0ty4zSkT6TCUgIhJ3\nJKEU4vZo/hrCO1GOAs6Nlp0K/N3dT4zmHzCzDQglJSk7APe6e7qBqZk9QAgy9iUMT59yt7t/O5q+\nP9rXD6L3skyN0nSSu6eCkgfNbCHwVzP7JCHwOC/aT/odPdF7N14lDKz0U8KQ9s/Fhgt/PHo30ypI\nvwsEYIG7F+IlfyJDmgIQEQHAzCqAQwklC9XRzXgt8AThHRLnRgMVTSK8oC/uRmIBSDSE9nXRy+S2\nArYEdiRcc0Zk2TbuZkL7k90IrzdPEqpK4m4gvKhvX2Ae4fXw7dZx97fN7Cna3oz7cPQ3PEZ4V8ad\n7n551swQkX6nKhgRSfksIbg4ivDCq5WEF3ftBWxqZgcQ3pQKoZQkbiGxN9xGr/6+ElgNvEAoodiE\n8FbgzDfhLsqYXxKtMzZ2vHbrRC9JWwaM6Wyd2LIx0TbnE14sVkUozXnFzF4ys32zbCci/UwBiIik\nHEF4Cdi+Gf/2B2oJ7SdSgceGGduOz5j/HXAQ4e3Po919S3c/jBCAZBqXMT+ZUOqxhBAApZalRaU1\nE6L0ZF0nMiWWZtz99+6+a7Tu4YTSmJui/YlIAelHJyKY2YaEV3Cf6+6PZ/n8n4Qb9g+Bd4EvA/E3\nlX6O9uOA7Ak87O53xPaxMzCRjg8+nya80j3lEMIL6Z4h9FQpi5adn7FOOfA44ISSjkOAv8aOtzmh\nYelF0fyTwH/c/Th3XwZca2ZjCK9dryEEMq3Z8kdE8k8BiIgAHAYk6NjWIuVawovBvg38H/B3M/sj\nIXDYg1A6Evcs8OWou+5rhPYfpxBu8JkDfX3JzN4H7icEQd8GTnX3tcBrZnYNcKaZVRN60swETgce\ncvd7AczsZ8BfzOx6QhAyMVpnGSHAAHgUOMHMFgOzgGnACcAj7p4qRVkF7Glme2ULxEQkf1QFIyIQ\nSjdedvdXs33o7k8Acwk9Um4EvkpoJHob8Ck6jph6PHALYdyN26PtzgL+BOwejckBbQOe7QrcSaiy\nOdbdz43t60hCT5yvR+t8nxBUfDqWvmuibbeMjnsBofHsh9x9SbTaqcAvCVVNd0fr3B1tl3I2sAtw\nl5lN6ySvRCQP9DZcERERKTiVgIiIiEjBKQARERGRglMAIiIiIgWnAEREREQKTgGIiIiIFJwCEBER\nESm4ITcQWTKZTK5YUUdrq7ofF0J5eRnjxlWjPC8c5XnhKc8LT3leeOXlZYwfPyrzXU657y9fOxoo\nysrKKC/PW/5JN8rLy5TnBaY8LzzleeEpzwsv33k95AIQERERKT4FICIiIlJwCkBERESk4BSAiIiI\nSMEpABEREZGCUwAiIiIiBVdS44CY2QjgOeCH7v5YJ+vMBH4PbA+8DHzf3Z8vXCpFRESkr0qmBCQK\nPv4ObNPFOiOBO4FHgZ2Ap4A7zayqIIkUERGRvCiJAMTMtgaeBjbrZtWvAevc/SQPjgPWAF/u7zSK\niIhI/pREAALsAzwI7A50NdTah4EnMpY9GW0nIiIiA0RJtAFx9ytS02bW1apTCO0+4hYD2/ZDskRE\nRKSflEQA0gsjgcaMZY3AiCKkRURkUFtb30TD+uZiJyOrikQ5TckyVq+up7mlteDHb2hpYFnDsoIf\nt5gS5WXsP3Zm3vY30AKQBjoGGyOAdb3ZSSJRKjVPg18qr5XnhaM87536xmYa17d0WN7SmmTZ6gZS\n799qbmll0Yp6RgzrmK/l5eVUVQ2jvr6J1tbsN8O336+lvLyMBUvWMn6DSgBaW5PM9qVsOmV0h/Vf\nfXcJZZV1QNf10v1F75ftXFmimRHTnyt2Mopi/+1/n7d9DbQA5D1gcsayycDC3uykpkadZgpNeV54\nAyHPV69t5LnXFjN/0RpqqodT19DE3PdrmTim+7Q/9/pilq6sZ+qEasrK2t+i31u6FghPyV3p0ZNz\noikdCOTNkth0Bby2tP2TdFmimaqdh+YNToaOgRaAPA2clLFsT+Ds3uyktraeliIU2Q1FiUQ5NTVV\nyvMCKmSer29qoWF9Cw/OXkDl8ATxOGDtuiYaYiULr89fSUWinLffr2XaxGoWLO3FTb2TIKCsGhbW\nr8q6HKBjuUbGet19PoSfdKVnPjXpywwvHxqtAMrK8luqWvIBiJltCKx29wbgX8CvzOw3wB+B7xHa\nhdzYm322tLTS3KybYSEpzwsrmUyyrqGJ5uZWFi1fxy2Pv82qNY2Mq6kkUZ79tjv7jaVMmziK8oxr\nzPzFa6kakaA8o5ShrqGXbQOiIKKsGt5btyodJMRVlJfR3BoK/ydE1RTJ8ibqpj7Zu2MNIsfMOJrK\nispiJ6PkVCTKGF1TxZraeppbilNhNLl6IlUVpV/SmC8VFYM/AMk8kxYChwPXuvsaM/sM8AfgO8CL\nwIHuXl/YJIr0r9bWJI1NLdTWre/w2RvvruK1d1YyrqaSl99ezvwlaxlVNSzdVmF9c2u7koe4+UvW\ndnncBUuzf17f2F1ZQpt4nFI1vILqqooQRGz2ICSaut0+dVHqOqWF11Ug0F83w6F2g+uNiopyxo6t\nZmV5nR5uBqiyZHLINTVKrlypE7ZQ0hcJ5XmnmppbWLC0jrfeW039+hZueeztfj3epLFVjBmVvch4\nwZK1TN9kLJXDEwC0sJ6G8tWsqG1g4w1HU5FRetLQ1MLoqmEMH17BDpuPY1hFIut+F9Yt4vrX/9Xn\ntBerNKC7QEDneeEpzwsvyvO8tYkuxRIQkUGpuaWVV+et4LYn5tGwvpmFy3vVeSurDaqHU9fQzLia\nEey4xQSGVZRTXl5GZeUwFi+rY7Ood8W4mkq222wcZWVl1DfXs6huaSd7nJCeamhu4NI5V4eZSliW\npGOjinJCR/hGeHhOz9J86PSDmVKd2Za8eyoNEBlcFICI9FF9YzNNLa2sWtPIu0vW8vwbS6lIlFNd\nWcGCpXXMXVhLS2vvSxpnbjkB23gsk8eNzPgkyaSxI7MsD+JPhmsa6qJgo455tXVRUHFl7//IPKmq\nqGLmpO0VSIiIAhCR7jS3tNLY1MK7i9dy2xNz8Xc79rrIRXVlBXUNzexiE5kwpoptNh3LB6duQEWi\nLF2V0VlpRT3rmLs6+34rEmUsa61iyYqVXPz8n/KS1nxVfagUQ0RSFICIRJLJJO8tq+P6+96gqaWV\nt9+v7fM+p4wfSV19E2vqm6iuHMZHtp/CTltNZItpG3S6TX1zPQtWL+330oqeBhUKGkSkPygAkSEr\nmUzy/BtLueK2V3KqItl928msb2phwphKJo0dSdWIBMMSCbactgGjRw7rMDhWT9Q313ParHOpb85v\nx67MYENBhYgUmwIQGRKSySRvvLuK1mTo4nrFbS93O45F1YgKakYOwzYey8gRFYzZoIxRY9czedzI\nLMFFC6mt5J87AAAgAElEQVQWmsub61meY+HJwrpFWYOP3lSBZHYJVbAhIqVIAYgMarN9CZfdkvkC\n5UiW0TWnTqhm7xlT2WJqTbsBLdLVIauBef2X3rhUb5HeBhAaH0FEBgIFIDLoLFtVz6vvrOTqu19v\nW5gRbHQ2xPYK4NZFwKL+T2dX1FtERAY7BSAy4Lzx7ipeens5S1fV8/o7K6ld18SG40aSKC/j/WVZ\n3hcyvJ7KHR/N2/ELMRiWqk1EZLBTACIlrbU1yR2z5vHA7AWsre98GO/FK2KDesVKO3ryMrHeBBQK\nDERE8kMBiJSUxqYWnnplEdfe473abuzoEXxwag2JykZeHNH5uwnVG0REpDQoAJGS8Ma7qzj3+ud7\ntO5HdpjCLjaJ7Tcf1643ysqGVZw665xOtzt7j5MZWzmmz2kVEZG+UwAiRbFyTSOvz19Jc0srV931\neqfrjRiWYGebyGf33JQNx2YfehzC+BmZwUe8tEMlHSIipUUBiBRUMpnkvv+8yz8eerPTdT74gRp+\n+MXtO31ja0p8mPKFde27rai0Q0SktCkAkX63ZMU6jvrlA92u993PbcuHtp6UfmPr3NXzO123q2HK\nj5lxtIIPEZESpwBE+kUymeTmx97mzQWru3x52yXH7UUZYdTRVHuO7tpydKWqoopNN9gop21FRKRw\nFIBI3q1Zt55jf/dE1s92sYk0NLXw9Y9tlfV18tnacnRHbT1ERAYeBSCSV+de/zxvZJR4pF47f9mP\n96ZqRPZTLtWeI7MtR3djdCjgEBEZmBSASF6sqG3gxMtndVh+5lEfYuY2U1i5svP3knT2BthjZhzN\n1uO36pf0iohIcSkAkT77673Owy+8127ZiOEJLvzBntSMGt7t9ovqlnYIPtSWQ0RkcFMAIjlLJpN8\n59eP0NKabLf8+K/MYLvNx4eeLKsWsqy17dXw2cSrXXJ9A6yIiAwsCkCk1156ezm/uXFO1s/+fNJ+\nlJWV5dyTZUr1ZDbbYOO+JlFEREqcAhDpkdVrG7nmHue/by4LCzJeb7/n9pPZb+Y05tW+2+UYHV2p\nqqhicvXEfCVZRERKmAIQ6dJb76/ml9fODjOJJsqq67K+YXZ2K8yenX0fp+zzI1rq6bQKJkXVLiIi\nQ4cCEOlg2ap6fv6XZ2lY3xIWJJoor17d7Wvts/nV3qfywckf6LIXjIiIDD0KQKSdZavr+b8rnmpb\nkGiicsajlFU0Z12/q3E6JldPZHRldX8kU0REBjgFIJL2/rI6Tr3ymXbLRo2voyUj+EgFHaoyERGR\nXCkAEQCefW0xV9z2Srtl5/+/HTn96XPT84dOP5iZk7ZX0CEiIn2mAERYWlvLHx54krJYbcnn9prW\nLvgAFHyIiEjeKAAZwlauaeTM6x9j/Vb3U7lt+8/uW9F+/uw9TlbwISIieaMAZIi66dG3uGv261Tu\n+Gi36569x8mMrRxTgFSJiMhQoQBkCPrF1f/hnaUrqNq5ffDx1U0OZaMJY9stU0NTERHpDwpAhpin\nX1nEO4vWUFZd1265SjlERKSQFIAMEfXN9dwx+xXueXY+ZdVQXrU2/dkxM45W8CEiIgWlAGQIWNO4\njlOeOIeWsvUdGpsCnQ4kJiIi0l/Ki50A6V/LVzdw3B/voaVsfdbP9QI4EREpBpWADHI/+f0symva\nRjIdtWxnvnfA7ul5NTIVEZFiUAAySNWuW89xv3sCEk3tXiL3vQN2Z7MNNi5iykRERFQFMyglk8kQ\nfABlle17u6i6RURESoFKQAaRFbUNnHnNc9TWZW/vccyMo1XdIiIiJUEByCCwtr6J/3fx4+0XJpoo\nq6zjoE9M5K73wiL1dhERkVKhAGQQeOC5d9svSDRROeNRyiqa08GHiIhIKVEbkAGuNZnk30/OS88f\n+vGtOOHITSmraG63nrrbiohIKVEJyACWTCY5+ryH0/MTNqhkp21Hceqs36WXHTr9YKZUT1Z3WxER\nKSkKQAaoZDLJUbHgA+Arn/gAp846p92ymZO2V+AhIiIlR1UwA9T197/RNpNo4lMfH8lV71zWbp2z\n9zhZwYeIiJQklYAMQOubWnjo+ah1aaKJMbs+wcOrG9uto7fbiohIKSuJAMTMRgCXAwcB64AL3f2i\nTtb9IvBLYCPgBeBYd3+hUGktBVfc9kp6esKUBupaFXyIiMjAUhIBCHABsBOwL7ApcK2ZzXP3m+Mr\nmdk2wPXAt4FZwPHAnWa2ubs3FDTFRbCuoYmLbpzD24uXU1ZdR1mimbqpbcOsHzr9YLX5EBGRAaHo\nAYiZjQSOAg5w9znAHDM7HzgGuDlj9U8AL7v79dG2PwN+CGwDPF+4VBfHb26cw9xli6na+dGsnyv4\nEBGRgaLoAQgwg5COp2LLngBOzrLucmBbM9sjWv9IYDXwVn8nstj+dNcc5q59m8odn8v6uRqciojI\nQFIKAcgUYJm7x0fOWgxUmtl4d18eW/4P4HOEAKUl+vdpd19dsNQWWH1zPTc89R/+W3kHI6a3/+yY\nGUdTWVGpMT5ERGTAKYUAZCTQmLEsNT8iY/l4YDLwA+AZ4PvA1WY2092X9Wsqi6C+uZ5Tn/gVDa0d\nm7eooamIiAxkpRCANNAx0EjNr8tYfh7wortfAWBm3wVeA44Aft3TAyYSA2P4k6f8rQ7BxzE7Hs0W\nYzehatjAKPFI5fVAyfPBQHleeMrzwlOeF16+87oUApD3gAlmVu7urdGyyUC9u6/KWHdn4OLUjLsn\nzWwOsElvDlhTMzBu3n978NV0tcv6t7fjmuMOY4OqUcVNVI4GSp4PJsrzwlOeF57yfOAqhQDkv0AT\nsBuhay3AXsB/sqz7PqHHS5wBz/bmgLW19bS0tHa/YhG9vXQRI6a3NTg97Wv70dpQxsqGuiKmqvcS\niXJqaqoGRJ4PFsrzwlOeF57yvPBSeZ4vRQ9A3L3ezK4FrjCzI4FpwAnAYQBmtiGwOhrn40/AVWb2\nHKEXzLeBjYFrenPMlpZWmptL94Stb67nvBcuaLdsYuWEkk5zd0o9zwcj5XnhKc8LT3k+cJVK5dnx\nwGzgIeAS4DR3vy36bCHwFQB3v5EwPsjJhHE/dgf2G2wNUOeunt9u/szdfqZeLiIiMqgUvQQEQikI\noSHpEVk+K8+Yvwq4qkBJK7j65noum/Pn9Py4pXszfuTYIqZIREQk/0qlBEQivmxeu/kfHbh3cRIi\nIiLSjxSAlJD65nr+9GqscOetDzOppqZ4CRIREeknCkBKyMK1S9rNn/utA4uUEhERkf6lAKSEXHzz\n7PT0Fo0fZ/SIkUVMjYiISP9RAFIi/rdwGc2bPp2e/+QuHyxiakRERPqXApASMNuXcO6/Hmu3bNOx\nU4qUGhERkf6nAKQEXHbLy+3mv7/DkRr3Q0REBjUFIEXW2prssKx6mNp+iIjI4KYApMiOPv/hYidB\nRESk4BSAFNHa+qZiJ0FERKQoFIAU0R/+/Up6euaWE4qYEhERkcJSAFIktXXreWXuivT8/jtNK2Jq\nRERECksBSJFcevNL6enpG4+hakRJvBdQRESkIBSAFMmb761OTx/z5eksrFtUxNSIiIgUlh67i2Dh\n8rr09NRJI/j5U+dR31xfxBSJiIgUVk4BiJnNAI4FpgNfBj4PvOruj+QvaYPX/xZEpR+JJmbuWs5D\nS9uCj6qKKiZXTyxSykRERAqj11UwZrYz8DSwObAzMAKYCdxnZp/Kb/IGp6vvfh0STVTOeJSHlt6V\nXn7o9IM5a4+fahRUEREZ9HJpA3IecKG77wusB3D3bwOXAmfkLWWD1Fvvh9KPsso6yiqa08urKqqY\nOWl7BR8iIjIk5FIFswvwgyzLLwO+07fkDH5/ufO1DssOnX6wgg8RERlScikBWQ/UZFm+EVCXZbnE\n1Nat77BsSvVkBR8iIjKk5BKA3Ar80szGRPNJM5sOXAzckbeUDUKN61uoawjVLttvPq7IqRERESme\nXAKQE4FRwDKgGngeeAVoAX6Sv6QNLslkku9f9Gh6fvTI4UVMjYiISHH1ug2Iu9cCe5rZRwm9X8qB\nl4F73L01z+kbNP563xttM4kmttpiJM//r3jpERERKaZeByBm9hBwkLs/CDwYWz7JzO5195n5TOBg\n0NjUwiMvvBdmEk2M2fUJbvhfY3ETJSIiUkQ9CkCi8T12iWb3AU42s7UZq20JbJq/pA0e7y5uy6qy\nyjoaW9uCDw08JiIiQ1FPS0DmEcb5KIvmv0Zo85GSBNaiNiBZPfHSwvT0Nw/cnH/OfxpQ91sRERm6\nehSAuPurhJFPMbO5wK7uvqw/EzaYPDbn/TCRaOKf8/+WXq7utyIiMlTl0gh1s84+M7NKd2/oW5IG\nl+Wr27Jj7IQm4pmjqhcRERmqcmmEOh44BdgeSESLywjvhNkGGNPJpkPS068uSk9vs+k4nk+G6WNm\nHK3SDxERGbJyGQfkcuBbhHFA9gbeA0YDuwG/yl/SBofGpramMvvsODU9XVlRWYzkiIiIlIRcApCP\nAYe5+yGAA792912AK4Ft85m4weCOWe+kp5taOw7DLiIiMhTlEoCMAl6Mpl8HdoymLwH2y0eiBqVE\nE5fOubLYqRARESkJuQQg7wGbRNNvADtE0+sAveAkJplMpqe3tmHtPlMDVBERGcpyCUBuAq42sz2B\nB4DDzOxg4BeABhePOfva59LTW0zdID2tBqgiIjLU9boXDKEHzDBgE3f/m5ndBNwIrAa+nM/EDWT1\njc3MXbgmPb/RlEqoDdNqgCoiIkNdLuOArAeOi81/z8xOJtxeWzrdcIh5+/3a9PTEcRVc5dcUMTUi\nIiKlpVdVMGa2nZlZ5nJ3X0HoAfNsvhI20M15s22g2K9/Zkq7z9T+Q0REhrqevoxuM+DfhIHGMLNn\ngU+7+wozG0Zo/3EisKK/EjrQvLFgVXp69Mjh6Wm1/xAREel5CchFQA1wOHAIoSvu+WY2CXga+Clw\nA1GAMtS1tiaZH38DbllZelrtP0RERHreBmRP4Eh3vwPAzF4DHga2AqYQSkPu7p8kDjwvz20rCJq+\nsUamFxERydTTEpCxwH9TM+7+EqFEZBSwo4KP9v71yFvp6W9/VoPDioiIZOppAJIAMscRbwSOd/cl\n+U3SwLa+qYUFS9uqX8aOHlHE1IiIiJSmXAYii5ufl1QMIvOXtAUfu287uYgpERERKV09DUCS0b9s\nyyWSTCY556+z0/Of2WOTLtYWEREZunraCLUMeM7M4gONjQQeNbPm+Iruvnm+EjfQXH//G+3mx4xS\n9YuIiEg2PQ1AftGvqRgk4oOP7b/TB6gakctI9yIiIoNfj+6Q7q4ApAeW1zYCUDUiwTc+0WHAWBER\nEYmUxCO6mY0ALgcOAtYBF7r7RZ2su3207s6Et+8e6+6PFCipnXro+QXp6b12mEp9cz2L6pYCsLBu\nUbGSJSIiUpJKIgABLgB2AvYFNgWuNbN57n5zfCUzqwHuA24FDgO+BdxiZlu6+zKK6Lr72tp/bLJR\nBSc+dnoRUyMiIlLaih6AmNlI4CjgAHefA8wxs/OBY4CbM1Y/HFjj7t+P5s8wswOBXYB7CpTkziWa\nKK9ezXULsielqqJKL6ITERGhBAIQYAYhHU/Flj0BnJxl3X2A2+IL3P3D/Ze0nnn4hfcg0UTljEcp\nq2jXKYhjZhydfv/L5OqJehGdiIgIfQhAzGxjYGvgMWB0H0ZEnQIsc/f4nXsxUGlm4919eWz55sCz\nZvYH4HPAXOBEd5+V47H7rDWZ5K/3OmXVdR2Cj7P3OJmxlXoXjIiISKZeByBmNhy4FvgK0Ep4Id0F\nZjYa+JK71/ZylyMJw7rHpeYzB9IYBZwEXAx8kvBm3vvMzNz9vV4eNy8Wr1jXYdmh0w9m5qTtVdoh\nIiLSiVxKQE4lVJvsD9wRLfsdcBVwLvCDXu6vgY6BRmo+8+7eDLwQ6xY8x8w+AXwzOnaPJBJ9HYG+\nzdOvLu6wbKOaKYyurM7bMQayVF7nM8+la8rzwlOeF57yvPDynde5BCCHAN9390fMLAkQTR9NKBnp\nbQDyHjDBzMrdvTVaNhmod/dVGesuBF7PWPYGsFFvDlhTk7+SidufnNdh2eiaKsaOVQASl888l55R\nnhee8rzwlOcDVy4ByAeAN7Msnw+My2F//wWagN2AVFuOvYD/ZFn3aWDvjGXTget7c8Da2npaWlq7\nX7Ebq9dm1hwFa2rrWVle1+f9DwaJRDk1NVV5y3PpnvK88JTnhac8L7xUnudLLgHIq8DHgCszln8t\n+qxX3L3ezK4FrjCzI4FpwAmEcT4wsw2B1e7eAFwBHGNmPycEHYcBmwHX9eaYLS2tNDf3/YS96dG3\n09Of2HUjHlv3NADNLcm87H8wyVeeS88pzwtPeV54yvOBK5cKnTOAi83sIkIAc5iZ3QCcDpyTYzqO\nB2YDDwGXAKe5e6q77UJCg1fcfT5wAKEHzEvAp4FPufvCHI/bJ0+90jbC6fZb1hQjCSIiIgNSr0tA\n3P0OM/sSYZyOFuAnwMvAV939plwS4e71wBHRv8zPyjPmnyIMPFZUyWSSxvXh5cCTJw7jsjl/LnKK\nREREBo5cuuFu7u73UAojjxZR7bqm9PSosY2sjn2m0U5FRES6lksVzJtm9piZHWFmQ7arx02PvJWe\n3tUmpaePmXG0xv8QERHpRi4ByL7Aa4QXyC0ys2vNbP+8pmoAeOKlqNlJoonKmrbhSlLDrouIiEjn\neh2AuPtj7v5dwlgd3wKqgDvMbJ6Z/aLrrQeH5lSXr0QTI3d8jBv+l/nOPBEREelKzsOauXuTu99C\nGHjsNGAs2V8gN+i8Om8FAGWVdSQTbW1B9LZbERGRnsnpZXRR248vAocCHwXmAb8GrslbykrYkpX1\nHZbp/S8iIiI9l0svmBuAzxBeRPdP4KPu/ni+E1bKZr28qMOyKdWTFXyIiIj0UC4lIBsSql3+5e4d\nXwU7BMxbtKbYSRARERnQchmIbL/+SMhA0Rx758DUCSNZUcS0iIiIDFQ9CkDM7G1gV3dfbmZzgWRn\n67r75vlKXCl69rXF6emtpo3h6aYuVhYREZGseloCcg2Qanl5df8kZWD4y52vh4lEE5OmNId3AIuI\niEiv9CgAcff4+B4PA0+5e7tnfzOrJLwcbtBKJpO0JpNh8LEZj/Lv+c3FTpKIiMiAlMs4IA8DY7Is\n3wa4rm/JKW2p7rdllXWUVbQFHxr/Q0REpHd62gbkOODCaLaMMAR7tlWfzVO6StKa+o4NPjT+h4iI\nSO/1tA3IpcAKQonJX4AfQ7sXwCaBtcBDeU1diXnxreUdlmn8DxERkd7raRuQZuBaADNLAje4e2N/\nJqwUvTK3YwAiIiIivdfTKphvAf+Igo4k8NVOqmBw92vzl7zSMrwiUewkiIiIDAo9rYK5GrgHWELX\n3XCTRCUlg5G/uwqAzaeM5v0ip0VERGQg62kVTHm26aGkcX1Lerq8fEhmgYiISN7k9DbcODObCOwD\nPOfu8/qcohL1+IttZR7bbjaWBSuLmBgREZEBLpe34W4H3AwcDbwIzAEmA41m9il3fzi/SSwNdQ1t\n435ss+k47lUAIiIikrNc6hIuAP4HvA4cAgwDpgG/Bs7OX9JKywPPvQvAmFHDSagKRkREpE9yuZPu\nAZzg7kuATwJ3ufv7hMapO+YxbSUlVQJS39jSzZoiIiLSnVwCkFZgvZlVAPsCD0bLRwPr8pSukrJk\nVX16eo/tJhcxJSIiIoNDLo1QnwJ+BiwFqoC7zOwDwDnA03lMW8m4+dG30tPTNxkLNBQvMSIiIoNA\nLiUgPwJ2Ar4PHOvuy4CfAlsDJ+YxbSWhuaWVZ19bkp7fxSbS0KwAREREpC96XQLi7m8CO2csPhM4\nzt0HXQOJeQvXpKcnbFBJQ0sDl865sogpEhERGfhyGgfEzEYB3wC2B5qAV4B/ALX5S1pp+PNdr6Wn\nT/jqjiyqW9ru88nVEwudJBERkQGv11UwZrYx8DJwEaFHzH7AxcCLZjYtv8krvsUr2trVThhT2e6z\nY2YcrTfhioiI5CCXNiAXAu8Cm7n7THefAWwGvAOcn8/EFVtLa2t6umpEBYny8nbtPyorKrNtJiIi\nIt3IJQD5OHC8uy9OLYimfwIckK+ElYKFy9pKP7720S2ob65X+w8REZE8yCUAaSb7eB/1wIi+Jae0\nvL2wrUnLhmNHqv2HiIhInuQSgDwJnGZmw1ILoulTos8GjfmL23rAbDp5dLvP1P5DREQkd7n0gvkp\nMAt4y8yei5btShgJdZ98JawUDKtoi8+GD0u0+0ztP0RERHLX6xIQd3+N8M6XvxOqXCqB64EZ7j4n\nv8krrsam0Ah1w7GhpEMDkImIiORHr0pAzKwGWO/u7wAn9U+SSsfzHkZAHVZRrgaoIiIiedSjEhAz\nG2Nm/wZWAGvM7BYzm9C/SSu+KeOrAViwtE4NUEVERPKop1UwvwY+DJxGaGy6K3BFfyWqVDS1hCqY\nD2+zYbvlaoAqIiLSNz2tgjkQ+Ja73wtgZrOAB8yswt2b+y11Rfb2+6EbbkWirN1yNUAVERHpm56W\ngEwCXorNP0UIXjbMvvrAt66hKT09rCLRxZoiIiLSWz0NQCoIA5ABEL31dtANPBZ39zPz09Pjawbt\nnykiIlIUuQxENiT8791V6ekDd9ukiCkREREZfHrTDXeamWU2fphqZu3agLj7fAaBNxasTk+Xl5V1\nsaaIiIj0Vm8CkP9kzJcBj2bMJ4FB0WBixPAEjetb2HjSqGInRUREZNDpaQCyX7+mogS1tCQB+NA2\ng7adrYiISNH0KABx90e7X2twaWkNY4AkylX9IiIikm9qhJpFazJJMhSAKAARERHpB7m8DTfvzGwE\ncDlwELAOuNDdL+pmm00JY5N82t0fy2d6WluT6WkFICIiIvlXKiUgFwA7AfsCPwBON7ODutnm98DI\n/kjMO4vWpKc1CJmIiEj+FT0AMbORwFHA/3P3Oe5+G3A+cEwX2xwK9Fv3lHeXrk1PbzZlNAANzQ39\ndTgREZEhJ6cqGDObAnwb2Bo4FtgbeMndPYfdzYjS8VRs2RPAyZ0cezxwLvAJ4JUcjtetl95anp6e\nOqGa+uZ6Lp1zZX8cSkREZEjqdQmImW0BvAwcDnyJUBLxVeA5M/twDmmYAizLeKndYqAyCjYyXQRc\n7e6v5XCsHhk9clh6uqysjEV1S9t9Prl6Yn8dWkREZEjIpQrmQuAW4INAY7TsEOB2QslEb42M7Scl\nNd/uJSxm9jFgD+CsHI7TY03NoRHqtIkda3mOmXE0VRVV/Xl4ERGRQS+XKpg9gb3dPWlmALh7s5md\nCTyTw/4a6PhSu9T8utSCaBj4K4Dvu/v6HI6Tlkh0HXctWRUOWzkiQUVFORWJtp4wo0ZUUVFR9KYz\nA0Yqr7vLc8kf5XnhKc8LT3leePnO61wCkATZS05qgJYc9vceMMHMyt29NVo2Gah391Wx9T4EbAbc\nZGbxvrF3m9k17v6Dnh6wpqbzEoyW1iRvvVcLQOWICsaOrWZZa9v6o2uqGDu2uqeHkkhXeS79Q3le\neMrzwlOeD1y5BCD3Aj8zs29G80kzGwecBzyYw/7+CzQBuwGzomV70fHdM88AW2Yse5PQg+aB3hyw\ntraelpbWrJ/VNTS1zSSTrFxZx5ra+vSiNbX1rCyv683hhrREopyamqou81zyS3leeMrzwlOeF14q\nz/MllwDkeOARYCFQRWj7sQmwgtAwtVfcvd7MrgWuMLMjgWnACcBhAGa2IbDa3RuAt+PbRlVA77v7\nst4cs6Wllebm7CfsC97W4HTvHabS3NxKc0vbwGTNLclOt5XOdZXn0j+U54WnPC885fnA1esAxN3f\nN7MdCQ1PZxKqY14GrnP32hzTcTxhJNSHgNXAadF4IBACncOBa7Nsl8yyrE+WrGwr7dh8ak2+dy8i\nIiLkOA6Iu68D/pyvRLh7PXBE9C/zs05bvbh73ocpvevpdwCoSJQzrqYy37sXERERcghAzOyhrj53\n9/1zT07xVQ5PsL65lRHD2uIejYIqIiKSX7mUgLyTZR9bAtsDv+lzioqsdl1ohDplfOjpolFQRURE\n8i+XNiAdqkkAzOw0YKM+p6iI1sV6wOy0VRjtVKOgioiI5F8+RxX5K/CVPO6v4JatbqtqGVU1rMPn\nGgVVREQkP/IZgOwBNHe7VglbEHsL7gcmdhxsrLJCjVJFRETyIZdGqA/TsftrDeGttpflI1HFsmZd\nWxXMlPEji5gSERGRwS2XRqjzsixbD1wKXNen1BTZO4vWpKeHD8t7D18RERGJ5BKA3Afc6+4r8p2Y\nYnvr/dXp6fKysi7WFBERkb7IpQ3IZYSXxQ06S1eFRqiqfhEREelfuQQgbxDG/BhUlqxcl56uruzY\nA0ZERETyJ5cqmDnA9Wb2E+B/QH38Q3c/Mh8JK7S5C9vaf3xsl2lFTImIiMjgl0sAshXweDQ9aKpi\nXnxreXraNhpTxJSIiIgMfrmMhLpffySk2J56ZVF6eoNRI4qYEhERkcGvR21AzKzFzCb1d2KKZdnq\ntlqkbCOgioiISH71tBHqoO6TumBJXXr6yE9vXcSUiIiIDA35HIp9wGpuaU1PbzxpVBFTIiIiMjT0\npg3IV8ystruV3P3aPqSnKJpb2wKQikRbTFbfXM/CukXZNhEREZE+6E0A8rserJMEBlwA0tLS9mqb\nRCLUNtU313ParHOpb67vbDMRERHJUW8CkMnuvqTfUlJEtXXr09OJ8hCALKpb2i74qKqoYnL1xIKn\nTUREZDDqaQCS+fbbQWXJqrZAI14Fk3Lo9IOZOWl7qiqqCpksERGRQUu9YIBhFW3ZkC0AmVI9WcGH\niIhIHvU0ALmGjCHXB5PZvhSAqROqi5wSERGRoaFHVTDufkR/J6SYJo6pYuWaRhYur+t+ZREREekz\njQMC6cBjp63UyFRERKQQFIAAa9Y1ATByRC7v5hMREZHeUgBCW9fbhvUtRU6JiIjI0DDkA5DW1iQt\nrSbkPvkAACAASURBVKGX8VYbjUkvb2huKFaSREREBr0hH4A0rG9OT1fERkG9dM6VxUqSiIjIoDfk\nA5BnXmsb3DVRHrJjUd3SdutoBFQREZH8GvIByPzFa9LTM7ea0OHzY2YcrUHIRERE8mzIByBz3lyW\nnq6uHNbh88qKykImR0REZEgY8gHI2vrm7lcSERGRvBryAcjw6D0wO3xwfJFTIiIiMnQM+QBkXWMo\nAdlsSk2RUyIiIjJ0DOkApDE28Nj6Jg1CJiIiUihDOgBZurrtBb8Tx6qni4iISKEM7QBkVVsAMnV8\ndRFTIiIiMrQM6QDkf++uTk9PGT8yPa1h2EVERPrXkA5AhlW0/fmjRw4HNAy7iIhIIQzpAKSppRWA\nMaOGp5dpGHYREZH+N6QDkHuemQ/A8IpE1s81DLuIiEj/GNIBSMqSWGPUePsPDcMuIiLSP4ZsANLS\n2pqe3m7zcQCsbFil9h8iIiIFMGQDkKdeXpye3m7TcdQ313PqrHParaP2HyIiIv1jyAYgcR/eZsMO\njU/P3uNktf8QERHpJ0M2AGlNJtPTI4a3b4R6zIyjGVs5ptBJEhERGTKGbADS0tLWBiRR3j4b1PhU\nRESkf1UUOwEAZjYCuBw4CFgHXOjuF3Wy7qeBs4EtgLeA09z99t4es6W1rQQkUV6WQ6pFREQkV6VS\nAnIBsBOwL/AD4HQzOyhzJTPbAbgJuBKYAfwR+JeZbd/bAza3hACkDChXACIiIlJQRS8BMbORwFHA\nAe4+B5hjZucDxwA3Z6x+CPCgu18WzV9uZp8DvgK81Jvjznp5EdAWfOj9LyIiIoVTCiUgMwiB0FOx\nZU8AH86y7tXAT7Ms36C3Bx07egQQqmL0/hcREZHCKoUAZAqwzN2bY8sWA5VmNj6+ogfpkg4z2xb4\nKPBAbw/60tvLAdh5q4l6/4uIiEiBlUIAMhJozFiWmh/R2UZmNoHQHuRxd/93bw86qmoYAKvr1rdb\nrve/iIiI9L+itwEBGugYaKTm12XbwMw2BO4HksCXe3vARKI8PRS7bTKGikRbI9RRI6qoqCiFuGxw\nSCTK2/0v/U95XnjK88JTnhdevvO6FAKQ94AJZlbu7qnBOSYD9e6+KnNlM/sA8BDQAuzr7st7e8Ca\nmirqG1sAmDSumtE1bdkwuqaKsWOre/9XSJdqalSqVGjK88JTnhee8nzgKoUA5L9AE7AbMCtathfw\nn8wVox4z90Tr7+fuSzPX6Yn3F9emp9fUr+X191e2zdfWs7K8LpfdShaJRDk1NVXU1ta3G/xN+o/y\nvPCU54WnPC+8VJ7nS9EDEHevN7NrgSvM7EhgGnACcBikq1tWu3sDcAqwGWG8kPLoMwilJbUddt6J\nxSuiACPRxP1rr2H9q21NUJpbkjQ362TOt5aWVuVrgSnPC095XnjK84GrVCrPjgdmE6pWLiGMbnpb\n9NlCwjgfEEZKrQKeAd6P/fttbw72ytwVAJRV1rE+2RZ8VFVUqQeMiIhIARS9BARCKQhwRPQv87Py\n2PTW+ThefUNzh2WHTj+YmZO2Vw8YERGRAiiVEpCCWrSiY+eaKdWTFXyIiIgUyJAMQOYvXlvsJIiI\niAxp/7+9O4+LsvgDOP4BURQQBS/wxtTxvvI2xLxTM++8Eo+s7PDKo7zKTPM+Sy01zzzLPH8eeZtZ\nZh55TqbiAV6oCCoesPz+eJaVhUUhYFH4vl+vfeXOMzvP7LDt892ZeWbSZQAScteY95HbQ3o8hBBC\niNSQLgOQ6A3osrhEpXJNhBBCiPQp3QUgkaYo7j+IgAyPuZZ9V2pXRwghhEiX0l0AEhwSDhi34MYk\nt98KIYQQ9pNuA5CYZAM6IYQQwr7SXQDy+/ErcdIyO2VOhZoIIdK6MWNG4utbhdq1q+LrW8XqUbt2\nVY4cOZToMg8f/ovatasmKO+mTRto2/aNRJ8jMT766F0uXrxglTZv3rf4+lbh0KGDNvPPnz8nTvrh\nw3/h61vF8vzDD9+J02aNGvnRp08vzp07a/Xax48fs2DBXDp0aEXdurVo27Y5U6dOJCQkznZihIWF\nMWPGFNq2fYP69V+hc+d2rFy5jKio5JsTGBh4mb5936dhQz/8/Tuwf/+vVse3bt1Ehw6tqFevFr16\n9eDUqRPxlhUWFhbnM9SsWQPL8Z9+WkmzZvXp1KkNJ08et6Q/fvyY9u1bceuW9XZp3303k/Xr1yTT\nO02a52IhMntycHB4diYhhEgGffsOoFevjwDYtm0ry5cvYe7cxRgbeUPWrO6JLrNs2fKsXbs5QXnr\n1WtIzZqvJPocCfW//63H2zsvBQsWskrfvn0r+fIVYPPmjVSqVDnB5cX8fnZwcKBDh8506PAWAFFR\nUQQFBTJ16kSGDh3IqlXGRTQyMpKBA/tw9epV3n+/N0qVICgokHnzvuWdd/yZOXMeOXPmBCA09A7v\nvNOVXLlyM2TICLy983Ly5AmmTBlPUNBl+vYdmNQm4dGjR/Tt+wFFixZjzpyFnD59khEjhjBjxmxK\nlCjF0aNHGDv2Sz79dDhlypRj9epVDBjQm59+2kjmzHF/DAcEnCNbtuwsXryS6M+Ng4PRdxASEsLM\nmdOYNGkGx479zcSJY/n++yUAbNiwllq1XsHTM4dVeR07dqF79074+dXF3T3xn7/klO56QEwm4w/o\nmjndxV5CCDtzcXHFw8MTDw9P3NzccHTMgIeHhyXNySnx30NOTk54eHgmKG+mTJnIli17os+RUIsW\nfU/Llm2s0rQ+TWDgZfz9u7Nz53YePHjwn8vPksXF0laenjkoU6Ycffp8TGDgZf799wwAq1Yt5+zZ\nf5k1ax61a9chTx4vKlZ8malTZ5ItWzamT59kKW/WrBk4OzszZco3VKz4Ml5e3tStW59PPhnOzz//\nyOXLl/5zXaPt27eHsLA7DB/+BYUKFaZRoyY0atSEFSuWAnDrVjDdur1NgwaN8fbOS7dubxMaGkpA\nwDmb5V24cJ4CBQpafW6yZzf+pkFBl3F3z0aFCpXw83uVS5eMnqiIiAhWrlxKp07+ccpzc3OjWrWa\nrF69MsnvNanSXwBi7mbL6JTu3roQ4jk0ZsxIxowZSdeuHWnevBGBgZc5f/4c/ft/RMOGftStW4sP\nPujJxYsBgPVQxdWrV/D1rcLu3Tt5880W1K1bi0GD+hEWFgZED8E0t7yubdvmrFnzIy1bNqFBA19G\njRpBRMSTrSm2bt3Em2+2oEEDX0aOHMbnnw+1OVwC8Mcf+3n48CElS5a2St+2bQtFixanTp16REZG\nsGvX9mRtr4wZMwKQIUMGANatW0PTps3x8PCwyufk5ETnzl3Zs2cnoaGhPH78mO3bf6F16zfjBH61\navkydepMvLy845wvur1jD6PFN4R25UoQBQsWxsXFxZJWtGhRjh8/BsCrr9bnrbeMXUcePnzI8uU/\n4OnpSeHCRWy+3/PnjQDElty5vQgNvcO1a1c5ffoUefJ4AbBhwxpq1KgVp/cj5vtdt+5nm8fsKd11\nA0SZoiDDY6Iyh6V2VYQQSXT/QQRXbt17dsZk4u3piksK9J5u2fI/xo6dhIdHDvLmzUf79i2pWrUG\nAwd+yt27YUyePI5Zs2bw1VfGr/nYQ8lLlsxn5MiviIoyMXhwf5YvX0LPnr3MR5/kDQ6+wa5dO5g8\n+WuCg6/z6acDqFixEs2atTAPDYyiX79BlC9fkWXLlrBx41q6detps84HDuzn5ZerxEnfseMXmjV7\ngyxZsvDyy1XYtGkjjRs3TZZ2Cg4OZs6c2fj4vEThwj6Eh4cTEHCe7t3fsZm/XLkKREZGovUpcuXK\nTXj4fUqUsL2lWMWKL9tML1u2POvWbbF5zNYQmoeHJzdvBlulXbt2jTt3rOej/PXXn/Tv/yEAI0aM\nsjn8AkYPSEREBD17+hMcfINy5SrQu3d/cuTISc6cOWnbtgPt2r2Bs3NmRo4cQ0REBKtWLWfGjG9t\nlgdQqVJlbt4M5ty5fylSpGi8+VJaugtAHpoekLn8bh46xd2QTgjx4rj/IIJBs37j/kP7/b/s4uzE\n+F41kz0IKVmyNDVqGHM1Hjx4QIsWbWjVqg3OzsZFqXHjZixbtjje1/fo8Z7lwtqgQWNOnTppM19k\nZCT9+g2iUKHC+PgUoVq1Gpw6dZJmzVqwZs2P1KvXkNdfbwHAgAGfcODA/njPqfVpqlWraZV29OgR\nbty4jq9vHQD8/F5lwoSvuHbtquXXeWIsWvQ9S5ca79tkigSgatUajB8/BQcHB0JDQ4mKiop3Lk10\nemjoHbJkyYKDgwOurm6JqkNihrwAqlevxbRpE5k371v8/Xvw77//sHHjOiIiHlvlK1KkKPPmLeG3\n3/YyevTneHvnpVSpMnHKu3DhAh4eHvTpM4CoKBPffvsNgwb1Y+7cRTg4OPDeex/SuXNXnJ2dyZgx\nI+vW/Uy1ajVwcHCkX78PuHz5Mi1btqZjxy6WMjNlykTevPnQ+rQEIPZ013QbhxjBRxanLLIGiBAi\nVcXs+s+cOTMtWrRm06YNnD59igsXAvjnn9N4eua0+VoHBwfy5y9gee7q6kpkZPxBWb58+WPkdbMM\nwZw9e4Y33mhtOZYhQ4Z4ewvAmAAZPRch2rZtW8iTx5uiRYsBUKuWHxMmfMWWLf+jS5fugHFBN5lM\nccqLioqyDKtEa9GiDW3avMnjx49ZuXIpf/55gJ49e1mCmejz37x5M055YPT4ALi7Z8PdPRtRUVGW\n4amEOnr0CAMG9I6T7uDgwMSJ0yhXroJVuoeHB59/PobRoz9n0aLv8fbOR5s2b7Jy5bI4+Tw8PCha\ntBjHjx9jzZqfbAYgS5asxMHBgUyZMgEwatQ4WrRozIkTxylTpixgzOuAJ3M/pk2bxbx531KkyEt8\n+eU4unRpT+XKVSlevISl3GzZsnP79u1EtUVyS3cBSMw7rTqVaEPF3GVlDRAhXkAumY3eiLQwBBN9\ncQEIDw/n7bffwsPDk1q1atOgQWMCAs6zfPkP8b7eySmj1fOn3VIae/5DdF7j4h8V61j8dXZwMHpU\noplMJnbt2k5o6B38/KpZlb9580ZLAOLmlpV79+JuCBoWFoabW1arNHd3d0vANGjQUAYM6M3AgX1Y\nvHgF7u5ZcXZ25qWXiqL1KRo2bBynzFOnTpAhQwaUKoGrqxuurm5ofcpmYPXppx/Tpk37OMNKJUuW\nYsGCpTbbIFeu3DbTq1evyfr1W7l16yaenjn4+ecf8fY2gszTp0/i6OhoFQwULuzDhQvnbZbl7Oxs\n9dzDwwN392wEB1+Pk3fTpg1UqVKdHDlycuzYUd5/vzeurm6UKVOWv/8+YnVOk8lk2ZYktaTPAMTc\n5t6uXhJ8CPECc8nsxEt5s6V2NZLV4cN/cfPmTZYsWWWZ6/HHH78ROzhIbj4+L6H1actzk8nEmTP/\nUKxYcZv5PT1zEBp6x/L84MED3LkTwujR48mf/8mkyQMH9vPNN9M4fvwYZcqU5aWXivLbb7/GKe/E\niWMUK6aeWseBA4fQuXM7Zs/+mkGDPgWgRYvWzJw5gw4d3rLcbgtGb8CiRd9Tu/aruLsbn5H69Ruy\nevVKmjZtbhWI/frrHvbt28t7730U55yZMmWy6jV6lgsXApg8eTzTps20TALdv/9XKlUyApsNG9YS\nFBTE5MkzLK/R+jRKlYhT1v3792jd+nXGjJlgmaNy48Z17twJoWDBwlZ5IyMjWbFiKdOnzwKMPc+i\ne5oiIyPjBJN37oTE26tmL+nuVhBTMi42I4QQyc3dPRvh4ffZvXsHV69eYf36NaxevYpHjx7ZzJ9c\nC2i1atWObdu2smHDWi5evMC0aRO5du1KvGsnFSumOHv2jOX5tm1b8PEpgq9vHXx8ilgeLVu2JWvW\nrGzevAGApk2bc+HCeaZPn8SFCwFcvBjAqlXLWbPmJ9q37/TUOubJ40WXLt1Yu3Y1Z878A0Dr1m2p\nUKESH330Dnv27OLatascPXqEgQP7cO/ePfr0+djy+u7d3+HevXt8/PFHHDlyiMDAy2zYsIYxY0bS\ntm0HChUqnMRWNIbTLlw4z7x533LlShALFszl77+P0rp1OwCaN2/J4cMH+fHH5Vy+fIl5877l9OkT\ntGvXETDujIlePMzFxZUKFSoyY8ZkTp8+idan+fzzoVSvXosiRV6yOu+mTRuoXLmqJegpUaI0v/yy\nmX/+Oc3hw39RuvST4Z379+9z9eoVm0GPPaW7AORUwK3UroIQQsSrTJmydOvWk8mTx9O1awc2b97I\nxx9/QkjIbYKDg+PkT67FFcuUKUv//oOYP38OPXp0Jjw8nNKly8a7Vkm1ajU4duxvwFh1c+/e3TRr\n1iJOvkyZMtGkSXN27NjG48ePyZUrNzNmfMvFixfo1asHPXp0YevWTYwY8QVVq1Z/5vtq374z3t75\nmDx5vCXf2LGTaN68FXPmzKRTpzaMGjUcH58izJmzkBw5nvzK9/TMwaxZ88ibNx9ffDEcf//2rFq1\nnJ49e/Hhh33/c9vF5OzszJgxE9i/fx9durRn//59TJ48g9y58wBQvHgJxoyZwPr1a+natQO///4b\nkyd/Y+m92bHjF1q0eM1S3tChIylevAQDB/alT5/3yJs3HyNGjLI6Z2RkJCtXLqVz566WtO7de3Ll\nSiB9+35AmzbtreaXHD/+N7lz50mWgCspHJJz+dkXwUczV0ddy/ELAANe/hCfbLbvrxbJw8nJEQ8P\nV27fvkdERNyJZyL5SZvbX1po81OnTuDq6ma1qulbb7WjY8cuvPZaszj5TSYTHTu25tNPP6N8+Qpx\njqe0tNDmqWXMmJHkz1/AMi8nocxtnmwTR9JdD0j6CreEECJhjh8/xqBBfTl+/G+CggJZtOh7bty4\nTvXqNW3md3R0pHNnf9au/cnONRVJcedOCAcPHqBFizbPzpzC0t0k1MhICUGEECK2Vq3acvVqEEOH\nDuLevbsUK1aciRNnPHUNjKZN32DTpo1cvBgQZ1KkeD4tX/4D/v49Un0fGEiHQzDvTFsVFeK1A5Ah\nGHuQblL7kza3P2lz+5M2tz8Zgkmiqzfvp3YVhBBCiHQv3QUgQgghhEh9EoAIIYQQwu4kABFCCCGE\n3UkAIoQQQgi7kwBECCGEEHYnAYgQQqSQMWNG4utbhdq1q+LrW8XqUbt2VY4cOZSk8gMDL3PgwO+W\nf/v6VrFsQZ8SZs6czqZNG6zS/vzzD3x9q7Bgwdw4+efMmUXfvu/HSY+MjMTXtwrHjh215IvdTvXr\nv0LXrh3Zu3dXnNdv3bqJ7t27UKFCBZo0acDw4Z9w7ty/cfKZTCZWrPgBf/8O1K//Cm3bNmf69Enc\nvRt3N97/6v79+4wZM5JmzerTunUzli1bYnU8IOA8/fp9QKNGfrRr9wZLlix4anlLly6idetm1K//\nCgMH9iEw8LLl2JEjh2jX7g2aN2/Exo3rrF43ZMhA9u+33uTv999/Y/Toz5P0/lKSBCBCCJFC+vYd\nwLp1W1i7djO9e39M7tx5WLduqyWtTJlySSp/zJiRnD59EgBv77ysW7eFnDlzJUfV4wgIOM/vv++j\nceOmVunbt28lX74CbN78P5uvS+heNeXLV2Tt2i2sW2c8vvtuIT4+Rfjss6FcvXrFku+772YyefI4\nmjRpxvr165k27Rvc3Nx4993ucQK6IUMGsHr1Krp1e5vFi1cyZMhnHDlymI8//oiIiIhEtoBtY8aM\n5OTJ44wbN5URI0bx44/L+emnFQA8ePCAAQN6kzdvPubOXUy/foNYvnwJ69b9bLOsTZs28MMPCxk8\neBgLFy7HxcWVTz7pbzk+Zcp4Wrdux4gRo5gyZbwlkDpz5h+Cg29Qo8YrVuVVr16ToKBA/v77SLK8\n1+QmAYgQQqQQFxdXPDw88fDwxM3NDUfHDHh4eFjS4tvoLaFiLiTp6Oj41FVLk2rJkgU0afK6VUAR\nERHB7t076dq1B1euBFp6NP6LjBkzWrVNkSIvMWTIZwDs378PgJMnj7NkyQLGjp1MmzbtKFCgAMWK\nFWfw4GE0btyU0aM/twQWmzZt4ODBA0ybNps6derh7Z2XihVfZsKEqZw9e4ZfftmchNYw3Lp1k927\ndzB48DBKly5D+fIVeffdD1m6dDEAhw4d5MGDcPr3H0yBAgWpUaMWbdq0j/fc9+/fp1ev3lStWp18\n+fLTqVMXLlwIICwsDIALFwLw86tL5cpVyZw5C1euBAKwcOFcunV722aZb7zRmgUL5iX5vaYECUCE\nECKVrV69irZtm9OwoR99+rzP+fPnLMf+/PN3unbtSN26tWjfviUbNqwBYNSo4Rw7dpS5c2fTr98H\nVkMw0UMcW7du5q232lG3bi0+/PAdrl27ain31KkT9OzpT716tXj//bfjHS4BCA0NZceObfj61rFK\n37//Vx48CKd27VdRqmSc4ZmkcnBwwMnJyRKobdy4jtKly1KhQqU4ebt1e5tr167y55/GkNSmTRvw\n86uLl5eXVb4cOXIyffrsOO8FngwNxR4yq127KosWfR8nf1BQIA4ODpQsWdqSVrRoUW7cuE5w8A2U\nKsHo0RPIkCGD1evu3bM9BNS6dTuaNXsDgLCwMFavXkXRosXJmjUrAF5e3mh9isDAy9y/f59cufJw\n9uy/XL9+PU7vR7QaNWpx+PBBgoICbR5PTeluLxghRNoRHhHO1XspN+chNi/XXGRxypKsZe7evZPF\ni+czePAw8ucvwMaN6+jTpxfLl68mUyZnhg//lC5dulG/fiOOHDnE6NGfU758Jfr3H8ylS5d4+eUq\ndOrkz507IXGGO+bP/47Bg4fh7p6NoUMHMm/etwwZ8hlhYWEMGNCbxo2bMmLEKP744zdmzJhCpUqV\nbdbx8OGD5MyZk3z58lulb9/+C+XLV8TFxQVfXz9++GERffsOJFOmTElul/DwcObPn0NUlIkaNWoB\ncPr0qXh33vX0zEHevPk5efIENWq8wr//nqF27To288bcmj6mDBkysG7dFpvHXFxc4qRF9zgFB9/A\ny8sbwBLkhYSEULRoMXLkyGnJ//DhAzZsWEvduvVtniPaunU/M2HCGJydnZky5RtL+rvvfsAXXwwn\nMjKSbt16kj17diZNGhtv7wdA1qxZKV68BAcO7H8uNqCLSQIQIcQLKTwinOG/jSU8Itxu58zilIVR\nNT9J1iBk2bLF+Pv3sOw6++67H7B//z62bt2Mn19d7t27i4eHJ7lz56Fhw9fIlSs3np6euLq64eTk\nRJYsWXBzc+POnZA4ZXfs2MXSW9CiRWs2bFgLwC+/bCZr1mx89JExv6BAgYIcPXqEu3fDbNZR69MU\nLuxjlfbgwQP27dtDr169AfDze5U5c2axd+8u6tVrmOh2OHToIA0a1DY/i+LRo0eUKFGKSZNmWOa1\nhIaGkjVr/JuoZc2aldDQO4DRy+Dq6pboeiRmGCtfvvwoVYIpU8YzbNgXPHz40DLcERHx2CqvyWTi\niy+G8/jxIzp29H9qudWq1eD775ewfv0aBg3qx8KFy8idOw+vvlqfmjV9iYyMwMXFlXPn/uXq1StU\nrVqDceNG88cfv1GlSjUGDhxiNbxXuLAPWutEtIJ9yBCMEEKkooCA83z99RQaNKhteQQEnOPy5Ut4\neHjQvHlLxowZSdu2zZk6dSJublkTfGGN2WPh6upqmR9x7ty/KFXCKm+ZMmXjLSck5DbZsmW3Stu7\ndxcPHz7E19cPgIIFC1OwYGGrYRgnJydMprgbnkbPXYl5kSxduiwLFy5j/vwfeOedD3BxcaV9+06U\nK/ekx8Pd3Z2bN2/GW8+bN4Nxd88GQNas7pa5EwllMplo0KA2DRv6Wf09Gjb0s8zriO2zz0Zz7do1\nmjath7//m7z2WjPAmP8TLSIigpEjh3Lw4AHGjZtC9uzZbZYVLU8eL4oVU/TvP5gcOXKwefNGyzFn\nZ2dL2QsXzqNr17fZvv0XAgLOsWLFGkJCbrNmzY9W5WXLlo2QkFuJagt7kB4QIcQLKbo34kUfgomM\njKR//8GUL1/RKt3NzQgyBg4cQps27dm7dxd79+5i3brVjB8/lcqVqz6z7IwZM1o9j56zasxJiIp1\nLP6d0R0cHDCZIq3Stm/fCkCbNq9bpV++fJGbN4PJkSMnbm5Zbc53iA4M3NyyWtKcnZ3JmzcfAG3b\ntuf+/Xt88cVw8ubNbwmWSpUqg9anbNYxOPgGwcE3KFXKmI+hVMl4886aNYM8ebxo1aqtVbqjoyML\nFiy1+ZrYAVi0/PkLsGDBUkJCQnBzc+PChQAcHR3JkycPYAQfw4YN4vDhv5g4cTolSpSyWQ4YvUC5\nc+chf/4ClrRChQrb7N06f/4cQUFB1Krly6RJ46hUqTIZM2akatXqHD16hDZt2lvymkxRODg8f/0N\nz1+NUphDhuS59UoIkfqyOGXBJ1tBuz2SO/gAKFiwENevXyNfvvyWx4IFczl58gTBwcFMnjyOggUL\n0aVLd+bMWUS5chX49dc9QMJvcY3Nx6cI//xj3SWv9el483t65uDOnTuW53fv3uXAgd/x9+/BggXL\nLI8pU77BZDKxZcsmAF56qSgXLpzn/v17VuWdOHEMFxcXqwttbJ07d6VgwcKMG/elJe31199A61Nx\n1rsAmD9/Drlz56FKleoANGr0Grt377CaeAvGHI2ff/4xTnAWLebfIeYjOiCMyWQy0bfv+1y8GED2\n7NlxcnLit9/2UrJkKZydMwPw1VcjOXLkEFOmfEPZsuXjfb8AixZ9z8qVTwKgyMhI/v33DIUK+cTJ\nu3DhPLp16wmAo6MDJpPJ8prYweSdOyF4euZ46rlTQ7oLQJxLHEztKgghhMWbb3Zi2bLFbN26mcDA\ny3z99VR2795J4cI+ZMuWjV27djBjxhQCAy9z6NBBzp59MnySOXMWLl++xO3bt4Gn92LE1LDha4SG\n3uHrr6dy6dJF1qz5iZ07t8Ub0BQrpjh37qzl+a5d2wBo3fpNfHyKWB6VKlWmcuVqbN5sDMNU4ihX\nfwAAEnxJREFUqFCJAgUKMmzYJ5w6dYKgoEB27drO1KkTaNeu41MDqAwZMtCv30DOnNGWIYXixUvQ\nrVtPRo4cxo8/ruTSpUucPfsvkyePY+vWzQwbNtIyrNOgQWPKli1P797vsXv3DoKCAtm//1c+/rg3\nxYoVtwyVJIWjoyOZMjkza9YMLl++xO7dO1i0aD5dunQHsMzl6d37Y7y8vLl16ya3bt209GiYTCZu\n3bppGRpr2bItGzeuY/v2rVy8GMD48aMxmUw0atTE6rwXLgQQGHiZmjWNO19KlCjFvn17CAg4z86d\n2+IMp509eybOkNvzIF0PwXi5psyCPUIIkVANGzYmJOQ2c+bM5PbtW/j4vMSECdPw9s4LwLhxk5k+\nfRJdu3bE1dWVFi1aWy6ezZu3YNy40QQEnOezz760uqA/7eLu4uLKuHFTmDRpLKtXr6JUqdI0bPga\nISFxu/oBKleuQkjIba5cCcLbOy/btm2lVq3aNucytGzZmqFDB6H1aZQqwaRJXzNr1nQ++eRj7t4N\nMw99tKNjx7ee2TYVKlSiXr2GzJ07m7p1G+Lu7k7Xrm/j4/MSK1b8wOzZX5MxYyYqVnyZ775bgI9P\nEav3P27cFBYvns+3337D9evX8PTMQZ06dena9e0kr8ESbfDgoYwfP5oePTrj4ZGDgQM/tdwSu2fP\nThwcHBg7dpTVa/Lmzc/y5au5ciWIDh1a8c03cyhbtjx+fq/Sr99A5syZTXDwdcqUKcfkyV/j7Oxs\n9fqFC+fh79/D8rxBg8b8+ecfvPded6pVq251t8u9e3c5d+4s1arVSJb3m5wcEhoxpxXtVvSKAviw\n/NuUzFE8tauT5jk5OeLh4crt2/eIiDCldnXSBWlz+3vR2jwoKJBbt25arcQ6YcIYTKYoBg8eavM1\no0aNoHDhIrz1Vlc71fLpXrQ2Ty0bNqxh164dTJw4Pcllmdv8v4372ZDuhmCiZXbKnNpVEEKIVBEa\nGkqfPr3YvXsnV69eZefObWzbtuWp61N06tSFzZs3WOYaiBfDunVr6Ny5a2pXw6Z0PQQjhBDpUYkS\nJenTZwCzZk3nxo3reHl507fvQKpUqRbva4oUKUrNmr5s3ryRJk1ejzefeH7s3/8rBQoUtLly7PMg\n3Q7BTKw9MkVmtAtr0k1qf9Lm9idtbn/S5vYnQzDJwCvkVQk+hBBCiFSULgMQJ5K+T4EQQggh/rt0\nGYD818V7hBBCCJE80mUA8uCRrIYqhBBCpKbn4i4YpZQzMBNoBdwHJmmtJ8eTtyIwCygLHAd6aa0P\nJeZ8ObLJLbhCCCFEanpeekAmApWAOsD7wGdKqVaxMymlXICNwG5z/v3ARqVUomaU5s3p+uxMQggh\nhEgxqR6AmIOKHkBvrfVRrfVaYDzwoY3s7YH7WuvB2tAXCAPa2sgbL4+szs/OJIQQQogUk+oBCFAe\nYyhof4y0XwFbK+JUMx+LaR+QqEXunRxlEqoQQgiRmp6HAMQbCNZax5wZeg3IrJSKvX+wNxAUK+0a\nkD8F6yeEEEKIZPY8BCAuwMNYadHPY4+VxJdXxlSEEEKIF8jzcBfMA+IGENHP7ycwb+x88YqKcCJH\n5pw4OT0PsVfalyGDo9V/RcqTNrc/aXP7kza3v+Ru6+chAAkEciqlHLXW0Qv6ewHhWusQG3m9YqV5\nAVcSerJVnWbIBJBU4O4uS9/bm7S5/Umb25+0+YvreQgdjwCPgeox0nyBP23k/R2oGSutljldCCGE\nEC+I52I3XKXULIxAojvGhNIFgL/Weq1SKg9wR2v9QCmVFTgDLAO+A94D2gBFtdbhqVJ5IYQQQiTa\n89ADAtAf+AvYAcwAhpvXAwFjeKUdgNY6DGgG1AYOAlWB1yT4EEIIIV4sz0UPiBBCCCHSl+elB0QI\nIYQQ6YgEIEIIIYSwOwlAhBBCCGF3EoAIIYQQwu4kABFCCCGE3T0PK6EmK6WUMzATaIWxRPskrfXk\nePJWBGYBZYHjQC+t9SF71TWtSGSbNwW+BIoCZzFuuV5vr7qmFYlp8xivKQwcA5pqrfekeCXTmER+\nzsua876MsXZRH631LjtVNc1IZJu3BEYDBYDDGG1+2F51TWvMbX8Q+CC+74ukXkPTYg/IRKASUAd4\nH/hMKdUqdiallAuwEdhtzr8f2KiUknV9Ey+hbV4O+AmYC5THWEzuR/OXtUicBLV5LLMwNnQU/01C\nP+fuwFaML+QywM/Az0qpnParapqR0DYvBfyAEYCUA45ifJ9ntl9V0w5z8LEMKPWUPEm+hqapAMTc\nID2A3lrro+bFzMYDH9rI3h64r7UerA19gTCgrf1q/OJLZJt3ALZrrb/RWp/TWs8EdmJeaE4kTCLb\nPPo1nQA3O1UxzUlkm3cFwrTWvcyf88+Bf4DK9qpvWpDINm8IHNda/6C1Pg98irFPWLwXUGGbUqok\nxvYmPs/ImuRraJoKQDB+VTthRGLRfgWq2chbzXwspn1AjZSpWpqVmDZfAHxiIz1b8lcrTUtMm6OU\nygGMBd4BZDPG/yYxbe4HrI2ZoLWuprXenHLVS5MS0+Y3gdJKqZpKKQeMbT3uYAzzisTxA7ZjXAuf\n9n2R5GtoWgtAvIFgrXVEjLRrQGbzl3DsvEGx0q5h7EUjEi7BbW6Oko9FP1dKlQbqAdvsUtO0IzGf\nc4DJwAKt9Sm71C5tSkybFwGClVLfKqWuKKV+U0rF3kRTPFti2nwF8D+MC+IjjJ6SNlrrO3apaRqi\ntZ6ttR6gtX7wjKxJvoamtQDEBXgYKy36uXMC88bOJ54uMW1uYR4P/wnYq7Vel0J1S6sS3OZKqfoY\nO0iPskO90rLEfM7dgMEYX86NgT3AVqVUvhStYdqTmDbPgTHk8j7GHmGLgAUy7yZFJfkamtYCkAfE\nffPRz+8nMG/sfOLpEtPmAJh3ON4BRCFzbv6LBLW5eQLebOB9rfUjO9UtrUrM5zwCOKy1Hmmeu/AJ\nxhyQt1K4jmlNYtp8HPC3+df7YeBd4B7QLWWrmK4l+Rqa1gKQQCCnUirm+/ICwrXWITbyesVK88LY\nfVckXGLaHPOvwD0YY7t1tNY37VPNNCWhbV4VYyLZT0qpMKVUmDl9k1Jqpp3qmlYk5nN+BTgdK+0f\njNtDRcIlps1fxrjzBQCtdZT5eaEUr2X6leRraFoLQI4Aj4HqMdJ8gT9t5P0do2s6plrmdJFwCW5z\n86z2zeb8flrra3apYdqT0Db/AygGVMCY0FfenN4DGJHCdUxrEvvdUj5WWgkgIEVqlnYlps2DiHvH\niwLOp0zVBMlwDU1TC5FprcOVUouA2Uqp7hiTYT4G/MHS9X/HPLnmR+ArpdQUjPUo3sMY01qZKpV/\nQSWyzYdi/CKvAziaj4HxiybU7pV/QSWyzc/FfK1SCiBIax1s31q/2BLZ5rOBD5VSIzDWpvDH+Nwv\nSZXKv6AS2eZzgPlKqYMYd830BAoCC1Ol8mlUcl9D01oPCEB/4C+MOQYzMFbajL4l7grmNSe01mFA\nM6A2xmpvVYHXtNbhdq/xiy9BbY6xmmEWjF/mQTEeU+1a27QhoW0eW5Qd6pZWJfS75SLQCGiOeeVZ\noInWWoZ3Ey+hbb4SY32QIcAhjFtBX5VAO8lif18k6zXUISpKvo+EEEIIYV9psQdECCGEEM85CUCE\nEEIIYXcSgAghhBDC7iQAEUIIIYTdSQAihBBCCLuTAEQIIYQQdicBiBBCCCHsTgIQIYQQQtidBCBC\nCCGEsLs0tReMEC86pdQujKWNY4sCJmmtByWgDD9gJ1DYvCx4slJKFSLuJl+RwC3zeQdqrS8l07nO\nA/O11l+Yn3cB/qe1DlZK+QPfa60zJMe5bJzbH5iP0fYO5mQTEIqx9PQgrfWRRJRXAKiptV6R3HUV\n4kUkPSBCPF+igBVAHoytraMf3sDIRJaTkqKAljypX0GMvX4qAuuT8TyVgYkASqnawAKMDa8AlmO0\nS0qKwvrvUBBojfH32Wze4TmhFmLsESOEQHpAhHgehWutb6R2JZ7BAbittb4eI+2KUupzYIlSqqzW\n+lhST6K1vhnjqSMxAiut9UPgepwXJTMbf4sgpdSHwC6gLrAhgUU5PDuLEOmHBCBCvGCUUtmBCcBr\nQG7gNrAW6G3eJjt2/qIYO4nWwLiI/wYM0FofNx93x+hlaAFkwhheGKy1/us/VC/S/N+H5rLzA2OB\nekBW4FeMIZpj5uO5gG+AVwFXjJ1Mh2it95iPn8cYBtmNsSMqwHmlVDeMC/p8rbWjUmo+UFJrXT3G\n+y6IMVTUQGu9QylVE/gKqALcwOip+dS8q2diPTSf/7H5XA7AJxhbxRc2H98HfKC1Pq+U2gn4AX5K\nqTpa6yJKqYzAl0AnIBvGzrmfaa1/+Q/1EeKFI0MwQrx4FgDlMQKGokBfoAvwTjz5VwCXgUoYW2ZH\nAqtjHN8EFAKamI//DvyqlCqf0AoppRyUUhWAYcARrfU/Sik3jGAnL8a23TWA+8Ae83wIgNlAZsAX\nKAP8A6xRSmWJdYp9GEMfURgBRPQ8iugekflAFaWUT4zXdAYumYOPcsAvwP/M5+lgbo8tCX2PMd6r\nDzAOCAD2mJP7AB8D/YBiwBtAcWCS+XgrYL+53pXNaQuB+ua6VABWAuuVUq8ltk5CvIikB0SI509n\npVTbWGl7tNZNzf/eCuzWWp8wP7+olOoNlI2nvCIYF9qLWusIc+9BCQClVD2gGpBTax1izj9MKfUK\nxkW1+1PquUkpZTL/29n8393Au+Z/vwV4Am201rfM5+sInAU+wOgxKAL8DQRorR8opfoAS3jSkwKA\nud63zE+DtdYPlVIxj+8x95Z0wuhVAOiIcZEHGABs0VqPMz8/p5TqBJxVStWO7nGxwUEpFcqT4ZOM\nwCNgM+CvtQ43p58BumitN5mfX1JKrQLamOt3Wyn1CGN47Za5V6o9UEFr/bf5NVPNQdwgjKBQiDRN\nAhAhnj9rMS5CMecMhMf49yyguTmQKAaUxuj2PxVPeUOAacAH5rtsNgPLzMcqYvSEXop5QccYisn0\njHr2AA6Y//0YuG6elxGtDPBPdPABYA4yDvAkWBqJEXC0VUr9ihEoLdVaP3rGuW1ZiDkAUUpVBEpi\n9BaB0dtRVCkVe7glypwvvgAkCqO3yQFjuOtLjAmow2LeYaS13qiUqqqUGgko86M0Rs+TLRXM//3V\nPHwTzQljSE2INE8CECGeP2Fa69i3uQKWuQYbgVLAUow7QQ4Bc+IrTGs9y/xrvAnGXIwvMHo5KmAE\nH3cwLtCxJ0k+5OmCtNbnnnI8vkmXjpjnTmit1yilvIHGGMMR/YDPlFLVtNbxBVTxWWh+bSWMYY19\nMdrREfgBI4CIXa+nTviNUcY5pdTrGEHXL0qpClrr2wBKqU+A4RhDQduAyRhDZO3jKTZ6Qu0rwN1Y\nxyLjZhci7ZE5IEK8WCpgXKzbaK2HaK2XAecw5oLEueArpXIppWYAzlrrRVprf4xf9N4YkyKPA+7m\n4+eiH8CnGPMYkuJvoLhSKmeM+mTGmANxQimVSSk1CXhJa71Ka/2u+X2YgKY2ynvqrcXmHomdQFug\nHU96P8B4n6W01udjvMdMwFSgQOyynnKOcIxeFi+MybPRPgU+11p/qLWeq7U+gNELEvNvErP+x83H\n8sZq9x5At4TWR4gXmfSACPFiuYrRe/CmUioYyIkxxJKHJ/Mw4MmF7xbGxbyIUmoIEAZ0xejdOAhc\nBI4CK8zzLy5hzM/wx+gxSIqlGBfmlUqpQRhzJz7DuNvlW631I6VUFeAV8xyWqxi9NK4Yk1dju2t+\nXxWUUjdtHAejF+QbjB9XK2OkT8KY/Po18DXgYc7njDHxNcG01n8rpcZh9CL9oLXeiNFuDZVSGzB6\nMLpgrJNyNVb9Cyul8mmtT5rzzjbf0nsCI3AajPH3ESLNkx4QIV4gWusrGMFBc+AkxkX2MjCFJ3dX\ngPnXttY6EuN2XRPG0MAxjGGYJlrrAK21CWPo4yDGHRpHMYYFWmitdz2lKs9c6ExrHYrRy3LbfO49\nGBf8WjHmT7TD6MFZC5zGuJOno9Y6OgCJeZ5jGHexrCD+O35+Mr9mtdbaMrShtf4DYxGw8sBfwBqM\nOTMNtNYRz3ovNnxpfv1MpZQrxoRbF+BPjIm4pTEm4+Y234oMxh0/ZYGj5qG0N831nY0RgLwFdNda\nL/kP9RHiheMQFZXSCyYKIYQQQliTHhAhhBBC2J0EIEIIIYSwOwlAhBBCCGF3EoAIIYQQwu4kABFC\nCCGE3UkAIoQQQgi7kwBECCGEEHYnAYgQQggh7E4CECGEEELYnQQgQgghhLA7CUCEEEIIYXcSgAgh\nhBDC7v4PgnSSu6sIG00AAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x1554be358>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "optimal_weight = (0.0, 1.0, 0.0)\n",
+    "weight_name = \"_\".join([\"%i\" % (100 * w) for w in optimal_weight])\n",
+    "best_clf = joblib.load(\"../results/voting_clf_%s.pkl\" % weight_name)\n",
+    "\n",
+    "adaboost_y_pred_train = best_clf.best_estimator_.predict_proba(X_train).T[1]\n",
+    "adaboost_y_pred_test = best_clf.best_estimator_.predict_proba(X_test).T[1]\n",
+    "adaboost_metrics_train = get_threshold_metrics(y_train, adaboost_y_pred_train)\n",
+    "adaboost_metrics_test = get_threshold_metrics(y_test, adaboost_y_pred_test)\n",
+    "\n",
+    "# Plot ROC\n",
+    "plt.figure()\n",
+    "for label, metrics in ('Training', adaboost_metrics_train), ('Testing', adaboost_metrics_test):\n",
+    "    roc_df = metrics['roc_df']\n",
+    "    plt.plot(roc_df.fpr, roc_df.tpr,\n",
+    "        label='{} (AUROC = {:.1%})'.format(label, metrics['auroc']))\n",
+    "plt.xlim([0.0, 1.0])\n",
+    "plt.ylim([0.0, 1.05])\n",
+    "plt.xlabel('False Positive Rate')\n",
+    "plt.ylabel('True Positive Rate')\n",
+    "plt.title('Predicting TP53 mutation from gene expression (ROC curves)\\nAdaboost')\n",
+    "plt.legend(loc='lower right');"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAiAAAAGbCAYAAAD9bCs3AAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAAPYQAAD2EBqD+naQAAIABJREFUeJzs3XecXGXZ//HPliS72WTTm4SqcAUwhiJIEQIoIDYUAUVU\nqo+K4QeP+oiC2EAEaSqoWEHsKFgoovQWEGmhX9RAAqmkb2b7/P64z8zOzM7szszOzuzufN+vV145\n58yZc+6958yc69y1Jh6PIyIiIlJOtZVOgIiIiFQfBSAiIiJSdgpAREREpOwUgIiIiEjZKQARERGR\nslMAIiIiImWnAERERETKTgGIiIiIlJ0CEBERESm7+konoNLM7E5g/4zNHcBy4Hrga+6+bpDOfTzw\nK2Abd3/VzL4BfN3d6/J8/xbAT4FT3P3VaNvLwB3ufuJgpDnl3HcA8/vZ7Sp3P7HQPDazpcCbMvaP\nA9PcfU20z97AecDuwCbgz8BZ7r6puL9oYMxsAvBD4Ofufm8B76vYZxid663Ab4AdgRfc/a2DfU4Z\nfsysG/imu3+7jOf8O/B3d/9V9Nv4jSy7bQaWAn8BvuHuXRnHmAv8H3AgMA1YAdwHfN/dH8xx3rcD\n/4/w+zYNeB24Dfiuuy8uwZ82ZJnZDsDNwC7uvmGwz1f1AQjhxvYI8DmgJto2mnBj+y6wC/DOQTx3\n6lj4Pwf+WcD73w0clrHtQ8CgXziE/GpOWf8J4W9JzcdV0f9557GZTSEEH18k/FCkWhft8zbgVuAW\n4Iho/wuAHeidH+WyC/BJ4JcFvq+SnyGEH/UtgcPp+bxEMu1FuNGXRfRwtoW7/yplczxKR03KtqnA\nMcCZQB3w1ZRjfILwfXw4en0xMBs4CbjPzP7P3b+fcd7PA5cCtwNnEIKP7YEvAx8xswPd/YmS/aFD\njLs/Z2Z/Ay4Djhvs8ykACTa4+38ztt1rZuOBb5nZnrmi5VJy99cJF3y+ajI3uPui0qUoN3d/NnXd\nzDYA8Sz5mJBvHu9C+KH5ax9PG6cDq4Ej3b0zOn8N8Csz297dny/urxqQGtKDyULel6Zcn2FkCvCE\nu/+rjOeUYaYcv38JZtYAnA98Nks6sv2+3GRmbwZOIApAzGxXQvBxlbt/JmP/P5jZpcDFZva4u98e\nvWdf4PvAD939iyn73x2VxjxKKLHeY0B/4NB3AbDEzC5198cG80QKQPr2EOEGsTXwYFTtsBRoIDy1\n3ufuh5rZGOAc4GPAdMCB77j7NYkDRTfIs4BPE6L2fwN3p57MzL5JqIKpTdn2ScINdw7hpvs7wlPr\nxwlfhjiw2MwS1R2Lgduj5a2Bl4GjgY8ChxKqPq4FTnP3WHSOeuBc4FjCDelO4A/Ar4mqhwaSif1I\ny2NCALKxn6LOs4BLEsFHpCP6vyHXm8zsSmAmcB3h6eZNhJKZEwAjVOm8GXgC+EwiEIiqkLrd/aCU\nY80H7gAOiNJ/O+GzuNPM7nT3g8ysllD8+4nouN3AIkJV0Z1mdhz9fIbRuZqBbwIfBLYAXoj+/itT\n0vMy4fMaC3yKUDp1F3Cqu7+QIz+6o3PXmFlXlA81wC8IP/7nAqOAd7r7s2b2UeBLhGtxE/A34KuJ\n6rOomPxjhJvAOcBbgGcJJV8QftzfBrxIuP5uz/5J5X9Nmtl+0bn2AFoJVXpfcvfV0evHRX9P4uay\nK6EY/jJ3vzjlfP1+h3OkcxLhZnk4MAF4jPD5Jm5qpwI/AI5396ujbQcSSvC+7u7fia7LbQjf7bOB\nycB/gC+4++MZf0e2z+Vw4GvAWwmlhH8CznT3zdF7G4BLgA8QqhReBn6R8fefFh17G+AN4O/AV9x9\nY/R6WhWMmc0kfF/eTfg9ewI4192vTzlmN/B5YDdCSeUoQgnvAnfvq7TtJGAMcGNfeZ9hPekPAGcC\nG4HTcuz/ZeDDwNcJ310I39W1hN+XNO6+2sz+FzAza0z8dmaK8uUC4D1AI+H35Svu/kDK73HyWoje\ncxUw3923jdYz7zMLga0IDwpHZZzvMeBld/9wtD7ga8HdV5jZ7YTv8Udz5F9JqBFq3+YQLurUH/CP\nEorHPwB8L9r2N+B/gIui7fcBf4yKABMuJPy4/IxQxL6a8MOVKq1KJioO/DXw3+g95xHqJn8I3ED4\nISJ67ZyUY2S6gnChHR6l+STCRZrws+i4P4j2WRFtK8dUyZl5vAuw1sz+YmbrzGyjmf0x+mID4O7L\n3P1JADMba2bvBr4D3JtH8eg+hB/F04HjgZ2Am4CLCfn5UcKX/bcp78mVD4ntD0fHhHCzPSVavoCQ\nzz8hBH8nE24uf45+CG6kn88w2u8+QjHz+YQg5G7gl2b2lYz0nEbIz+MIn/HbCddPLnsRbpiPRMuJ\nH/w64AvAicD/Rje5rwG/J/wYHkEIiI4E7ohu3glbEr4H50SvTyLUz/+OcE0dTghy/pDxvkz9XpNm\ntj/hRr4JOCr6+w8Abs84di3hh/j3hB/0e4ALzezglH3y+Q6nic5xR7T/Vwk3tCXAzWZ2AIC7X0b4\nvC4ys8lRid+V0fHPSzncLlGenU0IuqYSgtkZKftk+1w+DvwVeDrKp28QqgL/lvK+HxCuvy8Ah0Sv\nfS8KajCzYwjX6mXR69+KjvHDHH/3dMKDwzuBrxCuh5eBv0XHSvUdQv4ngtcPEALBvhwL3OjuHZkv\nmFldyr9RZvYmMzsjSvevo31qgIOBW929NdsJomP/FXhnFEQSHeO2Pt7zF3f/Th/BRxPh+zE/+ls/\nTGij8u+ohCaXzKp4SL/PXED4PTosOkfifDsSAvpEYDvgayHFn4HDzWxsH+keMJWABDVmltrwczLh\nh+wsYKG7P5ryWhvw2cSXI/oROxQ42t3/Eu1zi5mNA843s98D44FTgYvc/Tsp+2wRvbeX6Et0NnCd\nu382ZftYQunHOsKTJMBj/ZRS3ODuX46W7zCzQ4D3A2dFX4zjCE9bP0hJ20zCBVoq+ebxLoSSiSsI\ndbE7En6Y7zSzXbN8+VcTnpbeINyw+jMOOCpRTRPdKD4DHOTud0XbLiLcoJrzaYjl7pvM7Olo9ZmU\n6qmZhBKCHyf2NbM2wg35be7+oJn19xmeQAiS9k4pBr/FzEYDZ5vZFSkNeNcAh7t7PDrXW4Bvmtkk\nd1+bJd0PWkbVmZlB+DE8193/GW2bSPicrnD35BOlmT1FuLmeQPi8IDz1fc7db4n22ZnQzudEd0/c\nIL5O+IEz4PHMdJnZduR3TX6XkN/vT3nvA8AzhJv0T6LNNcC33P2qaJ+FwEcI34Fb8vkOu3t3ZjoJ\nJU1zgXe4+0PRtpujErMLgHdE204glHxdCHQBEwlPvKk3nWbgfe6+MErjg8BLhKDqzGiftM8lcj5w\nk7snbyBm9jxwm5kdFu27P3CLu/852uVuM9sErIzW9wdeSrlO74len5zlb4bQPmsKsJe7J9qF3Gyh\n/dZFhJKqhMfd/aSUtL2DEJhmFeX5HsAfs7xcQ09JZ6pXCL+VF0Trkwn5uTjXeSIvRMfcKvptaiAE\nUsU6gfDwsmviQcjM7iNU3cwnNGTNV+Z95kVCYPghQjAP4aFkLeFhFEpzLST8l9BObz9g0KpnFYAE\n8+l9YXcRGjlm1h8+kxGZH0QoWr8p4wZ7PSGSfyswi5DXN5DuGnIEIIQGldMJEW2Su19KuDEnbhb5\neCBjfSmhygNC63AIN8VUf6C0AUi+eXwy0OnuD0fr90U393sJP/g/TewYFdN/gPDD8VXCD+e+/ZSC\nrM1oI7Ii+j+1jvuN6P+JDKAxqLt/MkrnVMLNdvsovRCCpnzMBxZnqYP/LaGUYy9Cq3WA/2bc1BI3\nhybCD1UhUtuh7EX4MUq7Kbj7vWb2CiGQvCLlpftTlvvL32z6vSbNrJFwg/9exvduMSEAOZieACRO\nynfA3dvNbBUhXwDeRe7v8CcI3+FegRLhu78ceDTlfTWE7/kFZjbB3de7+8vRU/rl0T7Hu/srGcd6\nORF8RGlcHgVKmT3Nkp+LhR+A2cB3MtJ9D+G6PZhQ5XEH8Fkz25JQ2ndjyoMQ0eufMbNHCL83N7l7\nahCRaT7hoSGzUepvCe2w5qQE4dl+e5rIbStCSU+2QCBOKNWriY7xv4Rr5VR3T/1tTbSryhaspEpU\n4dakLOfVAzGHfQmfY/L3JypN2REgqoLJV9p9xt0XR8HMx+gJQD4GXOPuHSW8FhIWR/9vW0CaC6YA\nJHiYUPyaaEjYCrzq7i1Z9s3s5jmFUMSYrftnN+FpPlHEtzrj9WV9pGlK9H9mZFqMzVnSlah+m5rj\nPCsorbzy2N3/k/lGd19oZuuBeRnbO4meKszsHsKX5jRCEJNL1oAiV7HqQFjozvdjwo9mC/AUkCjl\n6NX4NIfJhJtcpsS21Jt4ts8ZiqtqTb2eE0/CudKRFkh49q7Q2b5LuUyL/u/rmpxE+LvOIFQDpIpn\nOV9f34HJ9P8dzhaATCE8XGTe6BJF6rMIbRMgVAFdEm2/JcuxXsuybSWhzUqq1DQmfiN+TE+wlZqG\nRFf20whVQ58gVKtcZmb3E0qqHnf3a6IS11MIJQnfstAO6YyUJ+VUk+kpfU2V7zXZ17U/Ifo/6/WS\nWhptZvcSquCuNbOD3P2+aJ/VZtZCaM/Sl0S1yKvuvs7MNtLzYNZLVPo82nMPyzCF0vxeQ/Zr8TeE\nz24SIe1vIVQjJ84NA7wWUt6TyP8JDCIFIMHGjGqWQqwjNHY6gOxfrBcIT2o1wAwg9el7Spb9U48L\nPT/GAJjZZEKjrswuqsVKPMXMIL2b3fQSHT+h3zy20NjyI8CD7v5UyvYawhP4qmj9/cB6d78nsY+7\nb4iKKTPHDymFOL2fjMb19Yaorv+fhDYWO7q7R9sPI/yN+VpDzw9lqlnR/+XoOruGcP3OJP36TaQj\n281oIPK5JjcQPpdLSC/yT8i88fUln+9wrvc9RygKz/a+1Kf4ywlpbiN0t/9Axr5T6W0Gfd/QEr8R\nXyI0OM60FpLtHb4LfNfMZkfn/jrhSXputM+fgD9F1+0hhMDut2Z2j7tnBp5rCNdCpsR3byDXZOIh\nLVfpWJK7x83sBEKbh6vMbGd3b49evp7QZmJsogFmKgsNxD9EaDe2Jtr8L+BAMxudcpxU/0Noy/N2\nz947ZB1Zgh4LYxatpeeaLOi3JMU1hDYcHyaUqqSWmpXsWojkemguKTVCHbi7CBdQrbs/kvhHeFr/\nJiHIWwjECA3lUn2wj+M+S/jwM3+ojiM0FhxNqMIYqPsITyUfztheyE2yVNoIP9SZT7SHE6pZEq3V\n/xf4cRSYABB9mXYiveqgVDYQijdT7Zex3kX6TWgOIcD8YSL4iLw3+r825X19uQvYJqo7T/VJQn7l\n6vZcSv+JzpXWwNBCD5StCMW8pdTvNRmVsjwCzMn43j0NfJsQTOQrn+9wrvdtCazKeN97CDfwRBfx\nIwjF5acT2oK9L0ujvx0spU7VzN5EaDB9ax/pfpYQoGyXcf5lhPYQu5pZg5m5mX0BwN2XuvtPCEHb\n1tG5/mhm10Wvb3T3awmNo+vJHtDfBewTFeOn+gSw3N0HEpC+RvhOZB47q6jd1LcJQfoZKS+dR6im\n+WkUbGT6bvSe1OqHiwmB4LmZO0ftj74IPJkj+IDwPdjOQuPQxPsaCL3uTqSn9HV2yuujgD37+BOT\n3H094bf/cEI7mtSG8iW5FlIk0phZVVhSKgEZuJsIF94/zOwcQv3zOwgNhm7ynpE7zwHOMbPNhBvp\n+wiN4LJy924L3Rovj+qr/0G4qX2T0IVwvZmtI9z0PmJmN2Xc6PIS1U//ihARjyHcwI9ISVu2xneD\nwt3bzOx8QsPJlYS8fRuhNfffPGokSmiU+m/gGjP7GeHJ+GuEtgWXDELSbgA+YGYXEz6H/QgBQKrE\nE8j7o8/FCT84Z1no4tpB+NFINMhrSnlfX5/hVYQeNn+LrodEb6bjCd0iB33AMndfG30uZ5tZJ+Hp\ncjvCD/+TRK3wC5SzGL6Aa/JM4EYz+y3hCa6e8AS4R5S2fOX1Hc7iSmABcKuZnUeoXjuE0MXzB+7e\nFbX/+Qnwz0S7CgsDPX3fzG7xMPYPhID0egu9jboI1/xqQs+UrKLfiLOAKyx0eb2e8OT6NUJ37Yfd\nvdXMHga+bmbthKqkOYTrJ1G9cjvwEzO7MMqLydH5nyN7QH8JIdi4zcy+RfjeHU8I+k7Ild58uPvm\nqK3DOwlP+/m4lFDteoaFruxL3P1J6xlp+i1m9mPCd2dWlMaDgS+7+79Tzv0fMzub8Du9E6FXzWpC\nycCXCO22ju4jHVcSGsL/I/quriYEnaOAy6NqnoXAqWb2AqEk6TTCw1W+VZS/IQyjUBstJ9Jeqmsh\nYb8oTaV+uEijEpCgkO6maftGjf4OI0SRXyU0CEx05zsmZb/zCRfjkYQ+9m8ldIXKefwoOj2e8MW+\nnnCxfpfwAwehQdEthGj/ohxp7K8LKYSnsisIEf7fCBdsoktoIUOb95WPeeWxu59DqIs+mHCz/19C\nvebHU/a5M3p9OuGL8wNCt8C9ve/xBXKlo7+0/YrwFHEM4QlkL3qXED1F6Ob5eeC3UWDwQcKN9hrC\nTXo24Yu9kZ4SlD4/w6htyv6Ez//bhGtnH0KvknMy9i+223S/73P3bxE+lwMJn8vZhHYN+2W0n8k3\nDf3t1+816aGnzaGEfP0z4YbRDrwrS6PdbOdP5HFe3+FMUdH+foQf6QsIN+8PEW5siYGsfkS4waQO\nqrUg+v8XKdteic53abT9WWDfPtobJNLwyyiNexM+lx8RqsTmpzR0/TTh5vhFQjXDWYQuzadEx0h0\neX4P4Tq7ghBYHuI9Q5un5tcKwjX4MKEdwZ8Jn8EHPWV8C3Jfk/199n8hqgrJ531RtcLphB5YqeNZ\n/Ikw2vLjhAe3fxPyeA2wj6eMfZHynvMIpZRxwmdxI+E7/Q9C75bnciU6KpXbj9Dw9jLC96MGOMB7\nergdR/it+jnhM3mY7N2Sc+XRTYTqlAc9Y3yfUlwLKd5D6D3ZluvvLYWaeLwcQz3IUBU1aDqM8IS2\nNmX7hYTW+tNyvllkEFTbNWlhILL57r5dpdMyFFjo4fQiIZD7bX/7S2lFvXVeAHbPaJhacqqCkc2E\np5hHzez7hKfLfQhPadm6Z4kMNl2TVczdYxZGhf6Smf3O07uWy+D7EvCnwQ4+QFUwVS8qYjuI0Ej2\nSkIR3zGEQaB6NcYSGWxVek3qJpsiqhZaSt9d6qXEoobQ76enmnBQqQpGREREyk4lICIiIlJ2agMi\nUsUszFuyf8bmDsKoltcDX0vtiWFm2xN6Jh1CGCNiFWHcju96jiHwzew7hN4ll3nKXDJZ9jsdOMzd\nD43W9yWM7bA3YT6lFYQeQ99x915DdUfFxwuitM2O/o6nCN0Vf57So4NopM+tUt7eTeid9CTwUzV+\nFBl8KgERqW5xwoBe7yB0L96LMDfKJYTBk5JzbEQDaj1KGB78HEJXva8ShoT+j5m9K/Pg0WBxnyR0\nhfxkNDBTLu8ltPcgOtYdhAaoJxGCim8SGqM+aGZpc1SY2UfpmdX3IkIvmo/R080xc16ZOKGLZeLv\n3p/Q5f1V4GoLExKKyCBSGxCRKmZmdxBmwz0oy2tfIwzGtTdhUKVFhOHlP5raMyEKKhYSxmXZ1lMm\n0TKz9xBu9O8kjJfxaXe/Msu5xhIGtJrr7i+Y2a2EeTf2z9hvJqGL4JXufmq0zQjBx01R2roz3nME\nYayKj3k0t4mZvQzc4e4nZknLxYRxJd7p7vdnvi4ipaESEBHJJTHF/NaEgapGE2YezRyMr5UwsNGV\n9MwhkXAiYfjq+4lmXc1xrncBr6UMrjSTLL9PHuYlOZX0Cd3OIIwe+tnM4CN6z3UUNlrrt4imQy/g\nPSJSILUBEZFc5kT/v0gYhfWRaBTMXtz9DkKAkRQNKPYBwpDpEIaVv9rMdskyn0ay+iVyA/BlM7ud\n0IbjzkS7jywlKIcDt7n7G7n+EHfPe4hwDxMbPkgotRGRQaIARERqzCx1hs7JhOH/zwIWuvsj0cRj\nhc4Y/QnS56y4jjA89GfpXbpwWMa2swlTgZ8EzI/SuJQQpFySGBLbzCYSSl16DZGd8TdBqGrKd26j\n5YQ5ZURkkKgKRkTmE3qMJP6tIMxr81965kLppPc04v05gVAq0mFmEwiTef0DOMbMEpPxYWY7A9NI\nKUFx9w53/xyhN8tJhJk/awhzWTxhZh+Kds36G2Zmb874mzoIbUfyVYMGBxMZVCoBEZGHCZOvJW66\nrcCr7p46Q+cr9J6yO8nM6oHJ7r4yWt8F2CU63tqUXRM39U8AP42WDyNUsfSa+Co63lXRP8xsPmHm\n258QZkheY2YtwDYZb10CvD1l/ZuECSDzNZswEqeIDBIFICKy0d37q175F3C6mU1PBBkZ3g9cZ2Yf\ndve/ExqfbiTMCJxZkvAzQmPU1ADkusSLZrYnoaTkWHe/LfWN7n5XNCndJWY21d1XR/u+z8yaEkGT\nu7cTesYkjpmzfUimqFpnN8LsuiIySFQFIyL5+BGhGuMHZpb2uxFVp3wLWAn808xGEapu/u7ud7n7\n3an/CD1S5pnZnmY2jtDY858ph3wOaAJOi8YRyTQHWB4FHwDfBUYBv4jOnSaaXfXNBfytZ0XH+2l/\nO4pI8VQCIiL9cvdXzOxzwC+ALc3sp4RBuxIjo24LHOLu7WZ2NDAF+EOOw/2GMJDZZwmjrb7s7i+l\nnGudmX2RUM1yj5n9HHiJ0Cj1COBTwMdT9n/SzD4J/Ap4xMx+ATxB+H3bl1AaMwO4ICMd08zsHdFy\nXbTPkYQBzM7No1RIRAZAAYiI5NXY0t2vNrPnCIN0nUMYeGw5YYCxI9zdo12PJwwq9u8cx1liZncB\nRxNKVW7Kss/PzOx5wvgj5xECmo3Af4AD3f2ejP2vM7P/Ap8jNFrdmlDC+yIhEPqpu7+YcZr3Rv8S\nebCOUG3zEXf/Wz55IiLF00ioIiIiUnZqAyIiIiJlpwBEREREyk4BiIiIiJSdAhAREREpOwUgIiIi\nUnYKQERERKTsqm4ckHg8Hl+zpoXubnU/Lofa2homT25CeV4+yvPyU56Xn/K8/Gpra5gyZVy20YmL\nO16pDjRc1NTUUFtbsvyTftTW1ijPy0x5Xn7K8/JTnpdfqfO66gIQERERqTwFICIiIlJ2CkBERESk\n7BSAiIiISNkpABEREZGyUwAiIiIiZTekxgExszHAQ8Dn3f3uHPvsCvwEmAs8CXzO3R8pXypFRERk\noIZMCUgUfPwB2KmPfcYCNwJ3AbsB9wM3mlljWRIpIiIiJTEkAhAz2xF4ANi2n10/Bmx29zM8OB3Y\nCBw12GkUERGR0hkSAQgwH7gN2Bvoa6i1dwD3Zmy7L3qfiIiIDBNDog2Iu1+RWDazvnadRWj3kWoF\nsPMgJEtEREQGyZAIQAowFmjL2NYGjKlAWkREpMqt29RGZ1d3pZNRlNauVla3rs57/7raGg6atGvJ\nzj/cApBWegcbY4DNhRykrm6o1DyNfIm8Vp6Xj/K8/JTn/evo7KYl1lHUe9/Y0MrSlZsYVV/Luk3t\nbIy1M3bMKMY01POYr2TS+DHU1tTQSTutNev6PNbTi9cya/JYqIGVa2O0tHYCfdf95zKc5+Ctqetk\nzJyHCn7fQXN/UrI0DLcA5DVgZsa2mcCyQg7S3KxOM+WmPC+/as3zza0ddHTmfiLt7o6zcu1mamoG\nNrPnplgHjzwbbn7FeOLF1UybNDbvG9/jL6xmwrjRPP3yGmZNH0P36A1pr69cGwOgvnboBUGd3YNc\nQrCigBvq9ik3jMnQMJjpkj4NtwDkAeCMjG37AucWcpANG2J0DdMis+Gmrq6W5uZG5XkZlTLPu+Nx\n1m1sY1Osg1hbJ+s3tVNXl/uW2dUd59XlGxk3dhSvr95MPB5nzKi6rPuu29TG66tbmDYxd6D0wmvr\n2bi5g9H1tXlNBd7a3tX/H1VudR3UNLRkf21JYYd6fTPUNneybpveN9qGNxWRtjIZbjeaavPe6Ucx\nurb/QLqmprTB7ZC/LsxsBrDe3VuBvwDfNbNLgZ8BnyW0C7mmkGN2dXXT2ccTkpSe8nxwxeNxnnx5\nDctWt1BfX8uG1k42bGxjzKjajP1g0QurmT1tXK9jPPzcKhrH1FEblQy0d3b3WZJQKktX5bg5J9R1\n0DGmn30iNaNKkKAi1NXWhBKVzDL5ug7qd/hvRdJUzRbMO5mGepVt5GNm0zQa6/MrLa2vH/kBSOZX\neBlwPHC1u280s/cDPwX+B3gcOMzdY+VNokjfuuNxXlm+MdR5Z3lwb2vvZtW6GA1j6li8bANLV7Uw\nafwY6lKe8p9evJaJ40YzOksJwkuvb6CpoT65/4bNhdWtr1ib/SsTaytdCUJNTQh4AKZNzH4zaO/s\nZv2mdnbcelLW17tr2lky5R/E64prOzDSVfONtr6uhvHNjWzcEKOzq+e2UcgNVSqrJh4fzs1oihJf\nu7ZFT+NlUl9fy6RJTYzEPO+Ox1mzvhVfso5XV2zilodCefro+lrah9DfOrk5vWg1Hoe1G9vYYfaE\nECWkWLF2M+/YcQYNo3uCno2xDraZOZ7pExupr6tl4ri+i2pra2uYOG70gNpYxDpjLG9ZxbKW5fzu\n2b8UfZyhpNTBQrXfaEfyb8tQFeX5wBpPpR6vVAcSGeo6u7p57PnVPPvqWiY0je71ektrJ0tXbWJy\ncwP3Pr6MpoZ6Gsekf0Xi8dAivy8DCT4mjR/D5JRGjas3tDJ5fAPTJ/W+0axYs5m3bDGBMVGwsLmt\nk/3f9ibeNK2JGdObWbeuhe6uofmAkQgwsmntbOXyRb/otf3YOUcyqymzDfrQkOtpPKHagwWRbBSA\nyIgSa+uko6ubV5dv5B/3LWbdpjbqamtyVjn0paW1M9lFrxCzpzWx87aTWbk2xr67TqWrfmPW/err\nahnXGL6CdbW1RZQYjM9YH0U3a1keW0fL2jU5b4aVlivA6EtjfSO7Tp87ZG/iyafxWj2Ni+RLAYgM\nK/F4nBVrY7R3dLFuUzu/+ZfT2t5JfV0t61vaCzpWajVDQkdnN13dcWZPG8fSVZuwLSey5YyeBpud\ntBNjHesLvPqoAAAgAElEQVQ3tbP1zPG0tnUyfdJYpk9uZELTaOpSukC2dsa5fNH3i/9jJVltoRIE\nkZFHAYgMOfF4nJbWTha9sJr/PLOC9o5unluyjrraGrq6i3ui392mUVdbQ11tDYfssRVbz8wsPehb\nrDPG4vVLuHzR1WFDM7ySGP5udfRPCtZXuwgFHSIjmwIQKbvEsMXtHV28smITDzy1nEefX01reyez\npjSxZOWmrO/rK/gYO6ae3Wway1a3sOdOMxjXMIrJzWOwrbL3rshUTJuEQpSzt0J/7RGGCgUYItVN\nAYgMmo7Obp5+ZS3/uO8hlq7YxOa2/ttT5Ao+AKZOaMC2nAjA7jadxjF1jBs7mi2mNg0onbHOGGcv\nPJ9YZ/7tRAoJKMp9o1V7BBEZDhSASMm0tXexfM1mfn3zsyxenr3hZX/GjKpj1+2nsr6lnbfbNOZs\nPYlZUwYWYPQl1hnj0ZVP5B18LJh3MttM2FJP7iIiA6QAREri4j89xlMvr+lzn/q6GsaPHc02M8ez\n49aTqK2tobs7zjazmtl21vi0BpyDKVHdkq1qpa+unqoyEBEpHQUgUrS1G9v48k8W9tk2Y3ebxgkf\nfCvNY+oqXh3Q05A0e3uOod7VU0RkJFEAIgV5/MXVXHf3S7y6IntbjUnjx3Dce+aw0zaTqK+rTRut\nsNT6ajiaqb+GpKpaEREpLwUgkpd4PM5JF9zR5z7HvHt7Dn77loOelv5KMvKlMSZERCpHAYjklJhh\n9ap/PsvajW1Z9/ngvttw+Du3LWgUz0JKLjKVqkusSjtERCpLAYj08te7X+L6hYtzvn7swTtw0G5b\nFDXZWDFdXvszlLvEiohIdgpABAilHRf98TGeeWVtn/ud9z97MXPy2LyPG+uIsfqNlclBsZa1LC9Z\n8KGSDBGR4UsBSJWLx+M89sJqLrv2iayvbz97Ah/ebztsq4lZSzwGMoLoQGY3VUmGiMjwpgCkSq1c\nF+O83zzMhhwTuH3+w3PZ3ablfP9AG4Kqy6uISHVTAFJlbn1oCb+/9fmcr5925NuY95apfR5jbes6\nvrbwvILOe9pun2ZUzZjkukowRESqmwKQKhFr6+Tzl96d9bWpExpYcMRctpw+rt+GpbmCj1wNQevr\napizxba0tXRXfCAyEREZOhSAjGC3PbyUhU8uZ8nKTckZaFMV2pslW/DRX0PQ+vpaxo5upK2l9AOR\niYjI8KUAZIRZvmYzl/zpMVavb825zw6zJ/CVT+xe0HFjnbFewce5+5zJpIaJRaVTRESqmwKQEeT6\n+17mr/e8nPW1t243mSUrNnHhKftQX1f4pG+L1y9JW1fwISIiA6EAZIS45aElWYOPU4+Yy6475O7N\n0p9svV0WzDtZwYeIiAyIApAR4Pe3PsetDy1Nrs+Y1Mh3P7P3gI+ba9TSbSYM/nwvIiIysikAGcY2\nxTq4/NrHeW7p+uS26UUEH7kGE8s2aum5+5yp7rMiIjJgCkCGsf/3g3t6bTu/iOAjn7lZjp1zpAYO\nExGRklEAMgx1dXdzwe8eTdu239tmccJ7dyz4WMtbVvUbfGjUUhERKTUFIMPQmT97gFXrerrZfu+z\nezN14sCDg1xzs2jUUhERKTUFIMPM0lWb0oKPQ/bYsiTBB8CspplsO2GrkhxLRESkL4UPCCEVE4/H\n+fovH0yu773zDD72ru0HdMzWztwDlomIiAwWBSDDyM9veDpt/eT37zSg48U6Y0XPZisiIjIQqoIZ\nJtZsaOWBp1Yk17994p55zeGSq4sthG62qWY2FT9gmYiISCEUgAwTF//pseTy3O2mMHv6uH7fk28X\nWwijm6qhqYiIlIuqYIaBZxavYdkbm5Prpx/1tn7fE+uM8ejKJ/IKPhrrGzW6qYiIlJVKQIa4X974\nNPc90VNVctheW/Vb9ZKt5CNXF1tQN1sRESk/BSBDWFd3d1rwAfCR+W/u932L1y9JCz40kJiIiAw1\nCkCGqHsfX8avbnombdsvzziw39KPta3r0nq2aAh1EREZihSADEGLXljdK/j45gl75Aw+Ej1dWjtb\ne3WrVfAhIiJDkQKQIeaHf3mcx15YnbbtolP2YXJzQ9b9++rpoplrRURkqFIAMkTE43FOuuCOtG31\ndbVc8aX51PZR7ZJrMrlz9zmTSQ0TS55OERGRUlAAMkRkBh87bzuZLxw9r982H6lDqSd6uqhXi4iI\nDHUKQIaA2x5emra+6/ZTOfUjfY/1EeuMsXj9krQ2H5pMTkREhgsFIEPAnY+9llw+4+O7YltN6nP/\nXO0+NJS6iIgMFxoJtcK643FeW9WSXO8v+IDs7T7U4FRERIYTlYBU0Or1Mb78k/uT6/PePKXP/RPd\nbVMnkdM4HyIiMhwpAKmg1OAD4KT375Rz31zVLrOaZir4EBGRYUdVMBXS1tGVtv6VY3djXOOonPtn\nDq8OYYh1tfsQEZHhSCUgFXLrQ0uSyx+Zvx07bJl7zI5YZ6zX8OrqbisiIsPZkAhAzGwM8GPgCGAz\ncLG7X5Jj3w8D3wG2BB4FTnP3R8uV1lL5z9Mrk8t775x9lloIwcejK59I26Y2HyIiMtwNlSqYi4Dd\ngAOAU4BvmNkRmTuZ2U7A7wgByNuARcCNZpZ9nPIhbOmqTcnl/oZZ/92zf0luWzDvZAUfIiIy7FU8\nADGzscBJwP9z90Xu/nfge8CCLLsfAjzp7r9z95eBrwIzgdytN4egWFtncrmv0o/M7raN9Y1sM2HL\nQU2biIhIOQyFKph5hHSkdgm5Fzgzy75vADub2T7R/icC64EXBzuRpXTDwsXJ5dnTm/J6j7rbiojI\nSFLxEhBgFrDa3TtTtq0AGswsc2CMPwE3EQKUdkJJyZHuvr4sKS2Rfz3Y0wD10D1zD52eOs+LutuK\niMhIMhQCkLFAW8a2xPqYjO1TCFUupwB7AlcDV5nZ1EFNYQl1x+N0x+PJ9Vwz3Wb2fBERERlJhkIV\nTCu9A43E+uaM7RcAj7v7FQBm9hngGeAE4MJ8T1hXV7m46/ml65LLB+0+m/r67GlZvWl12vrs5hk5\n9x3KEnldyTyvNsrz8lOel5/yvPxKnddDIQB5DZhqZrXu3h1tmwnE3H1dxr67Az9IrLh73MwWAVsX\ncsLm5spVZSy666Xk8gf2fzOTJvVuA7K5Pca6tWuT62fNP5U3TR82hTxZVTLPq5XyvPyU5+WnPB++\nhkIA8hjQAewFLIy27Qf8N8u+r9O7x4sBDxZywg0bYnR1dfe/4yD4xz09AcikxnrWrm1Jez3WEePM\ne85jc0rvl64YvfYbLurqamlubqxonlcb5Xn5Kc/LT3lefok8L5WKByDuHjOzq4ErzOxEYDbwReA4\nADObAax391bg58CVZvYQoRfMp4GtgF8Xcs6urm46O8t/wd6z6PXk8phRdXR3x+nujqfts3TDirTg\no7G+kakNUyuS3lKqVJ5XM+V5+SnPy095PnxVPACJfIEwEurthG61Z0fjgQAsA44Hrnb3a8ysidBF\ndwtC6cmB7r669yGHnt/f+nxy+YT3zul3f3W9FRGRkWpIBCDuHiM0JD0hy2u1GetXAleWKWkl09be\nlTYB3Z47zuj3Pep6KyIiI5WaD5fJwqeWJ5fnbJV74jkREZFqoACkTH7zL08un/jeHXPulzr4mIiI\nyEg1JKpgRrp4PL2h6dSJvatVYp0xFq9fosHHRESkKigAKYPU0o+jD3xLr9cTs96mTjwHMLNp2qCn\nTUREpBJUBTPI4vE4dz7W0/12n7m9Z79dvH5Jr+Dj3H3OVANUEREZsVQCMsgu+N0jyeXmsaNoHjs6\n7fXMOV/U9VZERKqBSkAGUXc8znNLeybq/fLHd+u1z/KWVWnrCj5ERKQaKAAZRIuXbUwuz91uCm+a\n2nvel9ReLwvmnazgQ0REqoICkEG0oaU9uXzUgW/u9fra1nVp1S8N9Q1lSZeIiEilKQAZRD+89vHk\n8vgsbT++tvC8tG3q9SIiItVCAcgg2RTrSFsfP3ZU2npm2w/1ehERkWqiAGSQPP5iz/x4xx68A7U1\nNTn3XTDvZCY1aHh2ERGpHgpABsmTL69JLu+9c++xP1Kp7YeIiFQbBSCDINbWyQNPrUiuj23QcCsi\nIiKpFIAMgs9fendyecYktesQERHJVNSjuZnNA04D5gBHAYcDT7v7naVL2vC0Yu3mtPWvHff2CqVE\nRERk6Cq4BMTMdgceALYDdgfGALsC/zaz95Y2ecPPo8/1ND795CE70NQwqo+9RUREqlMxVTAXABe7\n+wFAO4C7fxq4HPhmyVI2TF1zxwvJ5QN23aKCKRERERm6iglA3g5cnWX7j4CdBpac4e3lZRvS1mv6\n6HorIiJSzYoJQNqB5izbtwRaBpac4e2cXz+UXP7w/ttVMCUiIiJDWzEByN+A75hZYuSsuJnNAX4A\n3FCylA0zaza0pq1/YJ9tKpMQERGRYaCYAORLwDhgNdAEPAI8BXQB/1e6pA0vV938bHL5xPfuWMGU\niIiIDH0Fd8N19w3Avmb2LkLvl1rgSeBmd+8ucfqGjSdf6hn5dN+5fY98KiIiUu0KDkDM7HbgCHe/\nDbgtZft0M/uXu+9aygQOB13dPXHX+LGj1PhURESkH3kFINH4HokRteYDZ5rZpozdtge2KV3Sho/N\nrZ3J5fm7qOutiIhIf/ItAVlMGOcj8Wj/MUKbj4Q4sIkqbQPy7KvrksvbzhpfwZSIiIgMD3kFIO7+\nNGHkU8zsZWAPd1/d97uqx8+vfyq5vM3MbD2U08U6YyxrWT6YSRIRERnSimmEum2u18yswd1bc70+\nEnV3x+nsiifXJ40f0+f+sc4YZy88n1hnbLCTJiIiMmQV0wh1CnAWMBeoizbXEOaE2QmYmOOtI9Ky\nN3rGXjtkjy373X95y6q04KOxvpGZTdMGJW0iIiJDVTGz4f4YeBdwC2Em3D8AOwK7AV8tXdKGh7Ub\n25LLu+3QfyDR2tlTQHTsnCPZdfpcGusbByVtIiIiQ1UxA5G9GzjO3Y8BHLjQ3d8O/ALYuZSJGw5e\neG19cnnqhIac+8U6YzzzxnNcvugXyW2zmmYq+BARkapUTAnIOODxaPlZYJdo/TLgphKla9i474ll\nyeUJ40b3ej3WGWPx+iVpgUeCql5ERKRaFROAvAZsDSwBngPeFm3fDEwuUbqGhXg8zhsbeqpg6mrT\nC5T6anB67j5nqvRDRESqVjEByLXAVWZ2HHAr8EczewD4EPB8KRM31D3+4hvJZdsytL2NdcZY3rIK\ngGUty3sFHwvmncw2E7ZU8CEiIlWtmADkLGAUsLW7/97MrgWuAdYTGqVWjU2xjuTyp95jfZZ4qMGp\niIhIj2LGAWkHTk9Z/6yZnQlsIH101BHvlzc+k1yePqmRVzcuzRp8NNY3KvgQERFJUVAAYmZvBTrc\n3VO3u/saM5tH6AmzRwnTN2QtXr4hbT2z/cexc45kVlOYFXdm0zQFHyIiIinynYxuW+AfhIHGMLMH\ngfdFgcco4FvAl4A1uY8ysty48JXk8mc+2Lv38aymmWw7YatyJklERGTYyHcckEuAZuB44BhCV9zv\nmdl04AHgK8AfiQKUajAlZcyPPXecXsGUiIiIDD/5VsHsC5zo7jcAmNkzwB3ADsAsQmnIPwcniUNT\ne0do7jKleQw1NTX97C0iIiKp8i0BmQQ8llhx9ycIJSLjgF2qLfgAePCZlQA0NYyqcEpERESGn3wD\nkDqgPWNbG/AFd19Z2iQND5vbOgFYvb6qJv8VEREpiWLmgkn1aklSMcwsWbkpufyOnWdUMCUiIiLD\nU74BSDz6l2171fnjbT0Dvu6908wKpkRERGR4yrcRag3wkJmlDjQ2FrjLzDpTd3T37UqVuKHqmVfW\nJpffMntCBVMiIiIyPOUbgHxrUFMxjKxYszm5PK5RDVBFRESKkVcA4u4KQCKr1vUMtZ5tADIRERHp\nXzGT0ZWcmY0BfgwcAWwGLnb3S3LsOzfad3fC7LunufudZUoqdz32enJ56sSGPvYUERGRXAbaC6ZU\nLgJ2Aw4ATgG+YWZHZO5kZs3Av4EngbcCfwX+amZTy5XQh59blVyeMWlscjnWGWNZy/JyJUNERGRY\nq3gJiJmNBU4CDnX3RcAiM/sesAC4LmP344GN7v65aP2bZnYY8Hbg5jIlGYCmhp6si3XGOHvh+Vln\nwhUREZHeKh6AAPMI6bg/Zdu9wJlZ9p0P/D11g7u/Y/CSlu6V5RuTy+9++5bJ5eUtq9KCj8b6RmY2\nTStXskRERIadogMQM9sK2BG4Gxg/gBFRZwGr3T21O+8KoMHMprj7GynbtwMeNLOfAh8EXga+5O4L\nizx3QV5Z0ROA7PKW7LU+x845kl2nz6WxvrEcSRIRERmWCm4DYmajzeyPwGLgRkIAcYWZ3RK10SjU\nWMKw7qkS62Myto8DzgBeB95DCH7+bWZbFHHegv3+lueSy1vNGJd1n1lNMxV8iIiI9KOYEpCvEapN\nDgJuiLb9ELgSOJ/QiLQQrfQONBLrmzO2dwKPpnQLXmRmhwCfjM6dl7q64treNoypp70zTIkzalRd\ncnt9XU3acn39UGnbW3mJvC42z6VwyvPyU56Xn/K8/Eqd18UEIMcAn3P3O80sDhAtnwxcTeEByGvA\nVDOrdffuaNtMIObu6zL2XQY8m7HtOWBLCtDcXFwJRUdnGAh21x2mMWlSU3L7qynlN+ObG9Nek6DY\nPJfiKc/LT3lefsrz4auYAGQL4IUs218FJhdxvMeADmAvINGWYz/gv1n2fQDYP2PbHOB3hZxww4YY\nXV3d/e+YIdYWAhDbciJr17YAsKZ1Hd+5+7LkPhs3xFhb21LwsUequrpampsbi85zKZzyvPyU5+Wn\nPC+/RJ6XSjEByNPAu4FfZGz/WPRaQdw9ZmZXE9qRnAjMBr4IHAdgZjOA9e7eClwBLDCzrxOCjuOA\nbYHfFnLOrq5uOjsLu2DXbuwp5qirraGzs5tYZ4yv3n1u2n5TG6YWfOxqUEyey8Aoz8tPeV5+yvPh\nq5gKnW8CPzCzSwgBzHFRo9RvAOcVmY4vAA8DtwOXAWe7e6K77TLgaAB3fxU4lNAD5gngfcB73X1Z\nkefN23NLemqDJjeHJirLW1al7XPuPmeqAaqIiEgeCi4BcfcbzOwjhHE6uoD/I4xM+lF3v7aYRLh7\nDDgh+pf5Wm3G+v2EgcfKatGLq5PLb912CgCtna3JbQvmncykhonlTpaIiMiwVHAAYmbbufvNlHnk\n0Up74KkVAIwdU8+o+lpinTEuX9RTC9VQr3lhRERE8lVMG5AXzOxeQrfba9x9xLe4fG11z5+4uS2M\nl5ZZ/aKRT0VERPJXTBuQA4BnCBPILTezq83soJKmaojZsKmnAeqCI+b2en3BvJPV9kNERKQABQcg\n7n63u3+GMFbHp4BG4AYzW2xm3+r73cPTqys3JZdnTw8joKa2/1D1i4iISGGKHtbM3Tvc/a+EgcfO\nBiaRfQK5Ya8jpYvXxKbRvdp/iIiISGGKmozOzJqADwPHAu8izAtzIfDrkqVsCLntkaXJ5dGj6njm\njSVpr6v9h4iISGGK6QXzR+D9QDfwZ+Bd7n5PqRM2lIxJmfcls/RD7T9EREQKV0wJyAxCtctf3D1z\nsrgRZ+W6GCvXxgA4cLctevV+2WZCQdPQiIiICMUNRHbgYCRkqDr/tw8nl0dnzHKr0g8REZHi5BWA\nmNlLwB7u/oaZvQzEc+3r7tuVKnFDwbpN7cnlow98C4s39LT/UO8XERGR4uRbAvJrIBYtXzU4SRma\npjSP4Y0NbWwxrYnWrlaWtSyvdJJERESGvbwCEHdPHd/jDuB+d+9I3cfMGgiTw40ob2wIg5DZNuM4\ne+H5xDpj/bxDRERE+lPMOCB3ANlmXdsJ+O3AkjO0xKJh1wG6R21MCz4a6xvV/VZERKRI+bYBOR24\nOFqtIQzBnm3XB0uUriFhScoIqM1No2F9WD52zpHsOn2uGqCKiIgUKd82IJcDawglJr8C/pfk7RgI\njVI3AbeXNHUVtnFzTwPUmZPHJv/iWU0zFXyIiIgMQL5tQDqBqwHMLA780d3b+n7X8Bdr60ouNzeN\nrmBKRERERpZ8q2A+BfwpCjriwEdzVMHg7leXLnmV9fzSdcnlTkZ8vCUiIlI2+VbBXAXcDKyk7264\ncaKSkpFgbEPInprRMX765JUVTo2IiMjIkW8VTG225ZHujfWtUNdBwy53pW1X7xcREZGBKWo23FRm\nNg2YDzzk7osHnKIh5CFfRW3z+rRt5+5zphqgioiIDFAxs+G+FbgOOBl4HFgEzATazOy97n5HaZNY\nGQ89uxLqOhgz56HktgXzTmZSQ7YhUERERKQQxVSnXAQ8DzwLHAOMAmYDFwLnli5plbVhczs1DS1p\n2zTzrYiISGkUE4DsA3zR3VcC7wFucvfXCY1Tdylh2iqqvaM7bV0z34qIiJROMQFIN9BuZvXAAcBt\n0fbxwOYSpavinnjpjbR1zXwrIiJSOsU0Qr0f+CqwCmgEbjKzLYDzgAdKmLaKmjhuDKyudCpERERG\npmJKQE4FdgM+B5zm7quBrwA7Al8qYdoqavHyDdTUdfa/o4iIiBSs4BIQd38B2D1j87eB0929K8tb\nhqVl69bTuPtD/e8oIiIiBStqHBAzGwd8ApgLdABPAX8CNpQuaZWzKdbRqweMBh8TEREpnYKrYMxs\nK+BJ4BJCj5gDgR8Aj5vZ7NImrzLWbGhNq35RDxgREZHSKqYNyMXAEmBbd9/V3ecB2wKvAN8rZeIq\n5eklK9MGIFMPGBERkdIqJgA5GPiCu69IbIiW/w84tFQJq6T7nns+bV3VLyIiIqVVTADSSfbxPmLA\nmIElZ2hoSxmETNUvIiIipVdMAHIfcLaZjUpsiJbPil4b9upqa5LLqn4REREpvWJ6wXwFWAi8aGaJ\nhhJ7EEZCnV+qhFVSZ1d3/zuJiIhI0QouAXH3ZwhzvvyBUOXSAPwOmOfui0qbvMro6o5XOgkiIiIj\nWkElIGbWDLS7+yvAGYOTpMpb39KOKl5EREQGT14lIGY20cz+AawBNprZX81s6uAmrTI6OlX9IiIi\nMtjyrYK5EHgHcDahsekewBWDlahKUvsPERGRwZdvFcxhwKfc/V8AZrYQuNXM6t19RM3YpvYfIiIi\ngy/fEpDpwBMp6/cTgpcZJU9RhakEREREZPDlG4DUEwYgAyCa9XbEDDyW6uVlI2I+PRERkSGtmIHI\nRrQXXltf6SSIiIiMeIV0w51tZpm9U99kZmltQNz91YEnq3JG1SkmExERGWyFBCD/zVivAe7KWI8D\ndQNNVCWtb2mvdBJERERGvHwDkAMHNRVDyEuvqw2IiIjIYMsrAHH3u/rfa2ToVjdcERGRQacGDxle\nW91S6SSIiIiMeMXMhltyZjYG+DFwBLAZuNjdL+nnPdsQxiZ5n7vfXaq0NDXUs7lUBxMREZGshkoJ\nyEXAbsABwCnAN8zsiH7e8xNgbKkT0qGByERERAZdxQMQMxsLnAT8P3df5O5/B74HLOjjPccC40qd\nlng8TnuHAhAREZHBVlQVjJnNAj4N7AicBuwPPOHuXsTh5kXpuD9l273AmTnOPQU4HzgEeKqI8+X0\nxvrWUh5OREREcii4BMTM3gI8CRwPfIRQEvFR4CEze0cRaZgFrM6Y1G4F0BAFG5kuAa5y92eKOFef\nWju6Sn1IERERyaKYKpiLgb8Cbwbaom3HANcTSiYKNTblOAmJ9bS5Zszs3cA+wDlFnKdfr61SDxgR\nEZFyKKYKZl9gf3ePmxkA7t5pZt8G/lPE8VrpPaldYj3ZISUaBv4K4HPuPqDhSutyDLfe3tm7/Ud9\nXQ319RVvKjNsJfI6V55L6SnPy095Xn7K8/IrdV4XE4DUkb3kpBkopg7jNWCqmdW6eyICmAnE3H1d\nyn57AtsC15pZTcr2f5rZr939lHxP2NzcmHX7zQ/2nsZmfHMjkyY15XtoySFXnsvgUZ6Xn/K8/JTn\nw1cxAci/gK+a2Sej9biZTQYuAG4r4niPAR3AXsDCaNt+9J575j/A9hnbXiD0oLm1kBNu2BCjK0t3\n27Fjek9js3FDjLW1qpopVl1dLc3NjTnzXEpPeV5+yvPyU56XXyLPS6WYAOQLwJ3AMqCR0PZja2AN\noWFqQdw9ZmZXA1eY2YnAbOCLwHEAZjYDWO/urcBLqe+NqoBed/fVhZyzq6ubzizVLS++FuaBedPU\nJtZE2zq74ln3lcLkynMZPMrz8lOel5/yfPgquELH3V8HdiF0k70CuBs4A5jr7q8UmY4vAA8DtwOX\nAWdH44FACHSOzvG+kk3ckjoHzJRJw3pCXxERkSGvqHFA3H0z8MtSJcLdY8AJ0b/M13IGSe5eskhh\nxdqovWtdB8+PLqYmSURERPJVcABiZrf39bq7H1R8cirnurtD7U5NQ3p7j5lN0yqRHBERkRGtmBKQ\nzGqWekLj0LnApQNOUYW0xDoAqKnrGQ9twbyTaaxXC2sREZFSKzgAcfde1SQAZnY2sOWAU1QhHZ3d\nUNfBmDkPJbc11DdUMEUiIiIjVylHFfkNuRuLDnld3XFVv4iIiJRJKQOQfYDOfvcaolJ7wYCqX0RE\nRAZTMY1Q76B399dmwqy2PypFoiqhK57+J6n6RUREZPAU0wh1cZZt7cDlwG8HlJoKam0btoU3IiIi\nw04xAci/gX+5+5p+9xxG3tjQRo2mfBERESmLYtqA/IgwWdyI0R0v2YCqIiIikodiApDnCGN+jBib\nW1X9IiIiUk7FVMEsAn5nZv8HPA/EUl909xNLkbByeuCp5ZVOgoiISFUpJgDZAbgnWh4RVTGqgRER\nESmvYkZCPXAwElJJnV2ayllERKSc8moDYmZdZjZ9sBNTKf/67xIAGkaXclw2ERERySXfO27NoKai\nwpoaQkFQV1eFEyIiIlIl9MgPLHtjMwCTxo+pcEpERESqQyFtQI42sw397eTuVw8gPWW3ubUjubzd\nFihJy2QAACAASURBVM08VsG0iIiIVItCApAf5rFPHBhmAUjPGCAzJ4+FETW+q4iIyNBUSAAy091X\nDlpKKmTZms3J5YbRxfRKFhERkULl2wZkxI6U0dnZ0wV3stqAiIiIlEXV94LpSBkDZPQotckVEREp\nh3zvuL8mY8j1keL11S3J5fo6BSAiIiLlkFejB3c/YbATUilLVykAERERKbeqv+M+tbin24sCEBER\nkfKo+jtuouHp9EmNFU6JiIhI9aj6AKSrO3Tw2XrG+AqnREREpHooAOkKAcjEceqCKyIiUi5VH4B0\ndoduuPV1I7ansYiIyJBT9QHI+k3tANQpABERESmbqh573F9dm1zuop1lLW9UMDUiIiLVo6oDkOeW\nrIO6Dmqb1nNn583wbKVTJCIiUh2qOgDZ2BajYd5d1NR3pm1vrG9kZtO0CqVKRERk5KvqAOTRV1+m\nZqv04GPBvJPZZsKWNNZrXBAREZHBUtUBSHNzLZuj5WPnHMmu0+cq8BARESmDqu0FE+uMsXziHcn1\nWU0zFXyIiIiUSdUGIMtbVqWtq82HiIhI+VRtAJLqTesPUumHiIhIGVVtABJr62l8uv2sKRVMiYiI\nSPWp2gDkzkeXJpfHNoyqYEpERESqT9UGINEkuAC8eYvmyiVERESkClVtAOKvrksuN4yu6t7IIiIi\nZVe1AUhzk6pdREREKqVqA5AuOiqdBBERkapVlQFIrCPGxln3VjoZIiIiVasqA5DlLSvT1jUImYiI\nSHlVZQCS1gOm9WANQiYiIlJm1RmApEQgsyZOqGBKREREqtOQ6H9qZmOAHwNHAJuBi939khz7vg84\nF3gL8CJwtrtfX8j5uuM9AUjD6LoiUy0iIiLFGiolIBcBuwEHAKcA3zCzIzJ3MrO3AdcCvwDmAT8D\n/mJmcws5WWoAUlNTU3SiRUREpDgVLwExs7HAScCh7r4IWGRm3wMWANdl7H4McJu7/yha/7GZfRA4\nGngi33OmVsHUDpUQTEREpIpUPAAhlGTUA/enbLsXODPLvlcBo7NsL6ghR0oBiEpAREREKmAoPP/P\nAla7e2fKthVAg5mlTVPrQbKkw8x2Bt4F3FrICTd3xJLLtQpAREREym4oBCBjgbaMbYn1MbneZGZT\nCe1B7nH3f+R7ss3tMX75zFXJ9dpaBSAiIiLlNhSqYFrpHWgk1jdne4OZzQBuAeLAUYWc7LWNy9PW\npzVOo75+KMRhI1NdXW3a/zL4lOflpzwvP+V5+ZU6r4dCAPIaMNXMat29O9o2E4i5+7rMnc1sC+B2\noAs4wN3fKPbEbc++nZ3mz2LSpKZiDyF5am7WYG/lpjwvP+V5+SnPh6+hEIA8BnQAewELo237Af/N\n3DHqMXNztP+B7r5qICeOd9UTa2lj7dqWgRxG+lBXV0tzcyMbNsTo6uru/w0yYMrz8lOel5/yvPwS\neV4qFQ9A3D1mZlcDV5jZicBs4IvAcZCsblnv7q3AWcC2hPFCaqPXIJSWbCgqAXHo7NTFO9i6urqV\nz2WmPC8/5Xn5Kc+Hr6FSefYF4GFC1cplhNFN/x69towwzgeEkVIbgf8Ar6f8+36xJ25qrHgMJiIi\nUnWGxN3X3WPACdG/zNdqU5Z3LPW5G0YPiSwQERGpKkOlBKQiGjUPjIiISEVUdQBSq+5bIiIiFVHV\nd2CNQSYiIlIZVR2AbNzcUekkiIiIVKWqDkDmvXlK/zuJiIhIyVV1AKJ5YERERCpDAYiIiIiUXVUH\nIHU1CkBEZPCcd9632G+/Pdh//z3Zb7890v7tv/+ePPbYIwUf89FHH2b//ffMa99//vMGjjrq8ILP\nUYhTT/0Mr776Stq2X/7yp+y33x488shDWfe/8sqf99r+6KMPs99+eyTXFyz4n155duih8znttM/x\n0ksvpr23o6ODq676BccccwQHHbQvRx31Qb7//YtYt67XdGJs3LiRyy67lKOOOpx3v/udfOITR3PN\nNX8gHo8XmwW9vPbaUk4//RQOOWQ+xx13DPfff2/W/ZYte52DD96/z+ugvb2dSy/9Hh/4wCF88IOH\ncuGF59HW1pp8/dprr+H973/3/2/vvuOyqv4Ajn9ABAWEwIkrnMeZI7ch5V4ZbnPh+Glp5ciBs7Rh\nbk1LLTNH5sgyJU0kd5plwz2OpuIAHKiAAwfj98d9eORhKAQ+KHzfr9fzknvuee4994DP/T7nnHsO\n3bp14NixI+b0Bw8e0KVLO65ft1wu7csv5/HTT+vSeYUZI9vNwhUb+/CP7L5M3yuEeIKGDBnOgAHv\nALBlSyCrVi3nq6++wVjIG/LkcUnzMStXrsL69QGpytuoUVPq1XspzedIrZ9//gkPj8IUL/68RfrW\nrYEUKVKMgICNVK9eI9XHs0nwpdDGxobXX+/O66/3ACAuLo6QkGBmz57O2LEjWLPGuInGxMQwYsRg\nLl26xMCBg1CqHCEhwSxa9AX9+/syb94i8uXLB0BkZAT9+/cif/4CjBnzHh4ehTl27CizZk0lJOQi\nQ4aMSG+VcP/+fYYMeYvSpcuwcOFSTpw4xnvvjWHu3AWUK1fBIu/06ZMtgonkfP31lxw8eIAZM+YQ\nGxvHRx+9zxdffM6gQcMIDw9n3rxPmTFjLocPH2L69Ml8/fVyADZsWE/9+i/h7m451rFr15706dMN\nb++GuLik/e8vI2W7FpDbUQ+ffMn/XK5MLIkQIqtzdHTCzc0dNzd3nJ2dsbXNgZubmznNzi7t3wHt\n7Oxwc3NPVV57e3tcXZ9L8zlSa9myr2nbtoNFmtYnCA6+iK9vH7Zv38rdu4++wT5K7tyO5rpyd89L\npUovMHjwMIKDL/Lvv6cAWLNmFadP/8v8+Yto0OBlChYsRLVqLzJ79jxcXV2ZM2eG+Xjz58/FwcGB\nWbM+p1q1FylUyIOGDRszatR4fvzxey5evPCfyxpvz55d3LwZwfjxH/D88540a9aSZs1asnr1Cot8\ngYGbiIq689jj/f77b7Rp05ayZctRrlx52rZtz99/G2u1hoRcxMXFlapVq+Pt/QoXLhgtUdHR0Xz3\n3Qq6dfNNcjxnZ2dq167H2rXfpfta0yvbBSDnLj1cs87V2SETSyKEEEY3zaRJE+nVqytt2jQjOPgi\nZ8+e4d1336FpU28aNqzPW2/14/z5IMCyq+LSpVC8vGqyc+d2Onf2oWHD+owcOZSbN28C8V0wbczv\n69ixDevWfU/bti1p0sSLDz98j+joaHNZAgM30bmzD02aeDFx4jgmTBibbHcJwB9/7OXevXuUL1/R\nIn3Lls2ULl2Wl19uRExMNDt2bM3Q+sqZMycAOXIYM1n7+6+jVas2uLm5WeSzs7Oje/de7Nq1ncjI\nSB48eMDWrb/Qvn3nJIFf/fpezJ49j0KFPJKcL76+E3ejpdSFFhoaQvHinjg6OprTSpcuzZEjh83b\nERHhLFjwGSNHjn1s14+rqys7dmzl5s2bREZGsnPndsqWLQdAgQKFiIyM4PLlS5w4cZyCBQsBsGHD\nOurWrZ+k9SPh9fr7//jI81pDtuuCCbn+sE+wWAHnTCyJECK97tyNJvT6baudz8PdCcdcGf+xuXnz\nz0yePAM3t7wULlyELl3aUqtWXUaMGM2tWzeZOXMK8+fP5ZNPjG/zNonGry1fvpiJEz8hLi4WP793\nWbVqOf36DTDtfZg3LOwqO3ZsY+bMzwgLu8Lo0cOpVq06rVv7cPDgASZP/pChQ0dSpUo1Vq5czsaN\n6+ndu1+yZd63by8vvlgzSfq2bb/QuvVr5M6dmxdfrMmmTRtp3rxVhtRTWFgYCxcuoESJUnh6liAq\nKoqgoLP06dM/2fwvvFCVmJgYtD5O/vwFiIq6Q7lyyS8pVq3ai8mmV65cBX//zcnuS64Lzc3NnWvX\nwizSLl++TETEw3vP3LmzaNGiNZ6eJZI9bkIDBw5m7NgRtGrVCIBSpUozZcosAPLly0fHjq/TqdNr\nODjkYuLESURHR7NmzSrmzv0ixWNWr16Da9fCOHPmX0qWLP3YMjwp2S4A2Rmx1vyzU66cmVgSIUR6\n3Lkbzcj5v3HnXvTjM2cQRwc7pg6ol+FBSPnyFalb1xircffuXXx8OtCuXQccHIxu4ubNW7Ny5Tcp\nvr9v3zfNN9YmTZpz/PixZPPFxMQwdOhInn/ekxIlSlK7dl2OHz9G69Y+rFv3PY0aNeXVV30AGD58\nFPv27U3xnFqfoHbtehZpBw8e4OrVK3h5vQyAt/crTJv2CZcvXzJ/O0+LZcu+ZsUK47pjY2MAqFWr\nLlOnzsLGxobIyEji4uJSHEsTnx4ZGUHu3LmxsbHBySltXzzT0uUFUKdOfT79dDqLFn2Br29f/v33\nJBs3+hMdbXT///nnHxw5cgg/v3GpOt7Fi+cpVMiD8eM/4MGDB8yaNZU5c2bi5zcWgDfffJvu3Xvh\n4OBAzpw58ff/kdq162JjY8vQoW9x8eJF2rZtT9euPc3HtLe3p3DhImh9IlMDkGzXBZNQIaf8mV0E\nIYSwaPrPlSsXPj7t2bRpA5Mnf8iAAX2ZM2cGMTHJD5q3sbGhaNFi5m0nJydiYlIOyooUKZogr7O5\nC+b06VMWgyRz5MiRYmsBQHh4OM89Zzm+ZMuWzRQs6EHp0mUAqF/fGzBaeOLZ2dkRG5v0WuLi4szd\nKvF8fDqwZMkKFi5cSrNmLXF3z0e/fgPMwUz8+a9du5bkeGC0+AC4uLji4uJKXFycuXsqtQ4ePECT\nJg2SvJo29ebQoQNJ8ru5uTFhwiTWrfuBRo3qM2HCODp06IyjoxP37t1j+vRPGDbMz9yV9Ch37txm\n8uSPePvtIVSpUo0aNWoxatR4fv7Z3+LpFmdnZ3LmzGkx9mPRoi8oWbIUS5Z8yw8/fMfJkycsju3q\n+hw3btxIU11ktGzXAhIvR1BtcjfMndnFEEL8R465jNaIrNAFY29vb/45KiqK//2vB25u7tSv34Am\nTZoTFHSWVau+TfH9dnaWN7NHjStIPP4hPq9x849LtC/lMtvYGC0q8WJjY9mxYyuRkRF4e9e2OH5A\nwEZ69uwDgLNzHm7fvpXkeDdv3sTZOY9FmouLizlgGjlyLMOHD2LEiMF8881qXFzy4ODgQKlSpdH6\nOE2bNk9yzOPHj5IjRw6UKoeTkzNOTs5ofTzZwGr06GF06NAlSbdS+fIVWLJkRZL8APnzF0g2vU6d\nevz0UyDXr1/D3T0vP/74PR4eHhw/fpTQ0BDGjvWz+B0NHz6I5s1bM3z4KIvjnDsXxL17dylVqow5\nrWxZRWxsLFeuXE4yxmPTpg3UrFmHvHnzcfjwQQYOHISTkzOVKlXm0KED5rEjYPy+MnsurGwbgNy+\nLXOACPGsc8xlR6nCrpldjAy1f//fXLt2jeXL15jHevzxx28kDg4yWokSpdD64bfk2NhYTp06SZky\nZZPN7+6el8jICPP2X3/tIyIinI8/nkrRosXN6fv27eXzzz/lyJHDVKpUmVKlSvPbb0nnxTh69DBl\nyqhHlnHEiDF0797JNIBzNAA+Pu2ZN28ur7/ew/y4LRhPgixb9jUNGryCi4vxN9K4cVPWrv2OVq3a\nWARiu3fvYs+eX3nzzXeSnNPe3t6i1ehxzp0LYubMqXz66TxzgLB3726qVatBhQqVWLlyrUX+Ll3a\nMmrUeGrUqJ3kWPnyGa30QUFnzHUTFBSEjY0NHh6FLfLGxMSwevUK5syZDxgTbca3NMXExCQJJiMi\nwnF3z0dmyrZdMK5O9o/PJIQQVubi4kpU1B127tzGpUuh/PTTOtauXcP9+/eTzZ9RE2i1a9eJLVsC\n2bBhPefPn+PTT6dz+XJokgGv8cqUUZw+fcq8vWXLZkqUKImX18uUKFHS/GrbtiN58uQhIGADAK1a\nteHcubPMmTODc+eCOH8+iDVrVrFu3Q906dLtkWUsWLAQPXv2Zv36tZw6dRKA9u07UrVqdd55pz+7\ndu3g8uVLHDx4gBEjBnP79m0GDx5mfn+fPv25ffs2w4a9w4ED/xAcfJENG9YxadJEOnZ8neef90xn\nLRrdaefOnWXRoi8IDQ1hyZKvOHToIB06dDYHMwlfYAQa8d1J9+7dM3ev5M9fgFq16jB16sdofYIT\nJ44xbdokGjduluTx6k2bNlCjRi1z0FOuXEV++SWAkydPsH//31SsWMmc986dO1y6FIpS5chM2TYA\nKfe82+MzCSGElVWqVJnevfsxc+ZUevV6nYCAjQwbNorw8BuEhYUlyZ9SgPBfzvvuuyNZvHghfft2\nJyoqiooVK6c4V0nt2nU5fPgQYMy6+euvO2nd2idJPnt7e1q2bMO2bVt48OAB+fMXYO7cLzh//hwD\nBvSlb9+eBAZu4r33PqBWrTqPva4uXbrj4VGEmTOnmvNNnjyDNm3asXDhPLp168CHH46nRImSLFy4\nlLx5H37Ld3fPy/z5iyhcuAgffDAeX98urFmzin79BvD220P+c90l5ODgwKRJ09i7dw89e3Zh7949\nzJw5lwIFCiabP/F1btv2Cz4+LczbEyZMolSpMowcORg/v3cpX74iI0eOtXhPTEwM3323gu7de5nT\n+vTpR2hoMEOGvEWHDl2oUOFhAHLkyCEKFCiYIQFXethk5PSzz4JOqwfEAVTlNfo1rJ/Zxcny7Oxs\ncXNz4saN20TLzLNWIXVufVmhzo8fP4qTk7PFrKY9enSia9eetGjROkn+2NhYunZtz+jR71OlSlVr\nFhXIGnWeWSZNmkjRosXM43JSy1TnGTZ+Idu2gNggY0CEECLekSOHGTlyCEeOHCIkJJhly77m6tUr\n1KlTL9n8tra2dO/uy/r1P1i5pCI9IiLC+euvffj4dHh85ics2w5ClfBDCCEeateuI5cuhTB27Ehu\n375FmTJlmT597iPnwGjV6jU2bdrI+fNBFC/uab3Civ9s1apv8fXtm+nrwEA27oKpbuND31eSj+xF\nxpFmUuuTOrc+qXPrkzq3PumCySAZNG5LCCGEEP+BBCBCCCGEsLrsG4DIKBAhhBAi02TjAEQIIYQQ\nmSXbBiDSByOEEEJknmwbgEj8IYQQQmSebByASAQihHiyJk2aiJdXTRo0qIWXV02LV4MGtThw4J90\nHT84+CL79v1u/tnLq6Z5CfonYd68OWzatMEi7c8//8DLqyZLlnyVJP/ChfMZMmRgkvSYmBi8vGpy\n+PBBc77E9dS48Uv06tWVX3/dkeT9gYGb6NOnJ1WrVqVlyyaMHz+KM2f+TZIvNjaW1au/xdf3dRo3\nfomOHdswZ84Mbt1Kuhrvf3Xnzh0mTZpI69aNad++NStXLrfYf/ToEd58sw+NG79E9+4dCQwMeOTx\n9u37nR49OtG48UsMHfoWly6FmvcdOPAPnTq9Rps2zdi40d/ifWPGjGDvXstF/n7//Tc+/nhC+i7w\nCcq+AUhmF0AIkeUNGTIcf//NrF8fwKBBwyhQoCD+/oHmtEqVXkjX8SdNmsiJE8cA8PAojL//ZvMK\nqhktKOgsv/++h+bNW1mkb90aSJEixQgI+DnZ96X2y16VKtVYv34z/v7G68svl1KiREnef3+sxU34\nyy/nMXPmFFq2bM1PP/3Ep59+jrOzM2+80SdJQDdmzHDWrl1D797/45tvvmPMmPc5cGA/w4a9Q3R0\ndBprIHmTJk3k2LEjTJkym/fe+5Dvv1/FDz+sBiAyMpKRIwdTvXoNli1bTffuvfjkk4kcP3402WOF\nhoYwduwIXnutHV999Q1OTs6MGTPCvH/WrKm0b9+J9977kFmzppoDqVOnThIWdpW6dV+yOF6dOvUI\nCQnm0KEDGXKtGS37BiASgQghnjBHRyfc3Nxxc3PH2dkZW9scuLm5mdNSWugttRJOJGlra/vIWUvT\na/nyJbRs+apFQBEdHc3Ondvp1asvoaHB5haN/yJnzpwWdVOyZCnGjHkfgL179wBw7NgRli9fwuTJ\nM+nQoRPFihWjTJmy+PmNo3nzVnz88QRzYLFp0wb++msfn366gJdfboSHR2GqVXuRadNmc/r0KX75\n5dEtEalx/fo1du7chp/fOCpWrESVKtV44423WbHiGwCuXLlM/foN6N9/IIULF6F581YUL+6ZYj35\n+/9IpUov0KFDFzw9SzB27AQuXDhvzn/uXBDe3g2pUaMWuXLlJjQ0GIClS7+id+//JXvM115rz5Il\ni9J9rU9C9g1AMrsAQghhsnbtGjp2bEPTpt4MHjyQs2fPmPf9+efv9OrVlYYN69OlS1s2bFgHwIcf\njufw4YN89dUChg59y6ILJr6LIzAwgB49OtGwYX3efrs/ly9fMh/3+PGj9OvnS6NG9Rk48H8pdpeA\n8U1+27YteHm9bJG+d+9u7t6NokGDV1CqfJLumfSysbHBzs7OHKht3OhPxYqVqVq1epK8vXv/j8uX\nL/Hnn0aX1KZNG/D2bkihQoUs8uXNm485cxYkuRZ42DWUuMusQYNaLFv2dZL8ISHB2NjYUL58RXNa\n6dKluXr1CmFhVylduow5iIqLi2PXrh2EhFykSpWk5QcjwKpSpZp5O3fu3JQpU5YjRw4DUKiQB1of\nJzj4Infu3CF//oKcPv0vV65cSdL6Ea9u3frs3/8XISHBye7PTNl2LZj7MnWvEM+8qOgoLt1+cmMe\nEivklJ/cdrkz9Jg7d27nm28W4+c3jqJFi7Fxoz+DBw9g1aq12Ns7MH78aHr27E3jxs04cOAfPv54\nAlWqVOfdd/24cOECL75Yk27dfImICE/S3bF48Zf4+Y3DxcWVsWNHsGjRF4wZ8z43b95k+PBBNG/e\nivfe+5A//viNuXNnUb16jWTLuH//X+TLl48iRYpapG/d+gtVqlTD0dERLy9vvv12GUOGjMDe3j7d\n9RIVFcXixQuJi4ulbl1j5fITJ46nuPKuu3teChcuyrFjR6lb9yX+/fcUDRq8nGzehEvTJ5QjRw78\n/Tcnu8/R0TFJWnyLU1jYVQoV8gAwB3nh4eHm7rB79+7RrJk3sbGxtGvXCaXKJXuOa9fCknShubu7\nc/XqZQDeeOMtPvhgPDExMfTu3Y/nnnuOGTMmp9j6AZAnTx7Kli3Hvn17n4oF6BLKtgGIi1P6/4MI\nITJPVHQU43+bTFR0lNXOmdsuNx/WG5WhQcjKld/g69vXvOrsG2+8xd69ewgMDMDbuyG3b9/Czc2d\nAgUK0rRpC/LnL4C7uztOTs7Y2dmRO3dunJ2diYgIT3Lsrl17mlsLfHzas2HDegB++SWAPHlceeed\ndwEoVqw4Bw8e4Natm8mWUesTeHqWsEi7e/cue/bsYsCAQQB4e7/CwoXz+fXXHTRq1DTN9fDPP3/R\npEkD01Yc9+/fp1y5CsyYMdd8U46MjCRPnpQXUcuTJw+RkREA3L59Cycn5zSXIy3dWEWKFEWpcsya\nNZVx4z7g3r175u6O6OgH5nw2NjYsXLiUoKCzzJgxmWLFitG+feckx7t7926S4C1nTnvu3zeO9cor\njalXz4uYmGgcHZ04c+ZfLl0KpVatukyZ8jF//PEbNWvWZsSIMRbde56eJdBap6kerCHbdsE458qZ\n2UUQQgiCgs7y2WezaNKkgfkVFHSGixcv4ObmRps2bZk0aSIdO7Zh9uzpODvnSfWNNWGLhZOTk3l8\nxJkz/yb5Fl6pUuUUjxMefgNX1+cs0n79dQf37t3Dy8sbgOLFPSle3NOiG8bOzo7Y2KQLnsaPXUl4\nk6xYsTJLl65k8eJv6d//LRwdnejSpRsvvPCwxcPFxYVr166lWM5r18JwcXEFIE8eF27eTD6gSkls\nbCxNmjSgaVNvi99H06be5nEdib3//sdcvnyZVq0a4evbmRYtWgPG+J949vb2lCmjaNKkOd2792LN\nmtXJHsve3p779+9bpD14cJ9cuXKZtx0cHMzHXrp0Eb16/Y+tW38hKOgMq1evIzz8BuvWfW9xDFdX\nV8LDr6epLqwh27aA5Mgho0CEeJbFt0Y8610wMTExvPuun0XfP4CzsxFkjBgxhg4duvDrrzv49dcd\n+PuvZerU2dSoUeuxx86Z0/KLVvyY1Rw5cgBxifalvDK6jY0NsbExFmlbtwYC0KHDqxbpFy+e59q1\nMPLmzYezcx5u3076yGt8YODsnMec5uDgQOHCRQDo2LELd+7c5oMPxlO4cFFzsFShQiW0Pp5sGcPC\nrhIWdpUKFYzxGEqVTzHv/PlzKViwEO3adbRIt7W1ZcmSFcm+J3EAFq9o0WIsWbKC8PBwnJ2dOXcu\nCFtbWwoWLEhISDDBwReoWbOOOb+nZ8lkW6sA8ucvwPXrlgHWtWvXqFgx6dNSZ8+eISQkhPr1vZgx\nYwrVq9cgZ86c1KpVh4MHD9ChQxdz3tjYOGxsnr72hqevRFZiaysBiBDPutx2uSnhWtxqr4wOPgCK\nF3+eK1cuU6RIUfNryZKvOHbsKGFhYcycOYXixZ+nZ88+LFy4jBdeqMru3buA/z6fUYkSJTl50rJJ\nXusTKeZ3d89LRESEefvWrVvs2/c7vr59WbJkpfk1a9bnxMbGsnnzJgBKlSrNuXNnuXPntsXxjh49\njKOjI0WLFkvxnN2796J4cU+mTPnInPbqq6+h9fEk810ALF68kAIFCppv9s2atWDnzm0WA2/BGKPx\n44/fJwnO4iX8PSR8xQeECcXGxjJkyEDOnw/iueeew87Ojt9++5Xy5Svg4JCLI0cOMWHCWItHfrU+\njqenZ7LnrlChksUjs3fu3OHff09SsWLSMStLly6id+9+gHE/i401xjXGxMQkCSYjIsJxd8+b7Dkz\nU7YNQOztcmR2EYQQgs6du7Fy5TcEBgYQHHyRzz6bzc6d2/H0LIGrqys7dmxj7txZBAdf5J9//uL0\n6YfdJ7ly5ebixQvcuHEDeHQrRkJNm7YgMjKCzz6bzYUL51m37ge2b9+SYkBTpozizJnT5u0dO7YA\n0L59Z0qUKGl+Va9egxo1ahMQYHTDVK1anWLFijNu3CiOHz9KSEgwO3ZsZfbsaXTq1PWRAVSOGfNA\nxgAAEjJJREFUHDkYOnQEp05pc5dC2bLl6N27HxMnjuP777/jwoULnD79LzNnTiEwMIBx4yaau3Wa\nNGlO5cpVGDToTXbu3EZISDB79+5m2LBBlClT1txVkh62trbY2zswf/5cLl68wM6d21i2bDE9e/YB\n4KWXGpArV26mTZvEhQvn2bz5Z1avXoGvrzFoNDY2luvXr5kDlNatX2P//r9ZuXI5Z8+eYdKkiXh6\nlrDohgLjcdzg4IvUq2c8+VKuXAX27NlFUNBZtm/fkqQ77fTpUykOfM1M2TYAyeMoY0CEEJmvadPm\n9O37JgsXzsPXtwsHD+5n2rRP8fAoTM6cOZkyZSZaH6NXr6588MF4fHzam2+ebdr4sHv3Lvz8hgKW\nLSKPurk7OjoxZcos/v57H76+r7Nly2aaNm2BnV3yn4s1atQkPPwGoaEhAGzZEkj9+g147rmk3RJt\n27YnKOgsWp/A1taWGTM+I1++fIwaNYwePTrx5ZfzaNeuE337vvHYuqlatTqNGjXlq68WEBkZCUCv\nXv9j9Oj3CQwMwMfHh7fffpPw8HC+/HKJxeO5NjY2TJkyi6ZNW/DFF5/Ts2dnZs2aRr169Zk2bXa6\n52CJ5+c3ltjYWPr27c78+Z8xYsRo8yOxjo5OzJz5GZcvX6Jv3x58/fWXDB06wjzgODQ0BB+fFuaJ\nyYoUKcpHH03B338t/fv7EhUVxUcfTU1yzqVLF+Hr29e83aRJc0qXLsubb/ahQIGCFk+73L59izNn\nTlO7dt0Mud6MZJPaiDmr6LR6QBzAgIpvUKlgqcwuTpZnZ2eLm5sTN27cJloefbYKqXPre9bqPCQk\nmOvXr1nMxDpt2iRiY+Pw8xub7Hs+/PA9PD1L0qNHLyuV8tGetTrPLBs2rGPHjm1Mnz4n3ccy1XmG\njV/Iti0gdjIGRAiRTUVGRjJ48AB27tzOpUuX2L59C1u2bKZhw8Ypvqdbt54EBGwwjzUQzwZ//3V0\n794rs4uRrGz7FIwMQhVCZFflypVn8ODhzJ8/h6tXr1CokAdDhoygZs3aKb6nZMnS1KvnRUDARlq2\nfDXFfOLpsXfvbooVK57szLFPg2zbBTO02kBKu3lmcmmyPmkmtT6pc+uTOrc+qXPrky6YDJLDNtte\nuhBCCJHp5C4shBBCCKuTAEQIIYQQVicBiBBCCCGs7ql4CkYp5QDMA9oBd4AZWuuZKeStBswHKgNH\ngAFa63+sVVYhhBBCpN/T0gIyHagOvAwMBN5XSrVLnEkp5QhsBHaa8u8FNiqlMn6BBiGEEEI8MZke\ngJiCir7AIK31Qa31emAq8HYy2bsAd7TWftowBLgJdEwmrxBCCCGeUpkegABVMLqC9iZI2w0kNyNO\nbdO+hPYAT98k90IIIYRI0dMQgHgAYVrr6ARpl4FcSqnE6wd7ACGJ0i4DRZ9g+YQQQgiRwZ6GAMQR\nuJcoLX7bIZV5E+cTQgghxFPsaXgK5i5JA4j47TupzJs43yPliLOnqEtB7Oyehvgra8uRw9biX/Hk\nSZ1bn9S59UmdW19G1/XTEIAEA/mUUrZa6/gJ/QsBUVrr8GTyFkqUVggITe3Jvus8X1ahywQuLvKg\nkrVJnVuf1Ln1SZ0/u56G0PEA8ACokyDNC/gzmby/A/USpdU3pQshhBDiGfFUrIarlJqPEUj0wRhQ\nugTw1VqvV0oVBCK01neVUnmAU8BK4EvgTaADUFprHZUphRdCCCFEmj0NLSAA7wJ/A9uAucB403wg\nYHSvdALQWt8EWgMNgL+AWkALCT6EEEKIZ8tT0QIihBBCiOzlaWkBEUIIIUQ2IgGIEEIIIaxOAhAh\nhBBCWJ0EIEIIIYSwOglAhBBCCGF1T8NMqBlKKeUAzAPaYUzRPkNrPTOFvNWA+UBl4AgwQGv9j7XK\nmlWksc5bAR8BpYHTGI9c/2StsmYVaanzBO/xBA4DrbTWu554IbOYNP6dVzblfRFj7qLBWusdVipq\nlpHGOm8LfAwUA/Zj1Pl+a5U1qzHV/V/AWyl9XqT3HpoVW0CmA9WBl4GBwPtKqXaJMymlHIGNwE5T\n/r3ARqWUzOubdqmt8xeAH4CvgCoYk8l9b/qwFmmTqjpPZD7Ggo7iv0nt37kLEIjxgVwJ+BH4USmV\nz3pFzTJSW+cVgG8xApAXgIMYn+e5rFfUrMMUfKwEKjwiT7rvoVkqADFVSF9gkNb6oGkys6nA28lk\n7wLc0Vr7acMQ4CbQ0Xolfvalsc5fB7ZqrT/XWp/RWs8DtmOaaE6kThrrPP493QBnKxUxy0ljnfcC\nbmqtB5j+zicAJ4Ea1ipvVpDGOm8KHNFaf6u1PguMxlgnLMUbqEieUqo8xvImJR6TNd330CwVgGB8\nq7bDiMTi7QZqJ5O3tmlfQnuAuk+maFlWWup8CTAqmXTXjC9WlpaWOkcplReYDPQHZDHG/yYtde4N\nrE+YoLWurbUOeHLFy5LSUufXgIpKqXpKKRuMZT0iMLp5Rdp4A1sx7oWP+rxI9z00qwUgHkCY1jo6\nQdplIJfpQzhx3pBEaZcx1qIRqZfqOjdFyYfjt5VSFYFGwBarlDTrSMvfOcBMYInW+rhVSpc1paXO\nSwJhSqkvlFKhSqnflFKJF9EUj5eWOl8N/IxxQ7yP0VLSQWsdYZWSZiFa6wVa6+Fa67uPyZrue2hW\nC0AcgXuJ0uK3HVKZN3E+8WhpqXMzU3/4D8CvWmv/J1S2rCrVda6UaoyxgvSHVihXVpaWv3NnwA/j\nw7k5sAsIVEoVeaIlzHrSUud5MbpcBmKsEbYMWCLjbp6odN9Ds1oAcpekFx+/fSeVeRPnE4+WljoH\nwLTC8TYgDhlz81+kqs5NA/AWAAO11vetVLasKi1/59HAfq31RNPYhVEYY0B6POEyZjVpqfMpwCHT\nt/f9wBvAbaD3ky1itpbue2hWC0CCgXxKqYTXVQiI0lqHJ5O3UKK0Qhir74rUS0udY/oWuAujb/dl\nrfU16xQzS0ltndfCGEj2g1LqplLqpil9k1JqnpXKmlWk5e88FDiRKO0kxuOhIvXSUucvYjz5AoDW\nOs60/fwTL2X2le57aFYLQA4AD4A6CdK8gD+Tyfs7RtN0QvVN6SL1Ul3nplHtAab83lrry1YpYdaT\n2jr/AygDVMUY0FfFlN4XeO8JlzGrSetnS5VEaeWAoCdSsqwrLXUeQtInXhRw9skUTZAB99AsNRGZ\n1jpKKbUMWKCU6oMxGGYY4Avmpv8I0+Ca74FPlFKzMOajeBOjT+u7TCn8MyqNdT4W4xv5y4CtaR8Y\n32girV74Z1Qa6/xMwvcqpQBCtNZh1i31sy2Ndb4AeFsp9R7G3BS+GH/3yzOl8M+oNNb5QmCxUuov\njKdm+gHFgaWZUvgsKqPvoVmtBQTgXeBvjDEGczFm2ox/JC4U05wTWuubQGugAcZsb7WAFlrrKKuX\n+NmXqjrHmM0wN8Y385AEr9lWLW3WkNo6TyzOCmXLqlL72XIeaAa0wTTzLNBSay3du2mX2jr/DmN+\nkDHAPxiPgr4igXa6Jf68yNB7qE1cnHweCSGEEMK6smILiBBCCCGechKACCGEEMLqJAARQgghhNVJ\nACKEEEIIq5MARAghhBBWJwGIEEIIIaxOAhAhhBBCWJ0EIEIIIYSwOglAhBBCCGF1WWotGCGedUqp\nHRhTGycWB8zQWo9MxTG8ge2Ap2la8AyllHqepIt8xQDXTecdobW+kEHnOgss1lp/YNruCfystQ5T\nSvkCX2utc2TEuZI5ty+wGKPubUzJsUAkxtTTI7XWB9JwvGJAPa316owuqxDPImkBEeLpEgesBgpi\nLG0d//IAJqbxOE9SHNCWh+UrjrHWTzXgpww8Tw1gOoBSqgGwBGPBK4BVGPXyJMVh+XsoDrTH+P0E\nmFZ4Tq2lGGvECCGQFhAhnkZRWuurmV2Ix7ABbmitryRIC1VKTQCWK6Uqa60Pp/ckWutrCTZtSRBY\naa3vAVeSvCmDJfO7CFFKvQ3sABoCG1J5KJvHZxEi+5AARIhnjFLqOWAa0AIoANwA1gODTMtkJ85f\nGmMl0boYN/HfgOFa6yOm/S4YrQw+gD1G94Kf1vrv/1C8GNO/90zHLgpMBhoBeYDdGF00h0378wOf\nA68AThgrmY7RWu8y7T+L0Q2yE2NFVICzSqneGDf0xVprW6XUYqC81rpOgusujtFV1ERrvU0pVQ/4\nBKgJXMVoqRltWtUzre6Zzv/AdC4bYBTGUvGepv17gLe01meVUtsBb8BbKfWy1rqkUion8BHQDXDF\nWDn3fa31L/+hPEI8c6QLRohnzxKgCkbAUBoYAvQE+qeQfzVwEaiOsWR2DLA2wf5NwPNAS9P+34Hd\nSqkqqS2QUspGKVUVGAcc0FqfVEo5YwQ7hTGW7a4L3AF2mcZDACwAcgFeQCXgJLBOKZU70Sn2YHR9\nxGEEEPHjKOJbRBYDNZVSJRK8pztwwRR8vAD8AvxsOs/rpvrYnNprTHCtJYApQBCwy5Q8GBgGDAXK\nAK8BZYEZpv3tgL2mctcwpS0FGpvKUhX4DvhJKdUirWUS4lkkLSBCPH26K6U6JkrbpbVuZfo5ENip\ntT5q2j6vlBoEVE7heCUxbrTntdbRptaDcgBKqUZAbSCf1jrclH+cUuoljJtqn0eUc5NSKtb0s4Pp\n353AG6afewDuQAet9XXT+boCp4G3MFoMSgKHgCCt9V2l1GBgOQ9bUgAwlfu6aTNMa31PKZVw/y5T\na0k3jFYFgK4YN3mA4cBmrfUU0/YZpVQ34LRSqkF8i0sybJRSkTzsPskJ3AcCAF+tdZQp/RTQU2u9\nybR9QSm1BuhgKt8NpdR9jO6166ZWqS5AVa31IdN7ZpuCuJEYQaEQWZoEIEI8fdZj3IQSjhmISvDz\nfKCNKZAoA1TEaPY/nsLxxgCfAm+ZnrIJAFaa9lXDaAm9kPCGjtEVY/+YcvYF9pl+fgBcMY3LiFcJ\nOBkffACYgox9PAyWJmIEHB2VUrsxAqUVWuv7jzl3cpZiCkCUUtWA8hitRWC0dpRWSiXubokz5Usp\nAInDaG2yweju+ghjAOq4hE8Yaa03KqVqKaUmAsr0qojR8pScqqZ/d5u6b+LZYXSpCZHlSQAixNPn\nptY68WOugHmswUagArAC40mQf4CFKR1Maz3f9G28JcZYjA8wWjmqYgQfERg36MSDJO/xaCFa6zOP\n2J/SoEtbTGMntNbrlFIeQHOM7oihwPtKqdpa65QCqpQsNb23Oka3xp4E9WgLfIsRQCQu1yMH/CY4\nxhml1KsYQdcvSqmqWusbAEqpUcB4jK6gLcBMjC6yLikcNn5A7UvArUT7YpJmFyLrkTEgQjxbqmLc\nrDtorcdorVcCZzDGgiS54Sul8iul5gIOWutlWmtfjG/0HhiDIo8ALqb9Z+JfwGiMcQzpcQgoq5TK\nl6A8uTDGQBxVStkrpWYApbTWa7TWb5iuIxZolczxHvlosalFYjvQEejEw9YPMK6zgtb6bIJrtAdm\nA8USH+sR54jCaGUphDF4Nt5oYILW+m2t9Vda630YrSAJfycJy3/EtK9wonrvC/RObXmEeJZJC4gQ\nz5ZLGK0HnZVSYUA+jC6WgjwchwEPb3zXMW7mJZVSY4CbQC+M1o2/gPPAQWC1afzFBYzxGb4YLQbp\nsQLjxvydUmokxtiJ9zGedvlCa31fKVUTeMk0huUSRiuNE8bg1cRuma6rqlLqWjL7wWgF+Rzjy9V3\nCdJnYAx+/Qz4DHAz5XPAGPiaalrrQ0qpKRitSN9qrTdi1FtTpdQGjBaMnhjzpFxKVH5PpVQRrfUx\nU94Fpkd6j2IETn4Yvx8hsjxpARHiGaK1DsUIDtoAxzBusheBWTx8ugJM37a11jEYj+vGYnQNHMbo\nhmmptQ7SWsdidH38hfGExkGMbgEfrfWORxTlsROdaa0jMVpZbpjOvQvjhl8/wfiJThgtOOuBExhP\n8nTVWscHIAnPcxjjKZbVpPzEzw+m96zVWpu7NrTWf2BMAlYF+BtYhzFmponWOvpx15KMj0zvn6eU\ncsIYcOsI/IkxELcixmDcAqZHkcF44qcycNDUldbZVN4FGAFID6CP1nr5fyiPEM8cm7i4Jz1hohBC\nCCGEJWkBEUIIIYTVSQAihBBCCKuTAEQIIYQQVicBiBBCCCGsTgIQIYQQQlidBCBCCCGEsDoJQIQQ\nQghhdRKACCGEEMLqJAARQgghhNVJACKEEEIIq5MARAghhBBWJwGIEEIIIazu/4kfQPPCxVA5AAAA\nAElFTkSuQmCC\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x13fbaba20>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "optimal_weight = (0.0, 0.0, 1.0)\n",
+    "weight_name = \"_\".join([\"%i\" % (100 * w) for w in optimal_weight])\n",
+    "best_clf = joblib.load(\"../results/voting_clf_%s.pkl\" % weight_name)\n",
+    "\n",
+    "adaboost_y_pred_train = best_clf.best_estimator_.predict_proba(X_train).T[1]\n",
+    "adaboost_y_pred_test = best_clf.best_estimator_.predict_proba(X_test).T[1]\n",
+    "adaboost_metrics_train = get_threshold_metrics(y_train, adaboost_y_pred_train)\n",
+    "adaboost_metrics_test = get_threshold_metrics(y_test, adaboost_y_pred_test)\n",
+    "\n",
+    "# Plot ROC\n",
+    "plt.figure()\n",
+    "for label, metrics in ('Training', adaboost_metrics_train), ('Testing', adaboost_metrics_test):\n",
+    "    roc_df = metrics['roc_df']\n",
+    "    plt.plot(roc_df.fpr, roc_df.tpr,\n",
+    "        label='{} (AUROC = {:.1%})'.format(label, metrics['auroc']))\n",
+    "plt.xlim([0.0, 1.0])\n",
+    "plt.ylim([0.0, 1.05])\n",
+    "plt.xlabel('False Positive Rate')\n",
+    "plt.ylabel('True Positive Rate')\n",
+    "plt.title('Predicting TP53 mutation from gene expression (ROC curves)\\nPCA/SGD')\n",
+    "plt.legend(loc='lower right');"
+   ]
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "Python [default]",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/algorithms/scripts/VotingClassifier-paulseignourel.py
+++ b/algorithms/scripts/VotingClassifier-paulseignourel.py
@@ -1,0 +1,345 @@
+
+# coding: utf-8
+
+# # Create a logistic regression model to predict TP53 mutation from gene expression data in TCGA
+
+# In[1]:
+
+import os
+import urllib
+import random
+import warnings
+
+import pandas as pd
+import numpy as np
+import matplotlib.pyplot as plt
+import seaborn as sns
+from sklearn import preprocessing, grid_search
+from sklearn.linear_model import SGDClassifier
+from sklearn.cross_validation import train_test_split
+from sklearn.metrics import roc_auc_score, roc_curve
+from sklearn.pipeline import Pipeline, make_pipeline
+from sklearn.preprocessing import StandardScaler
+from sklearn.feature_selection import SelectKBest
+from statsmodels.robust.scale import mad
+from sklearn.ensemble import VotingClassifier
+from sklearn.ensemble import AdaBoostClassifier
+from sklearn.tree import DecisionTreeClassifier
+from sklearn.decomposition import FactorAnalysis
+from sklearn.externals import joblib
+from sklearn.svm import SVC
+
+
+# In[2]:
+
+get_ipython().magic('matplotlib inline')
+plt.style.use('seaborn-notebook')
+
+
+# ## Specify model configuration
+
+# In[3]:
+
+# We're going to be building a 'TP53' classifier 
+GENE = '7157' # TP53
+
+
+# In[4]:
+
+# SGDClassifier Parameter Sweep
+sgd_n_feature_kept = 500
+sgd_param_fixed = {
+    'loss': 'log',
+    'penalty': 'elasticnet',
+}
+sgd_param_grid = {
+    'alpha': [0.1],
+    'l1_ratio': [0.0],
+}
+
+
+# In[5]:
+
+# AdaBoost Parameter Sweep
+adaboost_n_feature_kept = 5000
+adaboost_param_fixed = {
+    'algorithm': 'SAMME.R',
+    'base_estimator': DecisionTreeClassifier(max_depth=1)
+}
+adaboost_param_grid = {
+    'learning_rate': [0.5],
+    'n_estimators': [50]
+}
+
+
+# In[6]:
+
+# Parameter Sweep for Hyperparameters
+pca_n_feature_kept = 2000
+pca_param_fixed = {
+    'loss': 'log',
+    'penalty': 'elasticnet',
+    'n_components': 500,
+}
+pca_param_grid = {
+    'alpha': [0.1],
+    'l1_ratio': [0.0],
+}
+
+
+# *Here is some [documentation](http://scikit-learn.org/stable/modules/generated/sklearn.linear_model.SGDClassifier.html) regarding the classifier and hyperparameters*
+# 
+# *Here is some [information](https://ghr.nlm.nih.gov/gene/TP53) about TP53*
+
+# ## Load Data
+
+# In[7]:
+
+get_ipython().run_cell_magic('time', '', "path = os.path.join('..', 'download', 'expression-matrix.tsv.bz2')\nX = pd.read_table(path, index_col=0)")
+
+
+# In[8]:
+
+get_ipython().run_cell_magic('time', '', "path = os.path.join('..', 'download', 'mutation-matrix.tsv.bz2')\nY = pd.read_table(path, index_col=0)")
+
+
+# In[9]:
+
+y = Y[GENE]
+
+
+# In[10]:
+
+# The Series now holds TP53 Mutation Status for each Sample
+y.head(6)
+
+
+# In[11]:
+
+# Here are the percentage of tumors with NF1
+y.value_counts(True)
+
+
+# ## Set aside 10% of the data for testing
+
+# In[12]:
+
+# Typically, this can only be done where the number of mutations is large enough
+X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=0)
+'Size: {:,} features, {:,} training samples, {:,} testing samples'.format(len(X.columns), len(X_train), len(X_test))
+
+
+# ## Median absolute deviation feature selection
+
+# In[13]:
+
+def fs_mad(x, y):
+    """    
+    Get the median absolute deviation (MAD) for each column of x
+    """
+    scores = mad(x) 
+    return scores, np.array([np.NaN]*len(scores))
+
+
+# ## SGD Calssifier¶
+
+# In[14]:
+
+# joblib is used to cross-validate in parallel by setting `n_jobs=-1` in GridSearchCV
+# Supress joblib warning. See https://github.com/scikit-learn/scikit-learn/issues/6370
+warnings.filterwarnings('ignore', message='Changing the shape of non-C contiguous array')
+
+sgd_clf = SGDClassifier(random_state=0, class_weight='balanced',
+                        loss=sgd_param_fixed['loss'], penalty=sgd_param_fixed['penalty'])
+
+sgd_pipeline = make_pipeline(
+    SelectKBest(fs_mad, k=sgd_n_feature_kept),  # Feature selection
+    StandardScaler(),  # Feature scaling
+    sgd_clf)
+
+
+# ## AdaBoost Classifier
+
+# In[15]:
+
+# Include loss='log' in param_grid doesn't work with pipeline somehow
+adaboost_clf = AdaBoostClassifier(random_state=0,
+                                  base_estimator=adaboost_param_fixed['base_estimator'],
+                                  algorithm=adaboost_param_fixed['algorithm'])
+
+adaboost_pipeline = make_pipeline(
+    SelectKBest(fs_mad, k=adaboost_n_feature_kept),  # Feature selection
+    StandardScaler(),  # Feature scaling
+    adaboost_clf)
+
+
+# ## PCA Classifier
+
+# In[16]:
+
+# Include loss='log' in param_grid doesn't work with pipeline somehow
+pca_pipeline = make_pipeline(
+    SelectKBest(fs_mad, k=pca_n_feature_kept),
+    FactorAnalysis(n_components=pca_param_fixed['n_components']),  # Feature selection
+    StandardScaler(),  # Feature scaling
+    sgd_clf)
+
+
+# ## Voting Classifier
+
+# In[17]:
+
+prefixes = ["sgd__sgdclassifier", "adaboost__adaboostclassifier", "pca__sgdclassifier"]
+param_grids = [sgd_param_grid, adaboost_param_grid, pca_param_grid]
+weights = [(1.0, 0.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, 1.0),
+           (0.0, 0.5, 0.5), (0.5, 0.0, 0.5), (0.5, 0.5, 0.0),
+           (1.0/3, 1.0/3, 1.0/3)]
+
+param_grid = {}
+for prefix, orig_param_grid in zip(prefixes, param_grids):
+    param_grid.update(dict(zip(["%s__%s" % (prefix, p) for p in orig_param_grid.keys()],
+                                orig_param_grid.values())))
+
+for weight in weights:
+    
+    param_grid.update(dict(weights=[weight]))
+    
+    estimators = [('sgd', sgd_pipeline), ('adaboost', adaboost_pipeline), ('pca', pca_pipeline)]
+    voting_clf = VotingClassifier(estimators=estimators, voting='soft') 
+    assert np.all([p in voting_clf.get_params().keys() for p in param_grid.keys()])
+
+    voting_grid = grid_search.GridSearchCV(estimator=voting_clf, param_grid=param_grid,
+                                           n_jobs=-1, scoring='roc_auc')
+    get_ipython().magic('time voting_grid.fit(X=X_train, y=y_train)')
+
+    weight_name = "_".join(["%i" % (100 * w) for w in weight])
+    print ("... done %s ..." % weight_name)
+    joblib.dump(voting_grid, "../results/voting_clf_%s.pkl" % weight_name)
+
+
+# ## Reload Estimators
+
+# In[18]:
+
+weights = [(1.0, 0.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, 1.0),
+           (0.0, 0.5, 0.5), (0.5, 0.0, 0.5), (0.5, 0.5, 0.0),
+           (1.0/3, 1.0/3, 1.0/3)]
+
+
+# In[19]:
+
+sgd_weights = []
+adaboost_weights = []
+pca_weights = []
+mean_scores = []
+
+for weight in weights:
+    weight_name = "_".join(["%i" % (100 * w) for w in weight])
+    sgd_weights.append(weight[0])
+    adaboost_weights.append(weight[1])
+    pca_weights.append(weight[2])
+    mean_scores.append(joblib.load("../results/voting_clf_%s.pkl" % weight_name).grid_scores_[0].mean_validation_score)
+
+result_dat = pd.DataFrame(dict(sgd_weight=sgd_weights, adaboost_weight=adaboost_weights,
+                               pca_weight=pca_weights, score=mean_scores))
+result_dat = result_dat[['sgd_weight', 'adaboost_weight', 'pca_weight', 'score']]
+print (result_dat)
+
+
+# ## Use Optimal Hyperparameters to Output ROC Curve
+
+# In[20]:
+
+optimal_weight = (0.0, 0.5, 0.5)
+weight_name = "_".join(["%i" % (100 * w) for w in optimal_weight])
+best_clf = joblib.load("../results/voting_clf_%s.pkl" % weight_name)
+
+
+# In[21]:
+
+y_pred_train = best_clf.best_estimator_.predict_proba(X_train).T[1]
+y_pred_test = best_clf.best_estimator_.predict_proba(X_test).T[1]
+
+def get_threshold_metrics(y_true, y_pred):
+    roc_columns = ['fpr', 'tpr', 'threshold']
+    roc_items = zip(roc_columns, roc_curve(y_true, y_pred))
+    roc_df = pd.DataFrame.from_items(roc_items)
+    auroc = roc_auc_score(y_true, y_pred)
+    return {'auroc': auroc, 'roc_df': roc_df}
+
+metrics_train = get_threshold_metrics(y_train, y_pred_train)
+metrics_test = get_threshold_metrics(y_test, y_pred_test)
+
+
+# In[22]:
+
+get_ipython().magic('matplotlib inline')
+
+
+# In[23]:
+
+# Plot ROC
+plt.figure()
+for label, metrics in ('Training', metrics_train), ('Testing', metrics_test):
+    roc_df = metrics['roc_df']
+    plt.plot(roc_df.fpr, roc_df.tpr,
+        label='{} (AUROC = {:.1%})'.format(label, metrics['auroc']))
+plt.xlim([0.0, 1.0])
+plt.ylim([0.0, 1.05])
+plt.xlabel('False Positive Rate')
+plt.ylabel('True Positive Rate')
+plt.title('Predicting TP53 mutation from gene expression (ROC curves)\nVoting Classifier')
+plt.legend(loc='lower right');
+
+
+# ## Compare with Simple Classifiers
+
+# In[24]:
+
+optimal_weight = (0.0, 1.0, 0.0)
+weight_name = "_".join(["%i" % (100 * w) for w in optimal_weight])
+best_clf = joblib.load("../results/voting_clf_%s.pkl" % weight_name)
+
+adaboost_y_pred_train = best_clf.best_estimator_.predict_proba(X_train).T[1]
+adaboost_y_pred_test = best_clf.best_estimator_.predict_proba(X_test).T[1]
+adaboost_metrics_train = get_threshold_metrics(y_train, adaboost_y_pred_train)
+adaboost_metrics_test = get_threshold_metrics(y_test, adaboost_y_pred_test)
+
+# Plot ROC
+plt.figure()
+for label, metrics in ('Training', adaboost_metrics_train), ('Testing', adaboost_metrics_test):
+    roc_df = metrics['roc_df']
+    plt.plot(roc_df.fpr, roc_df.tpr,
+        label='{} (AUROC = {:.1%})'.format(label, metrics['auroc']))
+plt.xlim([0.0, 1.0])
+plt.ylim([0.0, 1.05])
+plt.xlabel('False Positive Rate')
+plt.ylabel('True Positive Rate')
+plt.title('Predicting TP53 mutation from gene expression (ROC curves)\nAdaboost')
+plt.legend(loc='lower right');
+
+
+# In[25]:
+
+optimal_weight = (0.0, 0.0, 1.0)
+weight_name = "_".join(["%i" % (100 * w) for w in optimal_weight])
+best_clf = joblib.load("../results/voting_clf_%s.pkl" % weight_name)
+
+adaboost_y_pred_train = best_clf.best_estimator_.predict_proba(X_train).T[1]
+adaboost_y_pred_test = best_clf.best_estimator_.predict_proba(X_test).T[1]
+adaboost_metrics_train = get_threshold_metrics(y_train, adaboost_y_pred_train)
+adaboost_metrics_test = get_threshold_metrics(y_test, adaboost_y_pred_test)
+
+# Plot ROC
+plt.figure()
+for label, metrics in ('Training', adaboost_metrics_train), ('Testing', adaboost_metrics_test):
+    roc_df = metrics['roc_df']
+    plt.plot(roc_df.fpr, roc_df.tpr,
+        label='{} (AUROC = {:.1%})'.format(label, metrics['auroc']))
+plt.xlim([0.0, 1.0])
+plt.ylim([0.0, 1.05])
+plt.xlabel('False Positive Rate')
+plt.ylabel('True Positive Rate')
+plt.title('Predicting TP53 mutation from gene expression (ROC curves)\nPCA/SGD')
+plt.legend(loc='lower right');
+


### PR DESCRIPTION
This algo tests various weighted combinations of SGD, PCA-SGD and Adaboost. The best estimator is a 50-50 mixture of PCA-SGD and Adaboost, which achieves a 0.2-0.3% AUROC gain over PCA-SGD alone. This is a small gain in performance, and the computational time is very slow. However, it does show that a mixture of two good classifiers can at times result in a better classifier, and could have applications to other situations.

Note: due to the very slow computation time, I chose to dump the results for each model, rather than use the automated scikit grid search. This way, if the algo fails in the middle, I can refit only a subset of the models. The models are then reloaded and analyzed in a separate, independent section.